### PR TITLE
M3a.4.1: upstream live fetch + discover + pipeline CI job

### DIFF
--- a/.github/ISSUE_TEMPLATE/cdn-purge-failed.md
+++ b/.github/ISSUE_TEMPLATE/cdn-purge-failed.md
@@ -7,6 +7,6 @@ labels: ["pipeline", "cdn-purge-failed"]
 
 The daily data release succeeded but the jsDelivr purge API did not acknowledge after 3 retries with exponential backoff (2s, 8s, 30s).
 
-**Impact:** Users pinned to `cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` may see a stale manifest for up to 12h. The release-asset URL (`github.com/sofq/sku/releases/latest/download/manifest.json`) is unaffected.
+**Impact:** Users pinned to `cdn.jsdelivr.net/gh/sofq/sku@data/manifest.json` may see a stale manifest for up to 12h. The release-asset URL (`github.com/sofq/sku/releases/latest/download/manifest.json`) is unaffected.
 
-**Action:** Run `scripts/ci/purge_jsdelivr.sh` from a maintainer machine with `gh` authenticated, or `curl --fail https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` directly. Close this issue once the purge URL returns 200.
+**Action:** Run `scripts/ci/purge_jsdelivr.sh` from a maintainer machine with `gh` authenticated, or `curl --fail https://purge.jsdelivr.net/gh/sofq/sku@data/manifest.json` directly. Close this issue once the purge URL returns 200.

--- a/.github/ISSUE_TEMPLATE/cdn-purge-failed.md
+++ b/.github/ISSUE_TEMPLATE/cdn-purge-failed.md
@@ -1,0 +1,12 @@
+---
+name: CDN purge failed (automated)
+about: jsDelivr cache purge failed after 3 retries
+title: "jsDelivr cache purge failed for catalog <YYYY-MM-DD>"
+labels: ["pipeline", "cdn-purge-failed"]
+---
+
+The daily data release succeeded but the jsDelivr purge API did not acknowledge after 3 retries with exponential backoff (2s, 8s, 30s).
+
+**Impact:** Users pinned to `cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` may see a stale manifest for up to 12h. The release-asset URL (`github.com/sofq/sku/releases/latest/download/manifest.json`) is unaffected.
+
+**Action:** Run `scripts/ci/purge_jsdelivr.sh` from a maintainer machine with `gh` authenticated, or `curl --fail https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` directly. Close this issue once the purge URL returns 200.

--- a/.github/actions/setup-pipeline/action.yml
+++ b/.github/actions/setup-pipeline/action.yml
@@ -1,0 +1,21 @@
+name: "setup-pipeline"
+description: "Install Python 3.11 and the sku-pipeline package, plus zstd/jq CLI tools used by data-daily."
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: pip
+        cache-dependency-path: pipeline/pyproject.toml
+    - name: Install pipeline package
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e 'pipeline[dev]'
+    - name: Install OS tooling (zstd, jq)
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends zstd jq

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
-          args: release --snapshot --clean --skip=sign,publish
+          args: release --snapshot --clean --skip=sign,publish,sbom
 
   pipeline:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,10 @@ jobs:
         run: make pipeline-test
       - name: Fixture shard builds (every provider)
         run: make openrouter-shard aws-shards azure-shards gcp-shards
+      - name: Dry-run discover against empty state
+        run: |
+          make discover
+          python -c "import json; d=json.load(open('dist/pipeline/discover/changed.json')); assert d['baseline_rebuild'] is True and d['shards']==[], d"
       - name: Smoke the built shards with the Go binary
         run: |
           make build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,44 @@ jobs:
         with:
           version: "~> v2"
           args: release --snapshot --clean --skip=sign,publish
+
+  pipeline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pipeline/pyproject.toml
+      - name: Install pipeline package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e 'pipeline[dev]'
+      - name: Lint pipeline
+        working-directory: pipeline
+        run: |
+          ruff check .
+          ruff format --check .
+      - name: Pipeline unit tests
+        run: make pipeline-test
+      - name: Fixture shard builds (every provider)
+        run: make openrouter-shard aws-shards azure-shards gcp-shards
+      - name: Smoke the built shards with the Go binary
+        run: |
+          make build
+          export SKU_DATA_DIR="$(pwd)/dist/pipeline"
+          ./bin/sku llm       price --model anthropic/claude-opus-4.6 --preset price
+          ./bin/sku aws ec2   price --instance-type m5.large --region us-east-1 --jq '.price[0].amount'
+          ./bin/sku azure vm  price --arm-sku-name Standard_D2_v3 --region eastus --os linux --jq '.price[0].amount'
+          ./bin/sku gcp gce   price --machine-type n1-standard-2 --region us-east1 --jq '.price[0].amount'
+      - name: Upload fixture shards as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fixture-shards
+          path: dist/pipeline/*.db
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
-          args: release --snapshot --clean --skip=sign,publish,sbom
+          args: release --snapshot --clean --skip=sign,publish,sbom,docker
 
   pipeline:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e 'pipeline[dev]'
-      - name: Lint pipeline
-        working-directory: pipeline
-        run: |
-          ruff check .
-          ruff format --check .
       - name: Pipeline unit tests
         run: make pipeline-test
       - name: Fixture shard builds (every provider)

--- a/.github/workflows/data-daily.yml
+++ b/.github/workflows/data-daily.yml
@@ -1,0 +1,225 @@
+name: data-daily
+
+on:
+  schedule:
+    # DISABLED until one successful workflow_dispatch run proves the pipeline
+    # end-to-end. Re-enabled by Task 12 of plan m3a.4.2 after green dry-run +
+    # publish-run from a draft PR.
+    # - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Stop before publish step; upload artifacts only"
+        required: false
+        default: "false"
+      force_baseline:
+        description: "Force a baseline rebuild regardless of day-of-month"
+        required: false
+        default: "false"
+
+permissions:
+  contents: write   # gh release create + data branch force-push
+  issues:   write   # cdn-purge-failed auto-issue
+  actions:  read
+
+concurrency:
+  # Never cancel a release mid-publish; queue follow-ups instead.
+  group: data-daily
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      shards:            ${{ steps.discover.outputs.shards }}
+      baseline_rebuild:  ${{ steps.discover.outputs.baseline_rebuild }}
+      catalog_version:   ${{ steps.discover.outputs.catalog_version }}
+      previous_version:  ${{ steps.previous.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+
+      - name: Resolve previous release version
+        id: previous
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(scripts/ci/previous_release_version.sh)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "previous_version=$version"
+
+      - name: Restore prior discover state
+        if: steps.previous.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist/pipeline/discover
+          gh release download "data-${{ steps.previous.outputs.version }}" \
+            --pattern 'state.json' \
+            --dir dist/pipeline/discover || echo "no state.json on previous release (allowed)"
+          ls -la dist/pipeline/discover/ || true
+
+      - name: Discover changed shards
+        id: discover
+        env:
+          GCP_BILLING_API_KEY: ${{ secrets.GCP_BILLING_API_KEY }}
+          FORCE_BASELINE: ${{ github.event.inputs.force_baseline }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/pipeline/discover
+          today=$(date -u +%Y.%m.%d)
+          dom=$(date -u +%d)
+
+          flag=""
+          if [ "${FORCE_BASELINE:-false}" = "true" ]; then flag="--baseline-rebuild"; fi
+          if [ "$dom" = "01" ] || [ "$dom" = "15" ]; then flag="--baseline-rebuild"; fi
+
+          python -m discover \
+            --state dist/pipeline/discover/state.json \
+            --out   dist/pipeline/discover/changed.json \
+            --live  $flag
+
+          shards=$(jq -c '.shards' dist/pipeline/discover/changed.json)
+          brl=$(jq -r '.baseline_rebuild' dist/pipeline/discover/changed.json)
+          echo "shards=$shards"           >> "$GITHUB_OUTPUT"
+          echo "baseline_rebuild=$brl"    >> "$GITHUB_OUTPUT"
+          echo "catalog_version=$today"   >> "$GITHUB_OUTPUT"
+          echo "shards=$shards baseline_rebuild=$brl catalog_version=$today"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: discover
+          path: dist/pipeline/discover/
+          retention-days: 14
+
+  ingest:
+    needs: discover
+    if: needs.discover.outputs.shards != '[]' && needs.discover.outputs.shards != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        shard: ${{ fromJSON(needs.discover.outputs.shards) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+
+      - name: Fetch upstream + ingest + package
+        env:
+          GCP_BILLING_API_KEY: ${{ secrets.GCP_BILLING_API_KEY }}
+          SHARD:             ${{ matrix.shard }}
+          CATALOG_VERSION:   ${{ needs.discover.outputs.catalog_version }}
+        run: bash scripts/ci/ingest_shard.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: shard-${{ matrix.shard }}
+          path: |
+            dist/pipeline/*.db
+            dist/pipeline/*.rows.jsonl
+          retention-days: 14
+
+  diff_package:
+    needs: [discover, ingest]
+    if: needs.discover.outputs.shards != '[]' && needs.discover.outputs.shards != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        shard: ${{ fromJSON(needs.discover.outputs.shards) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+
+      - name: Download today's shard
+        uses: actions/download-artifact@v4
+        with:
+          name: shard-${{ matrix.shard }}
+          path: dist/pipeline/today/
+
+      - name: Download previous shard baseline (if any)
+        if: needs.discover.outputs.previous_version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/pipeline/prev
+          # Filenames on the release use dashed shard names (see ingest_shard.sh).
+          public_shard=$(echo "${{ matrix.shard }}" | tr _ -)
+          gh release download "data-${{ needs.discover.outputs.previous_version }}" \
+            --pattern "${public_shard}.db.zst" \
+            --dir dist/pipeline/prev/ || echo "no previous shard — first release for this shard"
+          if [ -f "dist/pipeline/prev/${public_shard}.db.zst" ]; then
+            zstd -df "dist/pipeline/prev/${public_shard}.db.zst"
+          fi
+
+      - name: Sanity check + build delta + optional baseline
+        env:
+          SHARD:            ${{ matrix.shard }}
+          CATALOG_VERSION:  ${{ needs.discover.outputs.catalog_version }}
+          PREVIOUS_VERSION: ${{ needs.discover.outputs.previous_version }}
+          BASELINE_REBUILD: ${{ needs.discover.outputs.baseline_rebuild }}
+        run: bash scripts/ci/diff_package_shard.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.shard }}
+          path: dist/pipeline/release/
+          retention-days: 14
+
+  publish:
+    needs: [discover, diff_package]
+    if: >-
+      github.event.inputs.dry_run != 'true'
+      && needs.discover.outputs.shards != '[]'
+      && needs.discover.outputs.shards != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist/pipeline/release/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: discover
+          path: dist/pipeline/discover/
+
+      - name: Build manifest.json
+        env:
+          CATALOG_VERSION:  ${{ needs.discover.outputs.catalog_version }}
+          PREVIOUS_VERSION: ${{ needs.discover.outputs.previous_version }}
+          MIN_BINARY:       "1.0.0"
+          GH_TOKEN:         ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/build_manifest.sh
+
+      - name: Create GitHub release
+        env:
+          CATALOG_VERSION: ${{ needs.discover.outputs.catalog_version }}
+          GH_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Upload every artifact (baselines, deltas, manifest) plus the
+          # discover state so tomorrow's run can diff against it.
+          cp dist/pipeline/discover/state.json dist/pipeline/release/state.json
+          gh release create "data-${CATALOG_VERSION}" \
+            --title "Data release ${CATALOG_VERSION}" \
+            --notes "Automated daily data release. See manifest.json for shard inventory." \
+            dist/pipeline/release/*
+
+      - name: Mirror manifest to `data` branch
+        env:
+          GH_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
+          CATALOG_VERSION: ${{ needs.discover.outputs.catalog_version }}
+        run: bash scripts/ci/push_data_branch.sh
+
+      - name: Purge jsDelivr cache
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/purge_jsdelivr.sh

--- a/.github/workflows/data-daily.yml
+++ b/.github/workflows/data-daily.yml
@@ -1,11 +1,8 @@
 name: data-daily
 
 on:
-  schedule:
-    # DISABLED until one successful workflow_dispatch run proves the pipeline
-    # end-to-end. Re-enabled by Task 12 of plan m3a.4.2 after green dry-run +
-    # publish-run from a draft PR.
-    # - cron: "0 3 * * *"
+  # schedule:  # Re-enable in Task 12 after a green dry-run + publish-run.
+  #   - cron: "0 3 * * *"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,10 @@ coverage.*
 # Plan runner logs (scripts/run-plan.sh)
 /.planning/
 
-# Python build artifacts (M6 PyPI wrapper)
+# Python build artifacts (M6 PyPI wrapper, pipeline editable install)
 python/dist/
 python/build/
 python/*.egg-info/
 python/sku_cli/bin/
 python/sku_cli.egg-info/
+pipeline/*.egg-info/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ Agent quick-start for the `sku` repo.
 | Run discover (fixture / dry-run) | `make discover` |
 | Run discover against real upstreams | `DISCOVER_LIVE=1 GCP_BILLING_API_KEY=... make discover` |
 | Live-ingest a single shard | `make shard-live SHARD=aws_ec2 SRC=/path/to/offer.json` |
+| Dispatch daily data workflow (dry-run) | `gh workflow run data-daily.yml -F dry_run=true -F force_baseline=true` |
+| Dispatch daily data workflow (publish) | `gh workflow run data-daily.yml -F dry_run=false -F force_baseline=true` |
 
 ## Repo map
 
@@ -43,8 +45,17 @@ Agent quick-start for the `sku` repo.
 
 ## Current milestone
 
-M7.2 — Guides, reference, agent skill: all docs/guides/*, docs/reference/*, and skill/using-sku/SKILL.md published. `make docs-verify` green.
-Next: M7.3 — Security, bench regression gate, v1.0.0 release.
+M3a.4.2 — `data-daily.yml` cron workflow publishes daily data releases:
+discover → ingest (matrix) → diff+package (matrix) → publish. Emits
+`data-YYYY.MM.DD` GitHub release with `<shard>.db.zst` baselines,
+`<shard>-<from>-to-<to>.sql.gz` deltas, and an authoritative `manifest.json`.
+Mirrors the manifest to the `data` branch for jsDelivr fallback; purges CDN
+on each publish. Dry-runs via `gh workflow run data-daily.yml -F dry_run=true`.
+Runbook: `docs/ops/data-daily-runbook.md`.
+
+Next: M3a.4.3 — `data-validate.yml` (OIDC cross-check vs upstream) +
+client-side `internal/updater` delta-chain walker + ETag + stable/daily
+channel split.
 
 ### Quick path (agent, repeatable, M3b.4 surface)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,8 @@ Agent quick-start for the `sku` repo.
 
 ## Current milestone
 
-M6 — Distribution channels: pre-release `v0.1.0-rc.1` cut.
-Exit-gated on fresh-machine install verification for the first non-pre-release tag.
-Next: M7 — Docs, polish, v1.0.
+M7.1 — Docs foundation: README v1, getting-started, install polish, per-command reference, examples verified by `make docs-verify`.
+Next: M7.2 — Guides and reference (kinds, presets, exit codes, agent-integration, llm-routing, offline-use, `skill/using-sku/SKILL.md`).
 
 ### Quick path (agent, repeatable, M3b.4 surface)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@ Agent quick-start for the `sku` repo.
 | Run Go integration tests | `make test-integration` |
 | Run benchmarks | `make bench` |
 | Run Python pipeline tests | `make pipeline-test` |
+| Run discover (fixture / dry-run) | `make discover` |
+| Run discover against real upstreams | `DISCOVER_LIVE=1 GCP_BILLING_API_KEY=... make discover` |
+| Live-ingest a single shard | `make shard-live SHARD=aws_ec2 SRC=/path/to/offer.json` |
 
 ## Repo map
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ Agent quick-start for the `sku` repo.
 
 ## Current milestone
 
-M7.1 — Docs foundation: README v1, getting-started, install polish, per-command reference, examples verified by `make docs-verify`.
-Next: M7.2 — Guides and reference (kinds, presets, exit codes, agent-integration, llm-routing, offline-use, `skill/using-sku/SKILL.md`).
+M7.2 — Guides, reference, agent skill: all docs/guides/*, docs/reference/*, and skill/using-sku/SKILL.md published. `make docs-verify` green.
+Next: M7.3 — Security, bench regression gate, v1.0.0 release.
 
 ### Quick path (agent, repeatable, M3b.4 surface)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,9 @@ Agent quick-start for the `sku` repo.
 
 ## Current milestone
 
-v1.0 shipped — no open milestone.
+M6 — Distribution channels: pre-release `v0.1.0-rc.1` cut.
+Exit-gated on fresh-machine install verification for the first non-pre-release tag.
+Next: M7 — Docs, polish, v1.0.
 
 ### Quick path (agent, repeatable, M3b.4 surface)
 

--- a/Makefile
+++ b/Makefile
@@ -228,3 +228,8 @@ npm-pack-smoke: build ## Pack root npm package and run `sku version` via shim
 pypi-wheel-smoke: build ## Stage local binary + build a single wheel
 	mkdir -p python/sku_cli/bin && cp bin/sku python/sku_cli/bin/
 	cd python && python3 -m build --wheel
+
+.PHONY: docs-verify
+docs-verify: build ## Re-run every verified snippet in docs/getting-started.md + docs/commands/
+	@test -d dist/pipeline || (echo "run 'make openrouter-shard aws-shards azure-shards gcp-shards' first" && exit 2)
+	bash scripts/verify-docs-snippets.sh

--- a/Makefile
+++ b/Makefile
@@ -233,3 +233,32 @@ pypi-wheel-smoke: build ## Stage local binary + build a single wheel
 docs-verify: build ## Re-run every verified snippet in docs/getting-started.md + docs/commands/
 	@test -d dist/pipeline || (echo "run 'make openrouter-shard aws-shards azure-shards gcp-shards' first" && exit 2)
 	bash scripts/verify-docs-snippets.sh
+
+# ---------------------------------------------------------------------------
+# Discover + live ingest (m3a.4.1)
+
+.PHONY: discover
+discover: ## Run the discover module; DISCOVER_LIVE=1 hits real upstreams
+	@mkdir -p $(CURDIR)/dist/pipeline/discover
+	$(MAKE) -C pipeline setup
+	cd pipeline && .venv/bin/python -m discover \
+	  --state $(CURDIR)/dist/pipeline/discover/state.json \
+	  --out   $(CURDIR)/dist/pipeline/discover/changed.json \
+	  $(if $(DISCOVER_LIVE),--live,) \
+	  $(if $(BASELINE_REBUILD),--baseline-rebuild,) \
+	  $(if $(DISCOVER_SHARDS),--shards $(DISCOVER_SHARDS),)
+
+# Map SHARD=<underscored> to the correct live-source flag for its ingest script.
+_SHARD_LIVE_FLAG = $(if $(filter aws_%,$(SHARD)),--offer,\
+                    $(if $(filter azure_%,$(SHARD)),--prices,\
+                    $(if $(filter gcp_%,$(SHARD)),--skus,)))
+
+.PHONY: shard-live
+shard-live: ## Ingest + package SHARD=<name> using SRC=<local-offer-path>
+	@test -n "$(SHARD)" || (echo "SHARD=<name> required" && exit 2)
+	@test -n "$(SRC)"   || (echo "SRC=<local-offer-path> required" && exit 2)
+	@test -n "$(_SHARD_LIVE_FLAG)" || \
+	  (echo "shard-live: SHARD=$(SHARD) is not aws_*, azure_*, or gcp_*" && exit 2)
+	mkdir -p dist/pipeline
+	$(MAKE) -C pipeline shard SHARD=$(SHARD) \
+	  INGEST_EXTRA='$(_SHARD_LIVE_FLAG) $(SRC) $(INGEST_EXTRA)'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,99 @@
-# sku
+# sku — agent-friendly cloud & LLM pricing CLI
 
-Agent-friendly cloud & LLM pricing CLI.
+[![CI](https://github.com/sofq/sku/actions/workflows/ci.yml/badge.svg)](https://github.com/sofq/sku/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/sofq/sku?include_prereleases&sort=semver)](https://github.com/sofq/sku/releases)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-**Status:** pre-alpha (M0). Not yet installable.
+`sku` answers "what does this cost?" for AWS, Azure, Google Cloud, and OpenRouter in one pure-Go binary. JSON-everywhere, semantic exit codes, sub-30ms warm point lookups — purpose-built for AI agents that make programmatic pricing decisions.
 
-See [`docs/superpowers/specs/2026-04-18-sku-design.md`](docs/superpowers/specs/2026-04-18-sku-design.md) for the design.
+## Five-minute quickstart
 
-## License
+```bash
+# Install
+brew install sofq/tap/sku         # or: npx @sofq/sku, pipx install sku-cli,
+                                  # scoop install sku, docker run ghcr.io/sofq/sku
 
-Apache-2.0 — see [LICENSE](LICENSE).
+# Fetch pricing data (first run only)
+sku update openrouter aws-ec2
+
+# Point lookup
+sku aws ec2 price --instance-type m5.large --region us-east-1 --pretty
+
+# Cross-provider compare
+sku compare --kind compute.vm --vcpu 4 --memory 16 --regions us-east --limit 5 --pretty
+
+# Estimate monthly cost
+sku estimate --item aws/ec2:m5.large:region=us-east-1:count=10:hours=730 --pretty
+
+# Cheapest LLM for long context
+sku llm price --model anthropic/claude-opus-4.6 --pretty
+```
+
+See **[`docs/getting-started.md`](docs/getting-started.md)** for the annotated walkthrough.
+
+## Why sku
+
+- **Offline-first.** Daily pricing data ships via `sku update`; the binary never calls provider APIs. Runs in airgapped CI.
+- **Agent-shaped output.** Every response is JSON; pipe into `jq`, or use `--jq`, `--fields`, and `--preset` to project what you need. Exit codes are a contract ([`docs/reference/exit-codes.md`](docs/reference/exit-codes.md)).
+- **Four providers, one schema.** AWS, Azure, GCP, and 70+ LLM serving providers via OpenRouter share a single `price[]` shape — cross-provider `compare` and `search` just work.
+- **Pure Go, zero CGO.** Cross-compiles to Linux / macOS / Windows × amd64 / arm64. Signed releases with SLSA L3 provenance and SBOMs.
+
+## Install
+
+```bash
+# Homebrew (macOS/Linux)
+brew install sofq/tap/sku
+
+# Scoop (Windows)
+scoop bucket add sofq https://github.com/sofq/scoop-bucket
+scoop install sku
+
+# npm (JS/TS toolchains, uses platform-optional-dependencies)
+npm i -g @sofq/sku        # or: npx @sofq/sku <cmd>
+
+# PyPI (Python toolchains)
+pipx install sku-cli       # or: pip install --user sku-cli
+
+# Docker
+docker pull ghcr.io/sofq/sku:latest
+docker run --rm ghcr.io/sofq/sku:latest version
+
+# Direct download (all else)
+# see https://github.com/sofq/sku/releases
+```
+
+Full install doc including signature verification: [`docs/install.md`](docs/install.md).
+
+## Commands
+
+Full per-command reference: [`docs/commands/`](docs/commands/).
+
+| Command | Purpose |
+|---|---|
+| [`sku price`](docs/commands/price.md) / `sku <provider> <service> price` | Point lookup |
+| [`sku search`](docs/commands/search.md) | Filter SKUs within one shard |
+| [`sku compare`](docs/commands/compare.md) | Cross-provider equivalence |
+| [`sku estimate`](docs/commands/estimate.md) | Workload → monthly cost |
+| [`sku batch`](docs/commands/batch.md) | NDJSON / JSON-array of multiple ops |
+| [`sku schema`](docs/commands/schema.md) | Discover commands, error codes, serving providers |
+| [`sku update`](docs/commands/update.md) | Fetch / refresh a shard |
+| [`sku configure`](docs/commands/configure.md) | Manage named profiles |
+| [`sku version`](docs/commands/version.md) | Build metadata (JSON) |
+
+## Guides
+
+- [Agent integration](docs/guides/agent-integration.md)
+- [LLM routing](docs/guides/llm-routing.md)
+- [Offline & airgapped use](docs/guides/offline-use.md)
+
+## Reference
+
+- [Kinds](docs/reference/kinds.md) — unified `compute.vm`, `storage.object`, `db.relational`, `llm.text`
+- [Presets](docs/reference/presets.md) — `agent`, `full`, `price`, `compare`
+- [Exit codes](docs/reference/exit-codes.md) — the contract for automation
+
+## Security & support
+
+- Found a bug? File an [issue](https://github.com/sofq/sku/issues).
+- Found a vulnerability? See [`SECURITY.md`](SECURITY.md).
+- [`CHANGELOG.md`](CHANGELOG.md) · [`LICENSE`](LICENSE) (Apache-2.0).

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -1,0 +1,47 @@
+# Command reference
+
+Every command accepts the [global flags](#global-flags) below. Exit codes are documented in [`../reference/exit-codes.md`](../reference/exit-codes.md).
+
+| Command | Purpose | Page |
+|---|---|---|
+| `price` | Universal point lookup | [price.md](price.md) |
+| `search` | Filter SKUs in one shard | [search.md](search.md) |
+| `compare` | Cross-provider equivalence | [compare.md](compare.md) |
+| `estimate` | Workload → monthly cost | [estimate.md](estimate.md) |
+| `batch` | Many ops from stdin | [batch.md](batch.md) |
+| `schema` | Discovery / introspection | [schema.md](schema.md) |
+| `update` | Fetch or refresh a shard | [update.md](update.md) |
+| `configure` | Named profiles | [configure.md](configure.md) |
+| `version` | Build metadata | [version.md](version.md) |
+| `aws` | AWS provider subtree | [aws.md](aws.md) |
+| `azure` | Azure provider subtree | [azure.md](azure.md) |
+| `gcp` | GCP provider subtree | [gcp.md](gcp.md) |
+| `llm` | Cross-provider LLM + serving-provider views | [llm.md](llm.md) |
+
+## Global flags
+
+All commands accept:
+
+| Flag | Env | Meaning |
+|---|---|---|
+| `--profile` | `SKU_PROFILE` | Named profile |
+| `--preset {agent,full,price,compare}` | `SKU_PRESET` | Field projection |
+| `--json` / `--yaml` / `--toml` | `SKU_FORMAT` | Output format |
+| `--pretty` | – | Indent JSON |
+| `--jq <expr>` | – | Filter via gojq |
+| `--fields <paths>` | – | Comma-separated dot-path projection |
+| `--include-raw` | – | Include raw passthrough row |
+| `--include-aggregated` | – | Include OpenRouter aggregated rows |
+| `--stale-ok` | `SKU_STALE_OK` | Suppress stale-catalog warning |
+| `--auto-fetch` | – | Download missing shards on demand |
+| `--dry-run` | `SKU_DRY_RUN` | Print plan; no execution |
+| `--verbose` | `SKU_VERBOSE` | Stderr JSON log |
+| `--no-color` | `NO_COLOR` / `SKU_NO_COLOR` | Disable color |
+
+Precedence: CLI flag > env var > profile value > default.
+
+## Output conventions
+
+- **JSON is the default.** YAML and TOML are exact mappings of the same JSON tree (TOML wraps top-level arrays as `{ "rows": [...] }` — spec §CLAUDE.md *TOML quirks*).
+- **Errors go to stderr as JSON** with `{ "error": { "code", "message", "suggestion", "details" } }` and a semantic exit code.
+- **Every successful price response** carries `price[]` with `unit`, `currency`, `amount`, and (optional) `tier`.

--- a/docs/commands/aws.md
+++ b/docs/commands/aws.md
@@ -1,0 +1,29 @@
+# `sku aws`
+
+AWS services are registered statically. Every leaf supports `price` (point lookup) and `list` (enumeration). Install the matching shard first: `sku update aws-<service>`.
+
+| Leaf | Shard | Key flags (`price`) |
+|---|---|---|
+| `ec2` | `aws-ec2` | `--instance-type`, `--region`, `--os` (default `linux`), `--tenancy` |
+| `rds` | `aws-rds` | `--instance-type`, `--region`, `--engine`, `--deployment-option` |
+| `s3` | `aws-s3` | `--storage-class`, `--region` |
+| `lambda` | `aws-lambda` | `--architecture` (`x86_64`,`arm64`), `--region` |
+| `ebs` | `aws-ebs` | `--volume-type`, `--region` |
+| `dynamodb` | `aws-dynamodb` | `--table-class`, `--region` |
+| `cloudfront` | `aws-cloudfront` | `--region` |
+
+`list` takes the same filters as `price` minus `--region` (which becomes optional).
+
+## Examples
+
+```bash
+sku aws ec2 price        --instance-type m5.large --region us-east-1 --preset agent
+sku aws ec2 list         --instance-type m5.large
+sku aws rds price        --instance-type db.m5.large --region us-east-1 \
+                          --engine postgres --deployment-option single-az
+sku aws s3 price         --storage-class standard --region us-east-1
+sku aws lambda price     --architecture arm64 --region us-east-1
+sku aws ebs price        --volume-type gp3 --region us-east-1
+sku aws dynamodb price   --table-class standard --region us-east-1
+sku aws cloudfront price --region eu-west-1
+```

--- a/docs/commands/azure.md
+++ b/docs/commands/azure.md
@@ -1,0 +1,21 @@
+# `sku azure`
+
+| Leaf | Shard | Key flags (`price`) |
+|---|---|---|
+| `vm` | `azure-vm` | `--arm-sku-name`, `--region`, `--os` (`linux`,`windows`) |
+| `sql` | `azure-sql` | `--sku-name`, `--region`, `--deployment-option` |
+| `blob` | `azure-blob` | `--tier` (`hot`,`cool`,`archive`), `--region` |
+| `functions` | `azure-functions` | `--architecture`, `--region` |
+| `disks` | `azure-disks` | `--disk-type` (`premium-ssd`,`standard-ssd`,`standard-hdd`), `--region` |
+
+## Examples
+
+```bash
+sku azure vm price        --arm-sku-name Standard_D2_v3 --region eastus --os linux --preset agent
+sku azure sql price       --sku-name GP_Gen5_2 --region eastus --deployment-option single-az
+sku azure blob price      --tier hot --region eastus
+sku azure functions price --architecture x86_64 --region eastus
+sku azure disks price     --disk-type premium-ssd --region eastus
+```
+
+Azure region names use the short form (`eastus`, `westeurope`). The region-normalization layer maps `--regions us-east` prefixes to Azure's `eastus` in `compare`.

--- a/docs/commands/batch.md
+++ b/docs/commands/batch.md
@@ -1,0 +1,40 @@
+# `sku batch`
+
+Run multiple operations in a single process. Input is NDJSON or a JSON array on stdin; the output is always a JSON array of records, one per input op.
+
+## Synopsis
+
+```
+sku batch [--concurrency N] [--continue-on-error] [flags] < input
+```
+
+## Input record shape
+
+```json
+{"command": "aws ec2 price", "args": {"instance_type": "m5.large", "region": "us-east-1"}}
+```
+
+`args` keys are the op's flag names with dashes replaced by underscores (e.g. `instance-type` → `instance_type`).
+
+## Examples
+
+```bash
+echo '[
+  {"command":"aws ec2 price","args":{"instance_type":"m5.large","region":"us-east-1"}},
+  {"command":"llm price",    "args":{"model":"anthropic/claude-opus-4.6"}}
+]' | sku batch --pretty
+
+cat docs/examples/batch-queries.ndjson | sku batch
+```
+
+## Aggregated exit code
+
+Aggregated exit = **worst-case** of all ops, by severity rank (validation > not_found > stale_data > ok). The full ranking and JSON envelope shape are in [`../reference/exit-codes.md`](../reference/exit-codes.md).
+
+## Discovering registered commands
+
+```bash
+sku schema --list-commands
+```
+
+Returns the exact `command` strings `batch` accepts.

--- a/docs/commands/compare.md
+++ b/docs/commands/compare.md
@@ -1,0 +1,38 @@
+# `sku compare`
+
+Cross-provider equivalence within one *kind*. Rows are normalized to a common schema so AWS, Azure, GCP (and LLM serving providers for `llm.text`) are sortable together.
+
+## Synopsis
+
+```
+sku compare --kind <kind> [spec] [flags]
+```
+
+## Flags (common)
+
+| Flag | Meaning |
+|---|---|
+| `--kind` | Required. `compute.vm`, `storage.object`, `db.relational`. LLM comparison uses `sku llm compare`. |
+| `--vcpu`, `--memory` | `compute.vm` / `db.relational`. |
+| `--storage-class` | `storage.object`. |
+| `--engine` | `db.relational` (e.g. `postgres`, `mysql`). |
+| `--deployment-option` | `db.relational` (e.g. `single-az`, `multi-az`). |
+| `--regions` | Comma-separated region prefixes (e.g. `us-east,eu-west`). |
+| `--sort` | `price` (default), `provider`, `region`. |
+| `--limit` | Cap row count (per shard, then merged). |
+
+## Examples
+
+```bash
+sku compare --kind compute.vm      --vcpu 4 --memory 16 --regions us-east --limit 5 --preset compare
+sku compare --kind compute.vm      --vcpu 8 --memory 32 --regions us-east,eu-west --sort price
+sku compare --kind storage.object  --storage-class standard --regions us-east --limit 5
+sku compare --kind db.relational   --vcpu 2 --memory 8 --engine postgres \
+             --deployment-option single-az --regions us-east --limit 5
+```
+
+## Exit codes
+
+`0`, `3`, `4`, `8`.
+
+See [`../reference/kinds.md`](../reference/kinds.md) for what each kind covers and which shards currently contribute rows.

--- a/docs/commands/configure.md
+++ b/docs/commands/configure.md
@@ -1,0 +1,34 @@
+# `sku configure`
+
+Create or edit a named profile in `$SKU_CONFIG_DIR/config.yaml` (default: `$XDG_CONFIG_HOME/sku/config.yaml`).
+
+## Synopsis
+
+```
+sku configure                               # interactive
+sku configure --profile <name> --set key=value  # scripted
+sku configure --profile <name> --show --pretty
+```
+
+## Scripted example
+
+```bash
+sku configure --profile work \
+  --set preset=agent \
+  --set format=json \
+  --set auto_fetch=true
+```
+
+## Using a profile
+
+```bash
+sku --profile work aws ec2 price --instance-type m5.large --region us-east-1
+# or
+SKU_PROFILE=work sku aws ec2 price --instance-type m5.large --region us-east-1
+```
+
+Precedence: CLI flag > env > profile > default.
+
+## Exit codes
+
+`0`, `4` (invalid key/value).

--- a/docs/commands/estimate.md
+++ b/docs/commands/estimate.md
@@ -1,0 +1,55 @@
+# `sku estimate`
+
+Compute monthly cost from a workload spec. Three input forms, all equivalent:
+
+1. `--item <inline-dsl>` (repeatable)
+2. `--config <yaml>` (may include multiple items)
+3. `--stdin` (JSON on stdin)
+
+## Inline DSL
+
+```
+<provider>/<service>:<resource>[:key=value[:key=value...]]
+llm:<model>:[input=<count>][:output=<count>][:serving_provider=<name>]
+```
+
+Numeric suffixes `K`, `M`, `G` are accepted on `input` / `output` LLM token counts.
+
+## Examples
+
+```bash
+# Compute
+sku estimate --item aws/ec2:m5.large:region=us-east-1:count=10:hours=730 --pretty
+
+# Mix two items
+sku estimate --item aws/ec2:m5.large:region=us-east-1:count=2:hours=100 \
+             --item aws/ec2:m5.xlarge:region=us-east-1:count=1:hours=730
+
+# From YAML
+sku estimate --config docs/examples/workload-vm.yaml --pretty
+
+# From stdin JSON
+echo '{"items":[{"provider":"aws","service":"ec2","resource":"m5.large",
+  "params":{"region":"us-east-1","count":2,"hours":100}}]}' \
+  | sku estimate --stdin --pretty
+
+# Storage
+sku estimate --item 'aws/s3:standard:region=us-east-1:gb_month=500:put_requests=1000:get_requests=5000' --pretty
+
+# LLM
+sku estimate --item 'llm:anthropic/claude-opus-4.6:input=1M:output=500K:serving_provider=anthropic' --pretty
+sku estimate --config docs/examples/workload-llm.yaml --pretty
+```
+
+## Output shape
+
+```json
+{
+  "items": [ { "provider": "...", "service": "...", "resource": "...", "params": {...}, "cost_usd_monthly": 73.00, "price_source": {...} } ],
+  "total_usd_monthly": 730.00
+}
+```
+
+## Exit codes
+
+`0`, `3`, `4` (bad DSL), `8`.

--- a/docs/commands/gcp.md
+++ b/docs/commands/gcp.md
@@ -1,0 +1,19 @@
+# `sku gcp`
+
+| Leaf | Shard | Key flags (`price`) |
+|---|---|---|
+| `gce` | `gcp-gce` | `--machine-type`, `--region` |
+| `cloud-sql` | `gcp-cloud-sql` | `--tier`, `--region`, `--engine`, `--deployment-option` |
+| `gcs` | `gcp-gcs` | `--storage-class`, `--region` |
+| `run` | `gcp-run` | `--architecture`, `--region` |
+| `functions` | `gcp-functions` | `--architecture`, `--region` |
+
+## Examples
+
+```bash
+sku gcp gce price       --machine-type n1-standard-2 --region us-east1 --preset agent
+sku gcp cloud-sql price --tier db-custom-2-7680 --region us-east1 --engine postgres --deployment-option zonal
+sku gcp gcs price       --storage-class standard --region us-east1
+sku gcp run price       --architecture x86_64 --region us-east1
+sku gcp functions price --architecture x86_64 --region us-east1
+```

--- a/docs/commands/llm.md
+++ b/docs/commands/llm.md
@@ -1,0 +1,41 @@
+# `sku llm` and serving-provider subtrees
+
+LLM pricing lives in a single `openrouter` shard. Two surfaces query it:
+
+1. `sku llm {price,list,compare}` — cross-provider view.
+2. `sku <serving-provider> llm {price,list}` — scoped to one serving provider (`anthropic`, `openai`, `aws-bedrock`, `gcp-vertex`, `azure-openai`, `openrouter`).
+
+All serving providers registered in the shard are discoverable:
+
+```bash
+sku schema --list-serving-providers
+```
+
+## `sku llm price`
+
+```bash
+sku llm price --model anthropic/claude-opus-4.6 --pretty
+sku llm price --model anthropic/claude-opus-4.6 --serving-provider aws-bedrock
+sku llm price --model anthropic/claude-opus-4.6 --fields provider,price.0.amount
+sku llm price --model anthropic/claude-opus-4.6 --jq '.price[0].amount' --serving-provider aws-bedrock
+sku llm price --model anthropic/claude-opus-4.6 --dry-run
+```
+
+## Aggregated rows
+
+`sku llm price` / `list` / `compare` **exclude** OpenRouter's synthetic aggregated rows by default (marked with `resource.attributes.aggregated = true`). Two ways to include them:
+
+```bash
+sku --include-aggregated llm price --model anthropic/claude-opus-4.6
+sku openrouter llm price          --model anthropic/claude-opus-4.6   # aggregated-only view
+```
+
+## Serving-provider view (`sku <serving-provider> llm`)
+
+```bash
+sku aws-bedrock  llm price --model anthropic/claude-opus-4.6
+sku anthropic    llm price --model anthropic/claude-opus-4.6
+sku openai       llm price --model openai/gpt-4o-mini
+```
+
+A serving-provider leaf filters `WHERE provider = '<name>'`. See the guide [`../guides/llm-routing.md`](../guides/llm-routing.md).

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -1,0 +1,32 @@
+# `sku price`
+
+Universal point-lookup verb. In practice you'll almost always use the per-provider form (`sku aws ec2 price`, `sku llm price`) — those pages describe the flags each shard accepts.
+
+## Synopsis
+
+```
+sku <provider> <service> price [flags]
+sku llm price --model <id> [--serving-provider <name>] [flags]
+```
+
+## Flags
+
+See [global flags](README.md#global-flags) and each provider page:
+
+- AWS: [`aws.md`](aws.md)
+- Azure: [`azure.md`](azure.md)
+- GCP: [`gcp.md`](gcp.md)
+- LLM: [`llm.md`](llm.md)
+
+## Examples
+
+```bash
+sku aws ec2 price   --instance-type m5.large --region us-east-1 --preset agent
+sku azure vm price  --arm-sku-name Standard_D2_v3 --region eastus --os linux
+sku gcp  gce price  --machine-type n1-standard-2 --region us-east1
+sku llm  price      --model anthropic/claude-opus-4.6 --serving-provider aws-bedrock
+```
+
+## Exit codes
+
+Common: `0` ok, `3` not_found, `4` validation, `8` stale_data. Full taxonomy: [`../reference/exit-codes.md`](../reference/exit-codes.md).

--- a/docs/commands/schema.md
+++ b/docs/commands/schema.md
@@ -1,0 +1,25 @@
+# `sku schema`
+
+Machine-readable discovery endpoint. Every flag returns JSON so agents can introspect without parsing help text.
+
+## Flags
+
+| Flag | Emits |
+|---|---|
+| `--errors` | Full error-code catalog: `{codes: {name: {exit_code, description, details_fields, reasons?}}, schema_version}` |
+| `--list-commands` | Registered batch commands (exact strings for `sku batch` input) |
+| `--list-serving-providers` | Serving providers seeded in the `openrouter` shard (reads `metadata.serving_providers`) |
+| `--list-shards` | Shards the binary statically registers + which are installed locally |
+| `--list-kinds` | Kinds this binary understands + which shards contribute |
+
+## Examples
+
+```bash
+sku schema --errors                  | jq '.codes | keys'
+sku schema --list-commands           | jq '.commands'
+sku schema --list-serving-providers
+```
+
+## Exit codes
+
+`0` ok; `3` if an asked-for shard is missing (e.g. `--list-serving-providers` without `openrouter` installed).

--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -1,0 +1,37 @@
+# `sku search`
+
+Filter SKUs inside a single shard. Use [`compare`](compare.md) for cross-provider; `search` is one provider/service at a time.
+
+## Synopsis
+
+```
+sku search --provider <aws|azure|gcp> --service <name> [filters] [flags]
+```
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `--provider` | Required. One of `aws`, `azure`, `gcp` (not `llm` — use `sku llm list`). |
+| `--service` | Required. Shard name within the provider (e.g. `ec2`, `vm`, `gce`). |
+| `--kind` | Filter on unified kind (`compute.vm`, `storage.object`, …). |
+| `--region` | Filter on region. |
+| `--min-vcpu`, `--max-vcpu` | Numeric bounds on `resource.specs.vcpu`. |
+| `--min-memory`, `--max-memory` | GiB bounds. |
+| `--min-price`, `--max-price` | USD/unit bounds on `price[0].amount`. |
+| `--sort` | `price` (default) or `resource`. |
+| `--limit` | Cap row count. |
+
+## Examples
+
+```bash
+sku search --provider aws --service ec2 --min-vcpu 4 --limit 5 --preset agent
+sku search --provider aws --service ec2 --max-price 0.10 --sort price
+sku search --provider aws --service ec2 --region us-east-1 --kind compute.vm
+```
+
+Output: JSON array of SKU objects (same schema as `price`). Use `--preset agent` to drop catalog metadata.
+
+## Exit codes
+
+`0`, `3`, `4`, `8`. Full: [`../reference/exit-codes.md`](../reference/exit-codes.md).

--- a/docs/commands/update.md
+++ b/docs/commands/update.md
@@ -1,0 +1,33 @@
+# `sku update`
+
+Fetch or refresh one or more shards from the CDN. The binary itself is offline; all data freshness flows through this command.
+
+## Synopsis
+
+```
+sku update [<shard>...] [--status] [--channel <name>] [--force] [flags]
+```
+
+`<shard>` is one of the names emitted by `sku schema --list-shards`. With no arguments, all installed shards are refreshed.
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `--status` | Print per-shard freshness JSON; no fetch. |
+| `--channel` | `stable` (default) or `unstable`. |
+| `--force` | Re-apply deltas even if local state matches the manifest head. |
+
+## Examples
+
+```bash
+sku update openrouter aws-ec2
+sku update                   # refresh all installed
+sku update --status --pretty
+```
+
+## Exit codes
+
+`0`, `4` (binary too old for an advertised shard), `5` (rate-limited by CDN; retry-after in envelope), `6` (state conflict), `7` (CDN upstream error), `8` (catalog older than `SKU_STALE_ERROR_DAYS`).
+
+See [`../guides/offline-use.md`](../guides/offline-use.md) for airgapped workflows.

--- a/docs/commands/version.md
+++ b/docs/commands/version.md
@@ -1,0 +1,19 @@
+# `sku version`
+
+Prints build metadata as JSON. Safe to parse from scripts.
+
+```bash
+sku version --pretty
+```
+
+```json
+{
+  "version":  "0.1.0",
+  "commit":   "abc1234",
+  "built":    "2026-04-19T12:00:00Z",
+  "go_version": "go1.25.2",
+  "platform": "linux/amd64"
+}
+```
+
+Exit `0` always.

--- a/docs/examples/workload-llm.yaml
+++ b/docs/examples/workload-llm.yaml
@@ -1,0 +1,8 @@
+items:
+  - provider: llm
+    service: text
+    resource: anthropic/claude-opus-4.6
+    params:
+      input: 1M
+      output: 500K
+      serving_provider: anthropic

--- a/docs/examples/workload-storage.yaml
+++ b/docs/examples/workload-storage.yaml
@@ -1,0 +1,9 @@
+items:
+  - provider: aws
+    service: s3
+    resource: standard
+    params:
+      region: us-east-1
+      gb_month: "500"
+      put_requests: "1000"
+      get_requests: "5000"

--- a/docs/examples/workload-vm.yaml
+++ b/docs/examples/workload-vm.yaml
@@ -1,0 +1,8 @@
+items:
+  - provider: aws
+    service: ec2
+    resource: m5.large
+    params:
+      region: us-east-1
+      count: 2
+      hours: 100

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,107 @@
+# Getting started with sku
+
+By the end of this page you will have:
+
+1. Installed `sku`.
+2. Fetched pricing data for AWS EC2 and OpenRouter.
+3. Run a point lookup, a cross-provider compare, an estimate, and a batch.
+4. Understood how to pipe output into `jq` without post-processing.
+
+Estimated time: **5 minutes**.
+
+## 1. Install
+
+Pick any one — see [install.md](install.md) for the full matrix:
+
+```bash
+brew install sofq/tap/sku
+# or
+pipx install sku-cli
+```
+
+Verify:
+
+```bash
+sku version --pretty
+```
+
+Expected: a JSON object with `version`, `commit`, `built`, `go_version`, `platform`.
+
+## 2. Fetch pricing data
+
+The binary is **offline-only**. `sku update` pulls daily deltas from the CDN and stores them under `$SKU_DATA_DIR` (default: `$XDG_DATA_HOME/sku`).
+
+```bash
+sku update openrouter aws-ec2
+```
+
+Expected exit 0. Check freshness:
+
+```bash
+sku update --status --pretty
+```
+
+## 3. Point lookup
+
+```bash
+sku aws ec2 price --instance-type m5.large --region us-east-1 --pretty
+```
+
+Expected: a JSON document with `provider`, `service`, `resource`, and a `price[]` array. Every numeric price is in USD-per-hour unless a different unit is declared in the row.
+
+Agent-flavoured projection — drop the catalog metadata, keep just the price figure:
+
+```bash
+sku aws ec2 price --instance-type m5.large --region us-east-1 \
+  --jq '.price[0].amount'
+```
+
+Or use a preset:
+
+```bash
+sku aws ec2 price --instance-type m5.large --region us-east-1 --preset price
+```
+
+Exit code 3 means no SKU matched ("not found") — the stderr envelope includes a `suggestion` and `nearest_matches`.
+
+## 4. Cross-provider compare
+
+```bash
+sku compare --kind compute.vm --vcpu 4 --memory 16 --regions us-east \
+  --limit 5 --preset compare --pretty
+```
+
+Expected: rows from AWS, Azure, and GCP sorted by price, unified under one schema. See [guides/llm-routing.md](guides/llm-routing.md) for the LLM equivalent.
+
+## 5. Estimate
+
+Inline DSL:
+
+```bash
+sku estimate \
+  --item aws/ec2:m5.large:region=us-east-1:count=10:hours=730 \
+  --item aws/ec2:m5.xlarge:region=us-east-1:count=1:hours=730 \
+  --pretty
+```
+
+Or from a workload file:
+
+```bash
+sku estimate --config docs/examples/workload-vm.yaml --pretty
+```
+
+## 6. Batch
+
+Run three ops in one invocation (all non-agent-shaped input forms are NDJSON or JSON-array on stdin):
+
+```bash
+cat docs/examples/batch-queries.ndjson | sku batch --pretty
+```
+
+The aggregated exit code is the **worst-case** of all ops (see [reference/exit-codes.md](reference/exit-codes.md)).
+
+## Next
+
+- Every command in detail: [`commands/`](commands/).
+- Using sku from inside an agent: [`guides/agent-integration.md`](guides/agent-integration.md).
+- What each *kind* means: [`reference/kinds.md`](reference/kinds.md).

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,12 @@
+# Guides
+
+Task-oriented walkthroughs. Every snippet runs against the shipping binary.
+
+| Guide | Page |
+|---|---|
+| Calling sku from an agent | [agent-integration.md](agent-integration.md) |
+| LLM routing by price | [llm-routing.md](llm-routing.md) |
+| Offline / airgapped use | [offline-use.md](offline-use.md) |
+
+For CLI syntax, see [`../commands/`](../commands/).
+For contracts (kinds, presets, exit codes), see [`../reference/`](../reference/).

--- a/docs/guides/agent-integration.md
+++ b/docs/guides/agent-integration.md
@@ -1,0 +1,93 @@
+# Calling sku from an agent
+
+`sku` is built for agent loops. This guide covers the four moves that pay off the most.
+
+## 1. Start with `agent` preset
+
+`agent` is the default — but if you've aliased `sku` through a profile that bumped `preset=full`, force it back:
+
+```bash
+sku --preset agent aws ec2 price --instance-type m5.large --region us-east-1
+```
+
+Output is ~200 bytes, JSON, with the minimum fields an agent needs: `provider`, `service`, `resource.name`, `location.provider_region`, `price`, `terms.commitment`.
+
+## 2. Project aggressively
+
+Agents rarely need the full record. Two tools do the same job with different ergonomics:
+
+```bash
+# --fields: declarative dot-path projection. Order preserved.
+sku aws ec2 price --instance-type m5.large --region us-east-1 \
+  --fields provider,resource.name,price.0.amount
+
+# --jq: full gojq expression. Use when you need computation.
+sku aws ec2 price --instance-type m5.large --region us-east-1 \
+  --jq '{type: .resource.name, usd_hr: .price[0].amount}'
+```
+
+Combine both: `--fields` runs first, then `--jq` operates on the reduced tree.
+
+## 3. Branch on exit code, parse stderr for details
+
+Exit code is a cheap branch. Only parse stderr when you need the structured detail:
+
+```bash
+if out=$(sku aws ec2 price --instance-type "$T" --region "$R" 2>err.json); then
+  amount=$(echo "$out" | jq -r '.price[0].amount')
+else
+  case $? in
+    3) nearest=$(jq -r '.error.details.nearest_matches // [] | join(",")' err.json) ;;
+    4) reason=$(jq -r '.error.details.reason' err.json) ;;
+    8) echo "shard stale" ;;
+    *) echo "unhandled"; cat err.json ;;
+  esac
+fi
+```
+
+Full exit-code table: [`../reference/exit-codes.md`](../reference/exit-codes.md).
+
+## 4. Collapse N lookups into one `sku batch`
+
+In-process dispatch. No shell-fork-per-op. No startup amortisation tricks.
+
+```bash
+cat <<'EOF' | sku batch --pretty
+{"command":"aws ec2 price","args":{"instance_type":"m5.large","region":"us-east-1"}}
+{"command":"aws ec2 price","args":{"instance_type":"m5.xlarge","region":"us-east-1"}}
+{"command":"llm price","args":{"model":"anthropic/claude-opus-4.6"}}
+EOF
+```
+
+Output is a JSON array with each op's own `exit_code` + body; the **process** exit is the aggregated worst-case (see [exit-codes.md](../reference/exit-codes.md)).
+
+Discover the exact `command` strings `batch` accepts:
+
+```bash
+sku schema --list-commands
+```
+
+## 5. Avoid implicit auto-fetch in agent flows
+
+`--auto-fetch` is a convenience for humans. In an agent loop, prefer the deterministic two-step:
+
+```bash
+sku update --status --pretty | jq -e '.shards[] | select(.name=="aws-ec2" and .installed==false)' >/dev/null \
+  && sku update aws-ec2
+sku aws ec2 price --instance-type m5.large --region us-east-1
+```
+
+This keeps shard fetches (slow, network) out of the hot path and explicit in the agent's trace.
+
+## 6. Profile your caller
+
+Stamp one profile per agent persona:
+
+```bash
+sku configure --profile copilot \
+  --set preset=agent \
+  --set stale_warning_days=14 \
+  --set auto_fetch=false
+```
+
+Then invoke with `--profile copilot` or `SKU_PROFILE=copilot`. Keeps the CLI invocation short and behaviour reproducible.

--- a/docs/guides/llm-routing.md
+++ b/docs/guides/llm-routing.md
@@ -1,0 +1,83 @@
+# LLM routing by price
+
+`sku`'s LLM data is uniform across 70+ serving providers, so you can answer "what is the cheapest way to run model X?" with one command.
+
+## Cheapest serving provider for a model
+
+```bash
+sku llm compare --model anthropic/claude-opus-4.6 --preset compare --pretty
+```
+
+Expected: sorted list of serving providers that carry that model, cheapest first. Aggregated OpenRouter rows are **excluded** by default (see [serving-providers.md](../reference/serving-providers.md)).
+
+Pick just the winner:
+
+```bash
+sku llm compare --model anthropic/claude-opus-4.6 \
+  --jq '[.[] | select(.resource.attributes.aggregated != true)] | sort_by(.price[0].amount)[0]'
+```
+
+## Cheapest model for a budget
+
+```bash
+sku llm list --max-input-price 1.0 --max-output-price 5.0 --preset agent --sort input-price
+```
+
+Prices are USD per **million tokens** for `llm.text`. `--max-input-price 1.0` means ≤ \$1/M input tokens.
+
+## Capability-filtered routing
+
+```bash
+sku llm list --capability tool_use --capability vision \
+  --max-input-price 3.0 --preset agent --sort input-price
+```
+
+Capabilities are enumerated in each model's `resource.capabilities` array.
+
+## Cost for a specific workload
+
+Use `estimate`:
+
+```bash
+sku estimate \
+  --item 'llm:anthropic/claude-opus-4.6:input=1M:output=500K:serving_provider=aws-bedrock' \
+  --pretty
+```
+
+Or from YAML:
+
+```bash
+sku estimate --config docs/examples/workload-llm.yaml --pretty
+```
+
+## Why price alone isn't enough
+
+Three second-order factors, all present in the `llm.text` rows:
+
+| Column | Meaning |
+|---|---|
+| `health.uptime_30d` | Serving provider's availability over the last 30d |
+| `health.latency_p95_ms` | P95 first-token latency (ms) |
+| `resource.context_length` | Hard context window |
+
+Route on a composite that weighs price + uptime + latency:
+
+```bash
+sku llm compare --model anthropic/claude-opus-4.6 \
+  --jq '[.[] | select(.resource.attributes.aggregated != true)]
+        | map(. + {score: (.price[0].amount - .health.uptime_30d*0.01 + .health.latency_p95_ms*0.0001)})
+        | sort_by(.score)[0]'
+```
+
+(Example scoring — tune weights to your SLO.)
+
+## Aggregated OpenRouter row
+
+OpenRouter publishes a synthetic *aggregated* rate across all its endpoints for a given model. To see it:
+
+```bash
+sku openrouter llm price --model anthropic/claude-opus-4.6        # only aggregated rows
+sku --include-aggregated llm compare --model anthropic/claude-opus-4.6
+```
+
+For most routing decisions you want the **concrete** serving providers, not the aggregated row (the aggregated row is not a real endpoint you can call).

--- a/docs/guides/offline-use.md
+++ b/docs/guides/offline-use.md
@@ -1,0 +1,92 @@
+# Offline & airgapped use
+
+The binary is offline-first. The only network call is `sku update`, fetching pricing data from the CDN. Everything else — `price`, `search`, `compare`, `estimate`, `batch` — reads from local SQLite shards.
+
+## Data directory
+
+Default layout:
+
+| OS | `$SKU_DATA_DIR` default |
+|---|---|
+| Linux | `$XDG_DATA_HOME/sku` (typically `~/.local/share/sku`) |
+| macOS | `$HOME/Library/Application Support/sku` |
+| Windows | `%APPDATA%\sku` |
+
+Layout:
+
+```
+$SKU_DATA_DIR/
+  manifest.json         # what's installed, last-updated, head versions
+  openrouter.db
+  aws-ec2.db
+  aws-rds.db
+  ...
+```
+
+## Seeding in an airgap
+
+The shards are ordinary SQLite files. To install them on a host without CDN access:
+
+1. On a connected host:
+
+   ```bash
+   sku update openrouter aws-ec2
+   tar czf sku-bundle.tgz -C "$SKU_DATA_DIR" manifest.json openrouter.db aws-ec2.db
+   ```
+
+2. Transfer `sku-bundle.tgz` to the airgapped host.
+
+3. On the airgapped host:
+
+   ```bash
+   mkdir -p "${SKU_DATA_DIR:-$HOME/.local/share/sku}"
+   tar xzf sku-bundle.tgz -C "${SKU_DATA_DIR:-$HOME/.local/share/sku}"
+   sku update --status --pretty
+   ```
+
+Expected: each shard listed with `installed: true` and the date it was fetched. Subsequent lookups work offline.
+
+## Disabling network entirely
+
+There is no opt-in "go online" flag. The *only* command that makes a network call is `sku update`. If your agent never runs `sku update`, the binary never talks to the network.
+
+For defense-in-depth, block egress to the known CDN hosts:
+
+```
+jsdelivr.net
+gh-release-assets (varies; use allow-list rather than deny)
+```
+
+## `--stale-ok` and `stale_error_days`
+
+By default the binary warns when a shard hasn't been updated in 14 days. Suppress the warning:
+
+```bash
+sku --stale-ok aws ec2 price ...
+SKU_STALE_OK=1 sku aws ec2 price ...
+```
+
+To **fail** (exit code 8) when shards get too stale, set a `stale_error_days` on a profile:
+
+```bash
+sku configure --profile ci \
+  --set stale_warning_days=3 \
+  --set stale_error_days=7
+SKU_PROFILE=ci sku aws ec2 price ...
+```
+
+## Verifying a bundle
+
+Bundle tarballs carry whatever signatures you add outside `sku` — it does not sign data shards itself. The CDN serves shards through jsDelivr; releases of the binary are cosign-signed separately (see [install.md](../install.md)).
+
+## CI patterns
+
+- **Deterministic**: turn off `auto_fetch`; fail fast if a shard is missing.
+
+  ```bash
+  sku configure --profile ci --set auto_fetch=false --set preset=price
+  ```
+
+- **Hermetic**: cache `$SKU_DATA_DIR` in your CI cache key; keyed on `sku version | jq -r '.version'` + a pinned data-release tag so the cache invalidates on either a binary upgrade or a deliberate data bump.
+
+- **Audit**: `sku --verbose <cmd>` emits one JSON log line per operation on stderr (shard read, delta apply, preset applied). Pipe to your log sink.

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,14 +17,52 @@ All channels ship the identical binary built by goreleaser from the tagged
 commit. Checksums are signed with cosign (keyless, GitHub OIDC) and attested
 with SLSA L3 provenance via `actions/attest-build-provenance`.
 
-## Verifying a download
+## Verifying a release
+
+Every release ships a cosign-signed `checksums.txt` plus SLSA L3 build-provenance attestations (spec §7 *Supply chain*).
 
 ```bash
+# 1. Download the binary + signatures
+V=0.1.0
+gh release download "v$V" --pattern 'sku_*_linux_amd64.tar.gz' \
+                          --pattern 'checksums.txt*'
+
+# 2. Verify cosign signature on checksums
 cosign verify-blob \
   --certificate-identity-regexp 'https://github.com/sofq/sku/.*' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --signature checksums.txt.sig \
+  --certificate-oidc-issuer     https://token.actions.githubusercontent.com \
+  --signature   checksums.txt.sig \
   --certificate checksums.txt.pem \
   checksums.txt
-sha256sum -c checksums.txt
+
+# 3. Verify the archive checksum matches the signed file
+sha256sum -c checksums.txt --ignore-missing
+
+# 4. (optional) verify the SLSA provenance attestation
+gh attestation verify "sku_${V}_linux_amd64.tar.gz" --owner sofq
 ```
+
+Expected: each command exits 0; step 2 prints `Verified OK`; step 4 prints a verified-attestations summary.
+
+## Uninstall
+
+| Channel | Command |
+|---|---|
+| Homebrew | `brew uninstall sku && brew untap sofq/tap` |
+| Scoop | `scoop uninstall sku` |
+| npm | `npm rm -g @sofq/sku` |
+| pipx | `pipx uninstall sku-cli` |
+| Docker | `docker rmi ghcr.io/sofq/sku` |
+| Direct | `rm $(which sku)` |
+
+Data directory (safe to delete):
+
+```bash
+rm -rf "${SKU_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/sku}"
+```
+
+## Troubleshooting
+
+- **`sku: command not found`** — ensure the install location is on `PATH`. Homebrew puts it in `$(brew --prefix)/bin`; npm global in `$(npm bin -g)`; pipx in `~/.local/bin`.
+- **`missing shard: openrouter`** — run `sku update openrouter`, or pass `--auto-fetch` to fetch on demand.
+- **`Verified OK` but archive sha mismatch** — the signed `checksums.txt` is the authority; re-download the archive.

--- a/docs/ops/data-daily-runbook.md
+++ b/docs/ops/data-daily-runbook.md
@@ -47,8 +47,8 @@ After this run:
 
 - `gh release view data-$(date -u +%Y.%m.%d)` should list every shard's
   `.db.zst` + `.sha256`, a `manifest.json`, and `state.json`.
-- The `data` branch must exist and contain `data/manifest.json`.
-- `curl https://cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json`
+- The `data` branch must exist and contain `manifest.json` at its root.
+- `curl https://cdn.jsdelivr.net/gh/sofq/sku@data/manifest.json`
   should return the new manifest (may take up to 30s after the purge step).
 
 Only after both runs are green do you enable the cron schedule (next section).
@@ -100,7 +100,7 @@ To clear:
 
 ```bash
 curl --fail --silent --show-error \
-  https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json
+  https://purge.jsdelivr.net/gh/sofq/sku@data/manifest.json
 
 gh issue close <issue-number> --comment "Purge verified; manifest fresh on jsDelivr."
 ```

--- a/docs/ops/data-daily-runbook.md
+++ b/docs/ops/data-daily-runbook.md
@@ -1,0 +1,131 @@
+# Data-daily workflow runbook
+
+Maintainer guide for `.github/workflows/data-daily.yml` — the cron-driven
+daily release that publishes shard baselines, SQL deltas, and `manifest.json`
+under the `data-YYYY.MM.DD` tag.
+
+## Secrets required
+
+| Secret | Purpose | How to create |
+|---|---|---|
+| `GCP_BILLING_API_KEY` | Anonymous GCP Cloud Billing Catalog API key, used by the `gcp_*` shards. | Google Cloud Console → APIs & Services → Credentials → Create API key → restrict to the **Cloud Billing API** → save to repo secrets as `GCP_BILLING_API_KEY`. |
+| `GITHUB_TOKEN` | Auto-injected by Actions; gives the workflow permission to create releases, push the `data` branch, and file incident issues. | No action — GitHub provides this. |
+
+No OIDC / cloud-IAM roles are required by this workflow. AWS pricing, Azure
+retail-prices, and OpenRouter are anonymous; GCP uses the API key above. The
+`data-validate.yml` workflow (m3a.4.3) introduces AWS SigV4 + GCP WIF.
+
+## First green run (bootstrap)
+
+The cron schedule is **commented out** in `data-daily.yml` when it first lands.
+Before enabling it, prove the end-to-end flow with two manual dispatches:
+
+```bash
+# 1. Dry run — discover + ingest + diff-package, but skip publish.
+gh workflow run data-daily.yml \
+  -F dry_run=true \
+  -F force_baseline=true
+
+gh run watch   # wait for completion; confirm all jobs green
+```
+
+Inspect the `release-*` artifacts on the run page: each should contain a
+`<shard>.db.zst` + `<shard>.db.zst.sha256` + `<shard>.meta.json`. Decompress
+one and run `sqlite3 aws-ec2.db '.tables'` — expect `skus`, `prices`,
+`resource_attrs`, `terms`, `health`, `metadata`.
+
+```bash
+# 2. Publish run — creates the first `data-YYYY.MM.DD` release.
+gh workflow run data-daily.yml \
+  -F dry_run=false \
+  -F force_baseline=true
+
+gh run watch
+```
+
+After this run:
+
+- `gh release view data-$(date -u +%Y.%m.%d)` should list every shard's
+  `.db.zst` + `.sha256`, a `manifest.json`, and `state.json`.
+- The `data` branch must exist and contain `data/manifest.json`.
+- `curl https://cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json`
+  should return the new manifest (may take up to 30s after the purge step).
+
+Only after both runs are green do you enable the cron schedule (next section).
+
+## Enabling the cron schedule
+
+Edit `.github/workflows/data-daily.yml` and uncomment the `- cron:` line under
+`on.schedule`:
+
+```yaml
+on:
+  schedule:
+    - cron: "0 3 * * *"
+```
+
+Open a PR titled `ci: enable daily cron for data-daily.yml`, merge after
+review. The first cron fire is at the next 03:00 UTC after merge.
+
+## Disabling on incident
+
+`gh workflow disable data-daily.yml` pauses the cron and blocks further
+manual dispatch. Use when upstream pricing pages are degraded, when the
+sanity check is failing consistently, or when the pipeline needs a pause for
+remediation work.
+
+Re-enable with `gh workflow enable data-daily.yml`. The next run picks up
+whatever has changed since the last green release via the discover state.
+
+## Manually republishing today's catalog
+
+If a scheduled run has already completed but you need to re-publish (e.g. to
+pick up a fixed ingest module):
+
+1. Delete the existing release: `gh release delete data-$(date -u +%Y.%m.%d) --yes --cleanup-tag`
+2. `gh workflow run data-daily.yml -F dry_run=false -F force_baseline=true`
+
+`force_baseline=true` rebuilds every shard baseline, bypassing the discover
+"nothing changed" short-circuit and resetting every client's delta chain
+onto today's baseline.
+
+## Recovering a purge-failed state
+
+When the CDN purge call exhausts its retries, the workflow auto-files an
+issue tagged `cdn-purge-failed` and exits non-zero. The release itself is
+already live — clients on the GitHub URL are unaffected; only jsDelivr
+callers may see a stale manifest for up to 12h.
+
+To clear:
+
+```bash
+curl --fail --silent --show-error \
+  https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json
+
+gh issue close <issue-number> --comment "Purge verified; manifest fresh on jsDelivr."
+```
+
+## Signals that something is wrong
+
+- A `diff-package` matrix leg failing `sanity_check` → typically a sudden
+  row-count cliff. Inspect the ingest job's `<shard>.rows.jsonl` artifact;
+  compare to yesterday's release. Upstream may have renamed/retired a SKU.
+- `discover` job reports every shard errored → upstream site (pricing feed)
+  is probably down. Workflow exits 2; no release published. Re-run once
+  upstream recovers.
+- `publish` job succeeds but no new release shows up → check `gh release
+  list`; the `gh release create` step may have race-conflicted on the tag.
+  Re-run with `force_baseline=true` after deleting any partial release.
+
+## Related files
+
+- `.github/workflows/data-daily.yml` — the workflow itself
+- `.github/actions/setup-pipeline/action.yml` — composite Python setup
+- `scripts/ci/ingest_shard.sh` — per-shard live fetch + ingest
+- `scripts/ci/diff_package_shard.sh` — sanity + delta + optional baseline
+- `scripts/ci/build_manifest.sh` — `manifest.json` assembly
+- `scripts/ci/push_data_branch.sh` — jsDelivr mirror
+- `scripts/ci/purge_jsdelivr.sh` — CDN purge with retry + auto-issue
+- `pipeline/package/build_delta.py` — SQL.gz delta builder
+- `pipeline/package/build_manifest.py` — manifest shape
+- `pipeline/package/sanity_check.py` — drift guard

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,13 @@
+# Reference
+
+Data contracts that automation can depend on.
+
+| Topic | Page |
+|---|---|
+| Kinds (unified schema) | [kinds.md](kinds.md) |
+| Presets (field projections) | [presets.md](presets.md) |
+| Exit codes & error envelope | [exit-codes.md](exit-codes.md) |
+| Global flags | [global-flags.md](global-flags.md) |
+| LLM serving providers | [serving-providers.md](serving-providers.md) |
+
+Every page here is verified against the binary — see `make docs-verify`.

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -1,0 +1,99 @@
+# Exit codes & error envelope
+
+Exit codes are a **contract**. Use them to branch in scripts and agents.
+
+## Codes
+
+| Exit | Code | Meaning |
+|---|---|---|
+| `0` | — | success |
+| `1` | `generic_error` | unclassified; fall back to `error.message` |
+| `2` | `auth` | CI-only: credential failure |
+| `3` | `not_found` | no SKU matches filters |
+| `4` | `validation` | input failed validation (see `reason`) |
+| `5` | `rate_limited` | upstream rate limit (CDN or ingest) |
+| `6` | `conflict` | state conflict (e.g. delta already applied) |
+| `7` | `server` | upstream CDN or pricing API 5xx |
+| `8` | `stale_data` | catalog older than the threshold and `--stale-ok` was not set |
+
+Query the machine-readable catalog any time:
+
+```bash
+sku schema --errors --pretty
+```
+
+## Envelope (stderr)
+
+All errors emit a single-line JSON object on **stderr**; stdout stays empty:
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "No SKU matches filters",
+    "suggestion": "Try `sku schema aws ec2` to see valid filters",
+    "details": {
+      "provider": "aws",
+      "service": "ec2",
+      "applied_filters": {"instance_type": "m5.huge", "region": "us-east-1"},
+      "nearest_matches": ["m5.large", "m5.xlarge"]
+    }
+  }
+}
+```
+
+## Per-code `details` shape
+
+Agents can branch on `error.details` — the shape is stable within a major version.
+
+| `code` | `details` keys |
+|---|---|
+| `not_found` | `provider`, `service`, `applied_filters`, `nearest_matches?` |
+| `validation` | `reason`, `flag?`, `value?`, `allowed?`, `shard?`, `required_binary_version?`, `hint?` |
+| `auth` | `resource` (never credential material) |
+| `rate_limited` | `retry_after_ms` |
+| `conflict` | `shard`, `current_head_version`, `expected_from`, `operation` |
+| `server` | `upstream`, `status_code?`, `correlation_id?` |
+| `stale_data` | `shard`, `last_updated`, `age_days`, `threshold_days` |
+| `generic_error` | free-form; agents should use `error.message` |
+
+`validation.reason` is one of: `flag_invalid`, `binary_too_old`, `binary_too_new`, `shard_too_old`, `shard_too_new`.
+
+## Aggregated exit (sku batch)
+
+`sku batch` rolls individual per-op exits into one process exit code using a severity rank (high to low):
+
+```
+validation > server > conflict > rate_limited > auth > not_found > stale_data > ok
+```
+
+Every individual result is still present in the JSON array on stdout, with its own `exit_code` field.
+
+## Branching example (bash)
+
+```bash
+sku aws ec2 price --instance-type "$T" --region "$R"
+case $? in
+  0) ;;                                   # got it
+  3) echo "no such instance type" ;;      # not_found
+  4) echo "bad flag or shard skew" ;;     # validation
+  8) echo "catalog stale — run sku update" ;;
+  *) echo "other failure" ;;
+esac
+```
+
+## Branching example (Python)
+
+```python
+import json, subprocess
+p = subprocess.run(
+    ["sku", "aws", "ec2", "price", "--instance-type", t, "--region", r],
+    capture_output=True,
+)
+if p.returncode == 0:
+    data = json.loads(p.stdout)
+elif p.returncode == 3:
+    err = json.loads(p.stderr)
+    hints = err["error"]["details"].get("nearest_matches", [])
+    ...
+```

--- a/docs/reference/global-flags.md
+++ b/docs/reference/global-flags.md
@@ -1,0 +1,36 @@
+# Global flags
+
+Every `sku` command accepts these. Precedence (high → low): **CLI flag > env var > profile value > default**.
+
+| Flag | Env var | Default | Meaning |
+|---|---|---|---|
+| `--profile <name>` | `SKU_PROFILE` | `default` | Named profile from `$SKU_CONFIG_DIR/config.yaml` |
+| `--preset {agent,full,price,compare}` | `SKU_PRESET` | `agent` | Field projection (see [presets.md](presets.md)) |
+| `--json` / `--yaml` / `--toml` | `SKU_FORMAT` | `json` | Output format |
+| `--pretty` | – | off | Indent output |
+| `--jq <expr>` | – | – | Apply a gojq filter to the response body |
+| `--fields <paths>` | – | – | Comma-separated dot-path projection (e.g. `provider,price.0.amount`) |
+| `--include-raw` | – | off | Attach the raw upstream row to each record |
+| `--include-aggregated` | – | off | Include OpenRouter's aggregated synthetic rows |
+| `--stale-ok` | `SKU_STALE_OK` | off | Suppress the stale-catalog warning |
+| `--stale-error-days` (via profile) | `SKU_STALE_ERROR_DAYS` | unset | Escalate stale warning to exit code 8 beyond N days |
+| `--auto-fetch` | – | off | Download missing shards on demand |
+| `--dry-run` | `SKU_DRY_RUN` | off | Print resolved query plan, do not execute |
+| `--verbose` | `SKU_VERBOSE` | off | Emit a JSON log line to stderr |
+| `--no-color` | `NO_COLOR`, `SKU_NO_COLOR` | off | Disable ANSI color in `--pretty` output |
+
+## TOML quirk
+
+TOML forbids top-level arrays. `--toml` wraps any top-level `[]` as `{"rows": [...]}`. Agents that dispatch on format should look under `rows` when parsing TOML output.
+
+## Profile resolution
+
+`$SKU_CONFIG_DIR` default:
+
+| OS | Default |
+|---|---|
+| Linux | `$XDG_CONFIG_HOME/sku/config.yaml` |
+| macOS | `$HOME/Library/Application Support/sku/config.yaml` |
+| Windows | `%APPDATA%\sku\config.yaml` |
+
+Managed via [`sku configure`](../commands/configure.md).

--- a/docs/reference/kinds.md
+++ b/docs/reference/kinds.md
@@ -1,0 +1,78 @@
+# Kinds
+
+The *kind* is the unified type assigned to every SKU at ingest. It is what makes cross-provider `compare` and `search --kind` possible. The authoritative taxonomy and per-kind equivalence rules live in `internal/compare/kinds/*.go`; attribute schemas live in `internal/schema/kinds/`.
+
+## Taxonomy
+
+```
+compute.vm        compute.function       compute.container     compute.kubernetes
+compute.batch
+storage.object    storage.block          storage.file          storage.archive
+db.relational     db.nosql               db.inmemory           db.warehouse
+network.cdn       network.dns            network.loadbalancer
+queue.messaging
+security.secrets  security.kms
+observability.logs   observability.metrics
+llm.text          llm.multimodal         llm.embedding
+llm.image         llm.audio
+```
+
+Not every kind has shipped yet. Query the set your binary recognises:
+
+```bash
+sku schema --list-kinds   # planned — binary support lands as a follow-up in v1.0
+```
+
+## Shards currently contributing rows (v0.1 baseline)
+
+| Kind | Shards |
+|---|---|
+| `compute.vm` | `aws-ec2`, `azure-vm`, `gcp-gce` |
+| `compute.function` | `aws-lambda`, `azure-functions`, `gcp-run`, `gcp-functions` |
+| `storage.object` | `aws-s3`, `azure-blob`, `gcp-gcs` |
+| `storage.block` | `aws-ebs`, `azure-disks` |
+| `db.relational` | `aws-rds`, `azure-sql`, `gcp-cloud-sql` |
+| `db.nosql` | `aws-dynamodb` |
+| `network.cdn` | `aws-cloudfront` |
+| `llm.text` | `openrouter` (70+ serving providers) |
+
+## Per-kind shape (what `compare` sees)
+
+### `compute.vm`
+
+| Field | Source |
+|---|---|
+| `resource.vcpu` | int |
+| `resource.memory_gb` | number |
+| `resource.gpu_count` | int (0 when absent) |
+| `resource.gpu_model` | string (`""` when absent) |
+| `resource.attributes.family` | e.g. `m5`, `n1-standard` |
+
+### `storage.object`
+
+| Field | Source |
+|---|---|
+| `resource.storage_class` | `standard`, `hot`, `cool`, `archive`, … |
+| `resource.durability_nines` | int |
+| `resource.availability_tier` | `standard`, `reduced-redundancy`, … |
+
+### `db.relational`
+
+| Field | Source |
+|---|---|
+| `resource.vcpu`, `resource.memory_gb`, `resource.storage_gb` | numeric |
+| `resource.engine` | `postgres`, `mysql`, `mssql`, … |
+| `resource.deployment_option` | `single-az`, `multi-az`, `zonal`, `regional` |
+
+### `llm.text`
+
+| Field | Source |
+|---|---|
+| `resource.name` | `anthropic/claude-opus-4.6` etc. |
+| `resource.context_length` | int (tokens) |
+| `resource.capabilities` | array of strings (`tool_use`, `vision`, `cache`, …) |
+| `health.uptime_30d`, `health.latency_p95_ms` | OpenRouter uptime telemetry |
+
+## Adding a new kind
+
+New kinds are a binary-version bump (requires registration in `internal/compare/kinds/` and `internal/schema/kinds/`). Tracked in spec §4 *Data/code decoupling*.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -1,0 +1,49 @@
+# Presets
+
+A *preset* is a named field projection applied before rendering. Choose a preset with `--preset` or `profiles.<name>.preset` in config.
+
+| Preset | Kept fields | Typical size | Use case |
+|---|---|---|---|
+| `agent` (default) | `provider`, `service`, `resource.name`, `location.provider_region`, `price`, `terms.commitment` | ~200 B | Agent default — minimum tokens |
+| `price` | `price` only | ~50 B | One-shot "how much" lookups |
+| `full` | Everything + raw (implies `--include-raw`) | 2–10 KB | Human inspection, debugging |
+| `compare` | `provider`, `resource.name`, `price`, `location.normalized_region` + kind-specific columns | ~150 B | Cross-provider rows |
+
+## Kind-specific `compare` columns
+
+The `compare` preset merges additional columns depending on `--kind`:
+
+| Kind | Extra columns |
+|---|---|
+| `compute.vm` | `resource.vcpu`, `resource.memory_gb`, `resource.gpu_count`, `resource.gpu_model` |
+| `storage.object` | `resource.durability_nines`, `resource.availability_tier` |
+| `db.relational` | `resource.vcpu`, `resource.memory_gb`, `resource.storage_gb` |
+| `llm.text` | `resource.context_length`, `resource.capabilities`, `health.uptime_30d`, `health.latency_p95_ms` |
+
+## Composition with `--fields` and `--jq`
+
+Presets apply first; `--fields` and `--jq` apply after. This means `--fields` works on the preset's projected keys:
+
+```bash
+# agent preset + just two keys
+sku aws ec2 price --instance-type m5.large --region us-east-1 \
+  --preset agent --fields resource.name,price.0.amount
+
+# price preset + jq to pull a scalar
+sku aws ec2 price --instance-type m5.large --region us-east-1 \
+  --preset price --jq '.price[0].amount'
+```
+
+## Which preset for which caller
+
+| Caller | Recommended preset |
+|---|---|
+| Interactive terminal use | `full --pretty` |
+| Agent picking one SKU | `agent` (default) |
+| Agent doing math on the amount | `price --jq '.price[0].amount'` |
+| Agent comparing rows | `compare --limit N` |
+| CI budget-diff tooling | `full` (for stable hash across minor revs) |
+
+## Adding a preset
+
+Presets are defined in `internal/output/presets.go`. New preset names become part of the stable CLI contract — adding one is a minor version bump; removing one is major.

--- a/docs/reference/serving-providers.md
+++ b/docs/reference/serving-providers.md
@@ -1,0 +1,44 @@
+# LLM serving providers
+
+The `openrouter` shard carries prices for 70+ *serving providers* — the entity that actually serves a model to you, not the model's author. Filter and view semantics are in [`../commands/llm.md`](../commands/llm.md).
+
+## Getting the live list
+
+The shard's `metadata.serving_providers` row is the source of truth. Query it any time:
+
+```bash
+sku update openrouter        # if not installed
+sku schema --list-serving-providers
+```
+
+Returns `{"serving_providers": ["anthropic", "aws-bedrock", "azure-openai", "gcp-vertex", "openai", "openrouter", ...]}`.
+
+## Top-level subcommands vs `--serving-provider`
+
+A handful of serving providers have dedicated top-level subcommands for ergonomics. These are **static**; newly appearing serving providers work via `--serving-provider` immediately, but a dedicated subcommand requires a binary release.
+
+| Subcommand | Valid from | `--serving-provider` equivalent |
+|---|---|---|
+| `sku anthropic llm price` | v0.1.0 | `--serving-provider anthropic` |
+| `sku openai llm price` | v0.1.0 | `--serving-provider openai` |
+| `sku aws-bedrock llm price` | v0.1.0 | `--serving-provider aws-bedrock` |
+| `sku gcp-vertex llm price` | v0.1.0 | `--serving-provider gcp-vertex` |
+| `sku azure-openai llm price` | v0.1.0 | `--serving-provider azure-openai` |
+| `sku openrouter llm price` | v0.1.0 | returns **only** aggregated rows |
+
+## Aggregated-row semantics
+
+OpenRouter publishes a synthetic *aggregated* row per model representing its own routed rate. These rows are excluded by default from `sku llm price`, `sku llm list`, `sku llm compare`, and `sku compare --kind llm.text` so `min(price)` queries are honest.
+
+Include them one of two ways:
+
+```bash
+sku --include-aggregated llm price --model anthropic/claude-opus-4.6
+sku openrouter llm price          --model anthropic/claude-opus-4.6
+```
+
+Aggregated rows carry `resource.attributes.aggregated = true`.
+
+## Validation source
+
+The daily validation harness (spec §6) cross-checks OpenRouter's reported Bedrock / Vertex / Azure-OpenAI rates against the matching cloud pricing APIs at a 1% tolerance. Drift fails the release and auto-files `llm-rate-mismatch: <serving-provider>/<model>`.

--- a/docs/superpowers/plans/2026-04-18-m3a.4.2-data-daily-workflow.md
+++ b/docs/superpowers/plans/2026-04-18-m3a.4.2-data-daily-workflow.md
@@ -1,0 +1,817 @@
+# M3a.4.2 — `data-daily.yml` End-to-End Data Release Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the first real cron-driven data release: a GitHub Actions workflow that discovers changed shards, fetches upstream price data, ingests + packages SQLite shards, computes SQL.gz deltas against the previous release, rebuilds full baselines on the 1st/15th of each month, publishes everything as a `data-YYYY.MM.DD` GitHub release, emits an authoritative `manifest.json` release asset, mirrors the manifest to a lightweight `data` branch for the jsDelivr CDN fallback, and purges the jsDelivr cache with retry + issue-file-on-failure. The workflow runs on `workflow_dispatch` from day one (so we can prove it end-to-end from the Actions UI without waiting for 03:00 UTC) and flips the cron schedule on as the final step after one successful manual run.
+
+**Architecture:**
+
+1. **Composite action** (`.github/actions/setup-pipeline/action.yml`): installs Python 3.11, restores the pip cache keyed on `pipeline/pyproject.toml`, and installs the pipeline package in editable mode. Used by every job in `data-daily.yml` (and re-used by `m3a.4.3`'s validate workflow) to keep the YAML terse.
+2. **`discover` job** (1 runner, ~2 min): fetches the previous run's `state.json` from the most recent `data-*` GitHub release's `discover-state.zst` asset (via `gh release download`), runs `make discover DISCOVER_LIVE=1`, uploads `changed-shards.json` + the new `state.json` as workflow artifacts, and emits `shards` + `baseline_rebuild` as job outputs for downstream matrix fan-out. Exits early with `conclusion: success, shards: []` when nothing changed (quiet day).
+3. **`ingest` job** (matrix over `needs.discover.outputs.shards`, up to 20 parallel runners): per shard — download upstream price data using the matching `fetch_*` helper from m3a.4.1 (into a workflow-cache'd `raw/<shard>/offer.json`), run the existing `pipeline/ingest/<shard>.py` with `--offer` / `--prices` / `--skus`, then run `pipeline/package/build_shard.py` to emit `dist/pipeline/<shard>.db`. Upload `<shard>.db` + `<shard>.rows.jsonl` as artifacts.
+4. **`diff-package` job** (matrix, same shape): download today's `<shard>.db` from the ingest job's artifact, `gh release download data-$PREV_VERSION` for yesterday's `<shard>.db.zst`, decompress, run a DuckDB script (`pipeline/package/build_delta.py`) that uses `ATTACH`-style joins (two SQLite DBs attached) to emit upsert + delete rows into `<shard>-$FROM-to-$TO.sql.gz`. On `baseline_rebuild=true` or day-of-month ∈ {1, 15}, additionally zstd-compress today's `<shard>.db` into `<shard>.db.zst` + `<shard>.db.zst.sha256`. Split any delta larger than 8 MB into sequenced `.sql.gz` parts (`...-part1.sql.gz`, `...-part2.sql.gz`) per spec §3 line 232.
+5. **`publish` job** (1 runner, ~2 min): downloads every artifact, assembles `manifest.json` per spec §3 line 236 shape (one entry per shard, baseline URL + sha256 + deltas list + `head_version` + `row_count`), `gh release create data-YYYY.MM.DD` with every file attached, force-pushes `data` branch containing **only** `manifest.json` for jsDelivr consumption, calls the jsDelivr purge endpoint with 3-retry exponential backoff (2s, 8s, 30s), and files a `cdn-purge-failed` issue on final failure.
+6. **Dry-run mode** (`workflow_dispatch` input `dry_run=true`, default `false`): stops after the `diff-package` job and uploads every artifact to the workflow run instead of creating a release. Used to prove the pipeline runs green before enabling the cron schedule.
+
+**Tech Stack:** GitHub Actions, `actions/setup-python@v5`, `actions/checkout@v4`, `actions/upload-artifact@v4` / `download-artifact@v4`, `actions/cache@v4`, `gh` CLI (pre-installed on runners), Python 3.11, DuckDB (already a pipeline dep), `zstd` (apt), `sqlite3` (apt). No new runtime deps.
+
+**Spec ref:** `docs/superpowers/specs/2026-04-18-sku-design.md` §3 *Update flow (daily)* (entire flow), §3 *Manifest structure* (line 234+ — authoritative output shape), §3 *Reliability* (line 269 — idempotent stages, graceful degradation), §7 *Workflows* (line 1018+ — `data-daily.yml` entry).
+
+**Explicit non-goals for m3a.4.2** (declared up front to prevent scope creep):
+- Validation job (job 4 in spec §3): full cross-check vs upstream re-fetch → `m3a.4.3`. This plan's `diff-package` job runs only a **lightweight sanity check** (row-count within ±5% of 30-day moving average, schema-shape match, FK integrity) — spec §3 line 198 describes it. Full upstream re-fetch comparisons land with `data-validate.yml`.
+- OIDC federation (AWS IAM role / GCP WIF): not needed for the fetchers in this plan — AWS pricing is anonymous, Azure retail-prices is anonymous, GCP uses an API key secret, OpenRouter is anonymous. OIDC is only introduced in `m3a.4.3` where the validation harness needs SigV4-signed `GetProducts` calls.
+- Client-side `internal/updater` changes: delta-chain walking + ETag caching + stable/daily channel split → `m3a.4.3`. This plan ships the *server-side* half of those features (emitting the manifest + deltas); the client keeps the one-shot baseline flow m3a.3 extracted into `internal/updater.Install`.
+- Code-signing / provenance attestation (`actions/attest-build-provenance`, cosign on shards): deferred to `m7.3-security-bench-release`'s security.yml. The data-release chain currently relies on HTTPS + sha256 manifest entries.
+- Docker multi-arch images, Homebrew taps, Scoop buckets, nfpms: all live in `release.yml` for code releases — data releases only publish to GH Releases + the `data` branch.
+- `data-baseline.yml` as a separate workflow file: folded into `data-daily.yml`'s day-of-month branch per spec §3 line 183 (simpler; matches the update-flow diagram over the §7 list).
+
+**Shards covered:** same 17-shard surface as m3a.4.1 (`openrouter` + 7 AWS + 5 Azure + 5 GCP). No new shards; this is workflow plumbing.
+
+---
+
+## File Structure
+
+| Path | Responsibility |
+|---|---|
+| `.github/actions/setup-pipeline/action.yml` | **Create**: composite action — checkout, setup-python, pip cache, `pip install -e pipeline[dev]`. |
+| `.github/workflows/data-daily.yml` | **Create**: the five-job workflow (discover → ingest → diff-package → publish), cron + workflow_dispatch triggers, dry-run input. |
+| `pipeline/package/build_delta.py` | **Create**: DuckDB script that attaches two SQLite shards (prev + new), emits upsert + delete rows into a `.sql.gz` delta. Splits deltas >8 MB into part files. |
+| `pipeline/package/build_manifest.py` | **Create**: assembles `manifest.json` per spec §3 shape from the set of built artifacts. |
+| `pipeline/package/sanity_check.py` | **Create**: ±5% row-count guard vs prior release, schema-shape match, FK integrity check. Called from the `diff-package` job per shard. |
+| `pipeline/tests/test_build_delta.py` | **Create**: two synthetic SQLite shards → diff → apply delta → verify result equals target (round-trip). |
+| `pipeline/tests/test_build_manifest.py` | **Create**: fixture artifact tree → manifest with expected keys, correct shas, correct delta chain order. |
+| `pipeline/tests/test_sanity_check.py` | **Create**: row-count drift, schema change, FK orphan — all three failure modes + happy path. |
+| `scripts/ci/purge_jsdelivr.sh` | **Create**: curl-based purge call with 3-retry exponential backoff + GH issue file on failure. |
+| `scripts/ci/previous_release_version.sh` | **Create**: `gh release list --limit 1 --json tagName --jq '.[0].tagName'` → `2026.04.17` (strips `data-` prefix). |
+| `.github/ISSUE_TEMPLATE/cdn-purge-failed.md` | **Create**: issue template used when jsDelivr purge retries are exhausted. |
+| `docs/ops/data-daily-runbook.md` | **Create**: maintainer runbook — required secrets, how to kick a dry-run, how to disable cron, how to manually re-publish. |
+| `CLAUDE.md` | **Modify**: bump milestone pointer to M3a.4.2, add `gh workflow run data-daily.yml` entrypoint. |
+
+---
+
+## Preflight
+
+- [ ] **Step 1: Fresh branch from green main.**
+
+```bash
+git pull --ff-only origin main
+git checkout -b m3a.4.2-data-daily-workflow
+```
+
+- [ ] **Step 2: Confirm m3a.4.1 has landed.**
+
+```bash
+test -d pipeline/discover || (echo "m3a.4.1 not merged — abort" && exit 2)
+grep -q "^  pipeline:" .github/workflows/ci.yml || (echo "m3a.4.1 CI job missing — abort" && exit 2)
+```
+
+- [ ] **Step 3: Repository secrets inventory.**
+
+Confirm these secrets exist on the repo (via `gh secret list`):
+- `GCP_BILLING_API_KEY` — read-only API key restricted to `cloudbilling.googleapis.com`. If missing, follow the runbook (Task 10) to create it now; GCP shards will error out otherwise.
+- `GITHUB_TOKEN` — auto-injected by Actions; no action needed.
+
+No OIDC secrets are required by this plan (m3a.4.3 adds them).
+
+---
+
+## Task 1: Composite setup-pipeline action
+
+**Files:**
+- Create: `.github/actions/setup-pipeline/action.yml`
+
+- [ ] **Step 1: Write the action.**
+
+```yaml
+name: "setup-pipeline"
+description: "Install Python 3.11 and the sku-pipeline package"
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: pip
+        cache-dependency-path: pipeline/pyproject.toml
+    - name: Install pipeline package
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e 'pipeline[dev]'
+    - name: Install OS tooling (duckdb cli, zstd, jq)
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends zstd jq
+```
+
+DuckDB's CLI is not needed — the pipeline uses the Python package. `sqlite3` is pre-installed on ubuntu-latest. `gh` is pre-installed.
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add .github/actions/setup-pipeline/action.yml
+git commit -m "ci: composite action for pipeline Python setup"
+```
+
+---
+
+## Task 2: `pipeline/package/build_delta.py`
+
+**Files:**
+- Create: `pipeline/package/build_delta.py`
+- Create: `pipeline/tests/test_build_delta.py`
+
+**Contract:**
+
+```python
+# pipeline/package/build_delta.py
+
+def build_delta(prev_db: Path, new_db: Path, out_sql_gz: Path, *, max_bytes: int = 8 * 1024 * 1024) -> list[Path]:
+    """Emit a gzipped SQL delta that transforms `prev_db` into `new_db`.
+
+    Produces `UPDATE/INSERT/DELETE` statements over the `skus` and `prices`
+    tables (§5 schema). Uses DuckDB with two SQLite shards attached:
+
+        INSTALL sqlite; LOAD sqlite;
+        ATTACH '<prev>' AS prev (TYPE SQLITE);
+        ATTACH '<new>'  AS curr (TYPE SQLITE);
+
+    For each of `skus`, `prices`:
+      - Rows in curr not in prev  → `INSERT OR REPLACE INTO ...`
+      - Rows in prev not in curr  → `DELETE FROM ... WHERE sku_id = ...`
+      - Rows whose hash differs   → `INSERT OR REPLACE INTO ...`
+    `metadata` table is replayed in full (small, changes every release).
+
+    Returns the list of part files written. If the gzipped size exceeds
+    `max_bytes`, splits by row into `<out>-part1.sql.gz`, `<out>-part2.sql.gz`
+    etc., each ≤ `max_bytes`, in apply-order.
+    """
+```
+
+- [ ] **Step 1: Unit tests (TDD).**
+
+`pipeline/tests/test_build_delta.py`:
+- Build two synthetic SQLite shards via `sqlite3` — same schema, 10 rows vs 12 rows (2 inserted, 1 updated, 0 deleted). Run `build_delta`; apply the resulting `.sql.gz` to a copy of `prev_db` via `sqlite3 prev.db < decompressed.sql`; assert final bytes match `new_db` (excluding `metadata` table, per spec §6 line 951).
+- Delete case: 10 rows → 7 rows → delta contains 3 DELETE statements, no INSERT/UPDATE.
+- Split case: force `max_bytes=256`; 20-row diff → expect ≥2 part files, each ≤ ~256 bytes decompressed; applying them in order reconstructs `new_db`.
+- Empty diff (prev == curr) → single 0-row `.sql.gz` containing only the metadata replay + a header comment `-- noop`; downstream manifest still lists it.
+
+- [ ] **Step 2: Implement `build_delta`.**
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add pipeline/package/build_delta.py pipeline/tests/test_build_delta.py
+git commit -m "feat(pipeline): build_delta emits SQL.gz deltas between shards"
+```
+
+---
+
+## Task 3: `pipeline/package/build_manifest.py`
+
+**Files:**
+- Create: `pipeline/package/build_manifest.py`
+- Create: `pipeline/tests/test_build_manifest.py`
+
+**Contract:**
+
+```python
+def build_manifest(
+    *,
+    artifacts_dir: Path,   # dist/pipeline/release/
+    out: Path,             # dist/pipeline/release/manifest.json
+    catalog_version: str,  # "2026.04.18"
+    release_base_url: str, # "https://github.com/sofq/sku/releases/download/data-2026.04.18"
+    previous_manifest: Path | None,   # from previous release; used for baseline_version + deltas carry-forward
+    min_binary_version: str,
+    shard_schema_version: int = 1,
+) -> None:
+    """Assemble manifest.json per spec §3 structure:
+
+        {
+          "schema_version": 1,
+          "generated_at": "...",
+          "catalog_version": "2026.04.18",
+          "shards": {
+            "aws-ec2": {
+              "baseline_version": ...,
+              "baseline_url": ...,
+              "baseline_sha256": ...,
+              "baseline_size": ...,
+              "head_version": ...,
+              "min_binary_version": ...,
+              "shard_schema_version": 1,
+              "deltas": [{"from": ..., "to": ..., "url": ..., "sha256": ..., "size": ...}],
+              "row_count": ...,
+              "last_updated": "..."
+            }
+          }
+        }
+    """
+```
+
+The function walks `artifacts_dir` (built by `diff-package` matrix), computes sha256 + size for every `.db.zst` + `.sql.gz`, carries `deltas[]` forward from `previous_manifest` (new deltas appended, stale ones trimmed when a baseline is rebuilt).
+
+- [ ] **Step 1: Unit tests (TDD).**
+  - Fresh first release (no previous manifest): every shard has `baseline_url` + empty `deltas` + `head_version == baseline_version == catalog_version`.
+  - Normal day (yesterday's manifest + today's delta per shard): `baseline_version` preserved; `deltas` extended by 1; `head_version` == today's catalog_version.
+  - Baseline-rebuild day: `baseline_url` replaced; `deltas: []`; `baseline_version == head_version`.
+  - SHA256 + size entries match the bytes on disk.
+  - `shards` dict is sorted alphabetically (reviewer-friendly diffs).
+
+- [ ] **Step 2: Implement.**
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add pipeline/package/build_manifest.py pipeline/tests/test_build_manifest.py
+git commit -m "feat(pipeline): build_manifest per spec §3 structure"
+```
+
+---
+
+## Task 4: `pipeline/package/sanity_check.py`
+
+**Files:**
+- Create: `pipeline/package/sanity_check.py`
+- Create: `pipeline/tests/test_sanity_check.py`
+
+**Contract:**
+
+```python
+def sanity_check(
+    *,
+    shard_db: Path,
+    previous_db: Path | None,
+    tolerance_pct: float = 5.0,
+) -> None:
+    """Spec §3 line 198 lightweight sanity check. Raises SanityError on:
+      - Row count delta > tolerance_pct vs previous.
+      - Schema mismatch (CREATE TABLE DDL differs).
+      - FK orphan (any skus.sku_id referenced by prices missing).
+      - metadata.generated_at not populated.
+    Noop on first release (previous_db is None).
+    """
+```
+
+- [ ] **Step 1: Unit tests (TDD):** happy path, row-count spike, schema drift, FK orphan. Confirm exceptions carry the shard name for downstream issue-filing.
+
+- [ ] **Step 2: Implement.**
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add pipeline/package/sanity_check.py pipeline/tests/test_sanity_check.py
+git commit -m "feat(pipeline): sanity_check — daily drift guard per spec §3"
+```
+
+---
+
+## Task 5: `scripts/ci/*` helpers
+
+**Files:**
+- Create: `scripts/ci/purge_jsdelivr.sh`
+- Create: `scripts/ci/previous_release_version.sh`
+
+- [ ] **Step 1: Write `previous_release_version.sh`.**
+
+```bash
+#!/usr/bin/env bash
+# Print the catalog_version of the most recent data release (stripping the `data-` prefix).
+# Exit 0 with empty output when no prior release exists (first-ever run).
+set -euo pipefail
+tag=$(gh release list --limit 50 --json tagName,name --jq '[.[] | select(.tagName | startswith("data-"))] | .[0].tagName // ""')
+echo "${tag#data-}"
+```
+
+- [ ] **Step 2: Write `purge_jsdelivr.sh`.**
+
+```bash
+#!/usr/bin/env bash
+# Purge jsDelivr edges for /gh/sofq/sku@latest/data/manifest.json.
+# 3 retries with exponential backoff (2s, 8s, 30s). On final failure, file
+# an issue via gh (template: .github/ISSUE_TEMPLATE/cdn-purge-failed.md).
+set -euo pipefail
+URL="https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json"
+for attempt in 1 2 3; do
+  if curl --fail --silent --show-error "$URL"; then
+    echo "jsdelivr purge OK on attempt $attempt"
+    exit 0
+  fi
+  case $attempt in 1) sleep 2;; 2) sleep 8;; 3) sleep 30;; esac
+done
+echo "jsdelivr purge FAILED after 3 attempts" >&2
+gh issue create \
+  --title "jsDelivr cache purge failed for catalog $(date -u +%Y-%m-%d)" \
+  --label "pipeline,cdn-purge-failed" \
+  --body "Automated issue — the daily manifest push succeeded but the jsDelivr purge API did not acknowledge after 3 retries. Users on the CDN fallback may see stale manifest for up to 12h. Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+exit 1
+```
+
+- [ ] **Step 3: Make executable + commit.**
+
+```bash
+chmod +x scripts/ci/*.sh
+git add scripts/ci/*.sh
+git commit -m "ci: jsdelivr purge + previous-release helpers"
+```
+
+---
+
+## Task 6: Issue template for CDN failures
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/cdn-purge-failed.md`
+
+- [ ] **Step 1: Write the template.**
+
+```markdown
+---
+name: CDN purge failed (automated)
+about: jsDelivr cache purge failed after 3 retries
+title: "jsDelivr cache purge failed for catalog <YYYY-MM-DD>"
+labels: ["pipeline", "cdn-purge-failed"]
+---
+
+The daily data release succeeded but the jsDelivr purge API did not acknowledge after 3 retries with exponential backoff (2s, 8s, 30s).
+
+**Impact:** Users pinned to `cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` may see stale manifest for up to 12h. The release-asset URL (`github.com/sofq/sku/releases/latest/download/manifest.json`) is unaffected.
+
+**Action:** run `scripts/ci/purge_jsdelivr.sh` manually from a maintainer machine with `gh` authenticated, or `curl` the purge endpoint directly. Close this issue once verified.
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add .github/ISSUE_TEMPLATE/cdn-purge-failed.md
+git commit -m "ci: issue template for cdn-purge-failed"
+```
+
+---
+
+## Task 7: `data-daily.yml` — discover + ingest jobs
+
+**Files:**
+- Create: `.github/workflows/data-daily.yml`
+
+- [ ] **Step 1: Write the skeleton (header + discover + ingest only, diff-package/publish come in Task 8).**
+
+```yaml
+name: data-daily
+
+on:
+  schedule:
+    # DISABLED until one workflow_dispatch run proves the pipeline green.
+    # Re-enable by uncommenting in Task 12 of this plan.
+    # - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Stop before publish step; artifacts only"
+        required: false
+        default: "false"
+      force_baseline:
+        description: "Force baseline rebuild regardless of day-of-month"
+        required: false
+        default: "false"
+
+permissions:
+  contents: write        # gh release create + data branch push
+  issues:   write        # cdn-purge-failed issue filing
+  actions:  read
+
+concurrency:
+  group: data-daily
+  cancel-in-progress: false    # never cancel a release mid-publish
+
+env:
+  CATALOG_VERSION: ""          # set in discover job
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      shards:            ${{ steps.discover.outputs.shards }}
+      baseline_rebuild:  ${{ steps.discover.outputs.baseline_rebuild }}
+      catalog_version:   ${{ steps.discover.outputs.catalog_version }}
+      previous_version:  ${{ steps.previous.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+      - name: Resolve previous release version
+        id: previous
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(scripts/ci/previous_release_version.sh)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Restore prior discover state
+        if: steps.previous.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist/pipeline/discover
+          gh release download "data-${{ steps.previous.outputs.version }}" \
+            --pattern 'discover-state.json' \
+            --dir dist/pipeline/discover || true
+          ls -la dist/pipeline/discover/
+      - name: Discover changed shards
+        id: discover
+        env:
+          GCP_BILLING_API_KEY: ${{ secrets.GCP_BILLING_API_KEY }}
+          BASELINE_REBUILD: ${{ github.event.inputs.force_baseline || '' }}
+          DAY_OF_MONTH: ${{ steps.date.outputs.day }}
+        run: |
+          today=$(date -u +%Y.%m.%d)
+          # baseline on 1st/15th or when no prior state exists or when user forced it
+          bl="false"
+          if [ "$BASELINE_REBUILD" = "true" ]; then bl="true"; fi
+          dom=$(date -u +%d)
+          if [ "$dom" = "01" ] || [ "$dom" = "15" ]; then bl="true"; fi
+          if [ ! -f dist/pipeline/discover/state.json ]; then bl="true"; fi
+          flag=""
+          if [ "$bl" = "true" ]; then flag="--baseline-rebuild"; fi
+
+          python -m pipeline.discover \
+            --state dist/pipeline/discover/state.json \
+            --out   dist/pipeline/discover/changed.json \
+            --live  $flag
+
+          shards=$(jq -c '.shards' dist/pipeline/discover/changed.json)
+          brl=$(jq -r '.baseline_rebuild' dist/pipeline/discover/changed.json)
+          echo "shards=$shards"           >> "$GITHUB_OUTPUT"
+          echo "baseline_rebuild=$brl"    >> "$GITHUB_OUTPUT"
+          echo "catalog_version=$today"   >> "$GITHUB_OUTPUT"
+      - name: Upload discover artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: discover
+          path: dist/pipeline/discover/
+          retention-days: 14
+
+  ingest:
+    needs: discover
+    if: fromJSON(needs.discover.outputs.shards) != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.discover.outputs.shards) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+      - name: Fetch upstream + ingest + package
+        env:
+          GCP_BILLING_API_KEY: ${{ secrets.GCP_BILLING_API_KEY }}
+          SHARD:             ${{ matrix.shard }}
+          CATALOG_VERSION:   ${{ needs.discover.outputs.catalog_version }}
+          SOURCE_DATE_EPOCH: ${{ github.event.repository.pushed_at }}   # or run-start timestamp
+        run: |
+          bash scripts/ci/ingest_shard.sh "$SHARD" "$CATALOG_VERSION"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: shard-${{ matrix.shard }}
+          path: |
+            dist/pipeline/${{ matrix.shard }}.db
+            dist/pipeline/${{ matrix.shard }}.rows.jsonl
+          retention-days: 14
+```
+
+`scripts/ci/ingest_shard.sh` is a new shim (Task 9) that wraps the provider-specific fetch + existing `make shard-live` target.
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add .github/workflows/data-daily.yml
+git commit -m "ci: data-daily.yml discover + ingest jobs"
+```
+
+---
+
+## Task 8: `data-daily.yml` — diff-package + publish jobs
+
+**Files:**
+- Modify: `.github/workflows/data-daily.yml`
+
+- [ ] **Step 1: Append the `diff_package` job.**
+
+```yaml
+  diff_package:
+    needs: [discover, ingest]
+    if: fromJSON(needs.discover.outputs.shards) != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.discover.outputs.shards) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+      - name: Download today's shard
+        uses: actions/download-artifact@v4
+        with:
+          name: shard-${{ matrix.shard }}
+          path: dist/pipeline/today/
+      - name: Download previous shard baseline
+        if: needs.discover.outputs.previous_version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist/pipeline/prev
+          gh release download "data-${{ needs.discover.outputs.previous_version }}" \
+            --pattern "${{ matrix.shard }}.db.zst" \
+            --dir dist/pipeline/prev/ || echo "no previous shard — baseline rebuild"
+          if [ -f "dist/pipeline/prev/${{ matrix.shard }}.db.zst" ]; then
+            zstd -d "dist/pipeline/prev/${{ matrix.shard }}.db.zst"
+          fi
+      - name: Sanity check + build delta + optional baseline
+        env:
+          SHARD:            ${{ matrix.shard }}
+          CATALOG_VERSION:  ${{ needs.discover.outputs.catalog_version }}
+          PREVIOUS_VERSION: ${{ needs.discover.outputs.previous_version }}
+          BASELINE_REBUILD: ${{ needs.discover.outputs.baseline_rebuild }}
+        run: bash scripts/ci/diff_package_shard.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.shard }}
+          path: dist/pipeline/release/
+          retention-days: 14
+```
+
+- [ ] **Step 2: Append the `publish` job.**
+
+```yaml
+  publish:
+    needs: [discover, diff_package]
+    if: github.event.inputs.dry_run != 'true' && fromJSON(needs.discover.outputs.shards) != '[]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist/pipeline/release/
+      - uses: actions/download-artifact@v4
+        with:
+          name: discover
+          path: dist/pipeline/discover/
+      - name: Build manifest.json
+        env:
+          CATALOG_VERSION:  ${{ needs.discover.outputs.catalog_version }}
+          PREVIOUS_VERSION: ${{ needs.discover.outputs.previous_version }}
+          MIN_BINARY:       "1.0.0"
+          GH_TOKEN:         ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/build_manifest.sh
+      - name: Create release
+        env:
+          CATALOG_VERSION: ${{ needs.discover.outputs.catalog_version }}
+          GH_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "data-${CATALOG_VERSION}" \
+            --title "Data release ${CATALOG_VERSION}" \
+            --notes "Automated daily data release. See manifest.json for shard inventory." \
+            dist/pipeline/release/*
+          gh release upload "data-${CATALOG_VERSION}" \
+            dist/pipeline/discover/state.json \
+            --clobber
+      - name: Mirror manifest to data branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/push_data_branch.sh
+      - name: Purge jsDelivr cache
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/purge_jsdelivr.sh
+```
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add .github/workflows/data-daily.yml
+git commit -m "ci: data-daily.yml diff-package + publish jobs"
+```
+
+---
+
+## Task 9: Per-job shell shims
+
+**Files:**
+- Create: `scripts/ci/ingest_shard.sh`
+- Create: `scripts/ci/diff_package_shard.sh`
+- Create: `scripts/ci/build_manifest.sh`
+- Create: `scripts/ci/push_data_branch.sh`
+
+All are ~40-line bash scripts; keeping them out of the YAML improves readability and lets them be unit-testable from `make`.
+
+- [ ] **Step 1: `ingest_shard.sh`** — maps `SHARD=aws_ec2` → `--offer`, `SHARD=azure_vm` → `--prices`, etc.; calls the matching `fetch_*` helper via a tiny Python one-liner; then `make shard-live SHARD=$SHARD SRC=<fetched-path>`. Reads `CATALOG_VERSION` into `--catalog-version`.
+
+- [ ] **Step 2: `diff_package_shard.sh`** — runs `python -m pipeline.package.sanity_check`; runs `python -m pipeline.package.build_delta` if previous exists; on baseline rebuild (or no previous) `zstd -19 --long=27 today/$SHARD.db -o release/$SHARD.db.zst && sha256sum release/$SHARD.db.zst > release/$SHARD.db.zst.sha256`.
+
+- [ ] **Step 3: `build_manifest.sh`** — fetches previous manifest via `gh release download data-$PREVIOUS_VERSION --pattern manifest.json`; runs `python -m pipeline.package.build_manifest` with all required flags; puts `manifest.json` alongside the shards.
+
+- [ ] **Step 4: `push_data_branch.sh`** — creates an orphan checkout of `data` branch (or initialises it on first ever push), replaces `manifest.json`, force-pushes. Key details:
+
+```bash
+set -euo pipefail
+DATA_BRANCH=data
+MANIFEST_SRC=dist/pipeline/release/manifest.json
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+git init -q
+git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git checkout -q --orphan "$DATA_BRANCH"
+git rm -rfq . 2>/dev/null || true
+mkdir -p data
+cp "$GITHUB_WORKSPACE/$MANIFEST_SRC" data/manifest.json
+git add data/manifest.json
+git -c user.email=bot@sku -c user.name=sku-data-bot commit -q -m "data-${CATALOG_VERSION}"
+git push -qf origin "$DATA_BRANCH"
+```
+
+- [ ] **Step 5: Make executable + commit.**
+
+```bash
+chmod +x scripts/ci/*.sh
+git add scripts/ci/*.sh
+git commit -m "ci: per-job shell shims for data-daily"
+```
+
+---
+
+## Task 10: `docs/ops/data-daily-runbook.md`
+
+**Files:**
+- Create: `docs/ops/data-daily-runbook.md`
+
+- [ ] **Step 1: Write the runbook covering:**
+
+1. **Secrets required:** `GCP_BILLING_API_KEY` — how to create it (Google Cloud Console → APIs & Services → Credentials → Create API key → restrict to Cloud Billing API → add to repo secrets as `GCP_BILLING_API_KEY`).
+2. **First green run:** dispatch via `gh workflow run data-daily.yml -F dry_run=true` to build artifacts without publishing; verify the artifacts on the Actions run page; re-dispatch with `dry_run=false` to actually publish.
+3. **Enabling cron:** uncomment the `- cron: "0 3 * * *"` line in `data-daily.yml` (Task 12 of this plan). The first cron fire will tail-end after the manual green run.
+4. **Disabling on incident:** `gh workflow disable data-daily.yml`. Cron pauses; publish chain stops.
+5. **Manual republish of a specific day:** dispatch with `force_baseline=true` (rebuilds everything as a baseline and publishes a fresh release tagged today).
+6. **Recovering a purge-failed state:** resolve the auto-filed `cdn-purge-failed` issue by running `curl https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` from any maintainer box.
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add docs/ops/data-daily-runbook.md
+git commit -m "docs: data-daily runbook (secrets, first run, incident recovery)"
+```
+
+---
+
+## Task 11: Dry-run from a draft PR
+
+**Files:** none
+
+- [ ] **Step 1: Push the branch, open a draft PR.**
+
+```bash
+git push -u origin m3a.4.2-data-daily-workflow
+gh pr create --draft \
+  --title "M3a.4.2 (draft): data-daily.yml end-to-end" \
+  --body "Draft — verifying workflow via dispatch before enabling cron."
+```
+
+- [ ] **Step 2: Dispatch a dry run from the PR branch.**
+
+```bash
+gh workflow run data-daily.yml --ref "$(git rev-parse --abbrev-ref HEAD)" \
+  -F dry_run=true -F force_baseline=true
+gh run watch
+```
+
+Expected: discover + ingest (17 parallel) + diff-package (17 parallel) all green; publish job skipped. Artifact `release-*` contains 17 `.db.zst` + 17 `.sha256` + (where applicable) 17 `.sql.gz` files.
+
+- [ ] **Step 3: Inspect artifacts for sanity.**
+
+Download the `release-aws-ec2` artifact; verify `.db.zst` decompresses to a valid SQLite shard; `sqlite3 aws-ec2.db '.tables'` should show `skus`, `prices`, `metadata`; row counts are non-zero and within an order of magnitude of what `make aws-ec2-shard` produces from fixtures (the live shard is much larger).
+
+- [ ] **Step 4: Dispatch a publish run (non-dry).**
+
+```bash
+gh workflow run data-daily.yml --ref "$(git rev-parse --abbrev-ref HEAD)" \
+  -F dry_run=false -F force_baseline=true
+gh run watch
+```
+
+Expected: publish job green; a new `data-YYYY.MM.DD` release exists; the `data` branch has `data/manifest.json`; `curl https://cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` returns the new file within ~30s of the purge step.
+
+- [ ] **Step 5: If anything failed, diagnose and iterate before proceeding. Do NOT enable cron until Steps 3 and 4 are green.**
+
+---
+
+## Task 12: Enable cron schedule
+
+**Files:**
+- Modify: `.github/workflows/data-daily.yml`
+
+- [ ] **Step 1: Uncomment the cron line** after Task 11 is fully green.
+
+```yaml
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    ...
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add .github/workflows/data-daily.yml
+git commit -m "ci: enable daily cron for data-daily.yml"
+```
+
+---
+
+## Task 13: CLAUDE.md + milestone pointer
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update "Current milestone" + add runbook link.**
+
+```markdown
+## Current milestone
+
+M3a.4.2 — `data-daily.yml` cron workflow publishes daily data releases:
+- Discover → Ingest (matrix) → Diff+Package (matrix) → Publish.
+- Emits `data-YYYY.MM.DD` GitHub release with shard .db.zst + .sql.gz deltas +
+  manifest.json.
+- Mirrors manifest to `data` branch for jsDelivr fallback; purges CDN on
+  each publish.
+- Dry-runs via `gh workflow run data-daily.yml -F dry_run=true`.
+- Runbook: `docs/ops/data-daily-runbook.md`.
+
+Next: M3a.4.3 — `data-validate.yml` (OIDC cross-check vs upstream) +
+client-side `internal/updater` delta-chain walking + ETag + channels.
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: bump CLAUDE.md to m3a.4.2"
+```
+
+---
+
+## Task 14: Exit verification + PR
+
+**Files:** none
+
+- [ ] **Step 1: Confirm cron-enabled PR is still green.**
+
+```bash
+gh pr checks --watch
+```
+
+- [ ] **Step 2: Mark ready for review, write release-style PR body.**
+
+```bash
+gh pr ready
+gh pr edit --title "M3a.4.2: data-daily.yml end-to-end data release workflow" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- `data-daily.yml` cron workflow (03:00 UTC + `workflow_dispatch`) now publishes a `data-YYYY.MM.DD` GitHub release every day: discover → ingest (matrix over changed shards) → diff+package → publish manifest + shards + deltas.
+- New Python modules: `pipeline/package/build_delta.py` (DuckDB SQL.gz diff), `pipeline/package/build_manifest.py` (spec §3 manifest shape), `pipeline/package/sanity_check.py` (row-count + schema + FK drift guard).
+- `data` branch carries `manifest.json` only; jsDelivr fallback mirrored on every publish, with retry + auto-issue on purge failure.
+- Composite action `.github/actions/setup-pipeline` removes Python-setup duplication.
+- Runbook: `docs/ops/data-daily-runbook.md`.
+
+This was verified end-to-end on this branch before merge: one `dry_run=true` dispatch produced artifacts, then a `dry_run=false` dispatch produced release `data-YYYY.MM.DD` (see PR checks for the workflow-run links).
+
+## Test plan
+
+- [x] All Python unit tests green (`make pipeline-test`).
+- [x] `workflow_dispatch` with `dry_run=true` produces all release artifacts.
+- [x] `workflow_dispatch` with `dry_run=false` publishes a real release.
+- [x] `data` branch updated; `cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` returns the new file after purge.
+- [x] Cron schedule enabled (final commit on branch).
+
+## Non-goals
+
+- OIDC-based validation cross-check (→ m3a.4.3).
+- Client `internal/updater` delta-chain walking (→ m3a.4.3).
+EOF
+)"
+```
+
+- [ ] **Step 3: Merge.**
+
+---
+
+## Post-merge next step
+
+Hand off to `m3a.4.3`:
+
+```bash
+claude -p "$(cat docs/superpowers/plans/2026-04-18-m3a.4.3-validate-and-updater.md)"
+```

--- a/docs/superpowers/plans/2026-04-18-m6-distribution-channels.md
+++ b/docs/superpowers/plans/2026-04-18-m6-distribution-channels.md
@@ -40,9 +40,10 @@
 ### Task 1: Expand goreleaser — checksum signing, SBOM, nfpms
 
 **Files:**
+
 - Modify: `.goreleaser.yml`
 
-- [x] **Step 1: Add signs, sboms, nfpms blocks**
+- [X] **Step 1: Add signs, sboms, nfpms blocks**
 
 Append to `.goreleaser.yml` (after the existing `checksum:` block, before `snapshot:`):
 
@@ -79,17 +80,17 @@ nfpms:
     bindir: /usr/bin
 ```
 
-- [x] **Step 2: Run snapshot to verify config parses**
+- [X] **Step 2: Run snapshot to verify config parses**
 
 Run: `goreleaser release --snapshot --clean --skip=sign,publish,docker,sbom`
 Expected: Exit 0. `dist/` contains platform archives + `checksums.txt`. The `--skip=sign,sbom` keeps local dry-run fast (cosign/syft not required locally).
 
-- [x] **Step 3: Run syft locally to verify SBOM generation works** *(syft not installed locally; plan allows skip — SBOM generation happens in CI via anchore/sbom-action)*
+- [X] **Step 3: Run syft locally to verify SBOM generation works** *(syft not installed locally; plan allows skip — SBOM generation happens in CI via anchore/sbom-action)*
 
 Run: `syft --version || echo "install syft via brew install syft"` then `goreleaser release --snapshot --clean --skip=sign,publish,docker`
 Expected: Exit 0. `dist/*.spdx.sbom.json` present for each archive.
 
-- [x] **Step 4: Commit**
+- [X] **Step 4: Commit**
 
 ```bash
 git add .goreleaser.yml
@@ -101,9 +102,10 @@ git commit -m "feat(m6): goreleaser — add cosign checksum signing, syft SBOMs,
 ### Task 2: Expand goreleaser — Homebrew tap and Scoop bucket
 
 **Files:**
+
 - Modify: `.goreleaser.yml`
 
-- [x] **Step 1: Add brews + scoops blocks**
+- [X] **Step 1: Add brews + scoops blocks**
 
 Append to `.goreleaser.yml` (after `nfpms:`):
 
@@ -135,17 +137,17 @@ scoops:
 
 Note: `skip_upload: auto` causes goreleaser to skip brew/scoop on any tag matching `*-rc.*` / `*-pre*`, matching spec §7 "Versioning policy" ("Pre-releases skip brew/npm/pypi").
 
-- [x] **Step 2: Snapshot build to confirm config parses**
+- [X] **Step 2: Snapshot build to confirm config parses**
 
 Run: `goreleaser release --snapshot --clean --skip=sign,publish,docker,sbom`
 Expected: Exit 0. `dist/sku.rb` (brew formula) and `dist/sku.json` (scoop manifest) present.
 
-- [x] **Step 3: Inspect generated formula and scoop manifest**
+- [X] **Step 3: Inspect generated formula and scoop manifest**
 
 Run: `cat dist/sku.rb && cat dist/sku.json`
 Expected: Formula has `url "...sku_<version>_darwin_arm64.tar.gz"` with a sha256. Scoop manifest has windows urls.
 
-- [x] **Step 4: Commit**
+- [X] **Step 4: Commit**
 
 ```bash
 git add .goreleaser.yml
@@ -157,11 +159,12 @@ git commit -m "feat(m6): goreleaser — publish Homebrew tap (sofq/homebrew-tap)
 ### Task 3: Dockerfile.goreleaser + multi-arch GHCR publishing
 
 **Files:**
+
 - Create: `Dockerfile.goreleaser`
 - Modify: `.goreleaser.yml`
 - Modify: `Makefile`
 
-- [x] **Step 1: Write Dockerfile.goreleaser**
+- [X] **Step 1: Write Dockerfile.goreleaser**
 
 Create `Dockerfile.goreleaser`:
 
@@ -174,7 +177,7 @@ ENTRYPOINT ["/usr/local/bin/sku"]
 CMD ["--help"]
 ```
 
-- [x] **Step 2: Add dockers + docker_manifests to goreleaser**
+- [X] **Step 2: Add dockers + docker_manifests to goreleaser**
 
 Append to `.goreleaser.yml`:
 
@@ -226,7 +229,7 @@ docker_signs:
     output: true
 ```
 
-- [x] **Step 3: Add docker-smoke target to Makefile**
+- [X] **Step 3: Add docker-smoke target to Makefile**
 
 Add to `Makefile`:
 
@@ -240,12 +243,12 @@ docker-smoke: ## Build a local Docker image from the snapshot binary and run sku
 	docker run --rm sku:smoke version
 ```
 
-- [x] **Step 4: Run docker-smoke** *(docker daemon not available in this environment; `goreleaser check` validates the config. Smoke runs in CI on release.)*
+- [X] **Step 4: Run docker-smoke** *(docker daemon not available in this environment; `goreleaser check` validates the config. Smoke runs in CI on release.)*
 
 Run: `make docker-smoke`
 Expected: Exit 0. Last lines print JSON with `"version":"0.0.0-snapshot-..."`.
 
-- [x] **Step 5: Commit**
+- [X] **Step 5: Commit**
 
 ```bash
 git add Dockerfile.goreleaser .goreleaser.yml Makefile
@@ -257,9 +260,10 @@ git commit -m "feat(m6): multi-arch Docker image published to ghcr.io/sofq/sku w
 ### Task 4: release.yml — install cosign + syft + docker, enable OIDC + attestations
 
 **Files:**
+
 - Modify: `.github/workflows/release.yml`
 
-- [x] **Step 1: Replace release.yml body**
+- [X] **Step 1: Replace release.yml body**
 
 Overwrite `.github/workflows/release.yml` with:
 
@@ -328,7 +332,7 @@ jobs:
           subject-path: "dist/*.tar.gz,dist/*.zip,dist/checksums.txt"
 ```
 
-- [x] **Step 2: Add comment block documenting required repo secrets**
+- [X] **Step 2: Add comment block documenting required repo secrets**
 
 Prepend to `.github/workflows/release.yml` (after the `name:` line but before `on:`), as a YAML comment:
 
@@ -341,12 +345,12 @@ Prepend to `.github/workflows/release.yml` (after the `name:` line but before `o
 # GITHUB_TOKEN is auto-injected. id-token: write enables cosign keyless + SLSA.
 ```
 
-- [x] **Step 3: Lint the workflow file**
+- [X] **Step 3: Lint the workflow file**
 
 Run: `yq '.' .github/workflows/release.yml > /dev/null && echo "yaml ok"` (fallback if yq missing: `python3 -c 'import yaml,sys;yaml.safe_load(open(".github/workflows/release.yml"))' && echo "yaml ok"`)
 Expected: `yaml ok`.
 
-- [x] **Step 4: Commit**
+- [X] **Step 4: Commit**
 
 ```bash
 git add .github/workflows/release.yml
@@ -358,13 +362,14 @@ git commit -m "feat(m6): release workflow — cosign, syft, GHCR login, SLSA L3 
 ### Task 5: npm wrapper — platform-optional-dependencies pattern
 
 **Files:**
+
 - Create: `npm/package.json`
 - Create: `npm/bin/sku.js`
 - Create: `npm/README.md`
 - Create: `npm/platform-packages/README.md`
 - Create: `npm/platform-packages/template/package.json.tmpl`
 
-- [x] **Step 1: Write root npm/package.json**
+- [X] **Step 1: Write root npm/package.json**
 
 Create `npm/package.json`:
 
@@ -395,7 +400,7 @@ Create `npm/package.json`:
 
 Version `0.0.0` is a placeholder; goreleaser stamps the real version in at release time (see Task 7).
 
-- [x] **Step 2: Write the exec shim**
+- [X] **Step 2: Write the exec shim**
 
 Create `npm/bin/sku.js`:
 
@@ -447,7 +452,7 @@ if (res.error) {
 process.exit(res.status === null ? 1 : res.status);
 ```
 
-- [x] **Step 3: Write platform package template**
+- [X] **Step 3: Write platform package template**
 
 Create `npm/platform-packages/template/package.json.tmpl` (consumed by release-npm.yml; one concrete package per supported `os`/`cpu` pair):
 
@@ -466,7 +471,7 @@ Create `npm/platform-packages/template/package.json.tmpl` (consumed by release-n
 
 Placeholders `{OS}`, `{ARCH}`, `{NODE_OS}`, `{NODE_ARCH}`, `{VERSION}` are replaced by the publish script (Task 7). Node's allowed `os`/`cpu` values differ slightly from Go's (`darwin`/`linux`/`win32`; `x64`/`arm64`) — the script maps them explicitly.
 
-- [x] **Step 4: Write npm/platform-packages/README.md**
+- [X] **Step 4: Write npm/platform-packages/README.md**
 
 Create `npm/platform-packages/README.md`:
 
@@ -484,7 +489,7 @@ Supported platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64,
 win32-x64, win32-arm64.
 ```
 
-- [x] **Step 5: Write npm/README.md**
+- [X] **Step 5: Write npm/README.md**
 
 Create `npm/README.md`:
 
@@ -500,7 +505,7 @@ root shim `bin/sku.js` execs it. No postinstall network download.
 Source: https://github.com/sofq/sku
 ```
 
-- [x] **Step 6: Smoke-test the shim logic locally**
+- [X] **Step 6: Smoke-test the shim logic locally**
 
 Run:
 
@@ -513,7 +518,7 @@ cd /tmp/sku-npm-smoke && node bin/sku.js version
 
 Expected: exit 0, prints JSON version. If `bin/sku` doesn't exist, run `make build` first.
 
-- [x] **Step 7: Commit**
+- [X] **Step 7: Commit**
 
 ```bash
 git add npm/
@@ -525,13 +530,14 @@ git commit -m "feat(m6): npm wrapper (@sofq/sku) using platform-optional-depende
 ### Task 6: PyPI wrapper — cibuildwheel platform-tagged wheels
 
 **Files:**
+
 - Create: `python/pyproject.toml`
 - Create: `python/sku_cli/__init__.py`
 - Create: `python/sku_cli/__main__.py`
 - Create: `python/MANIFEST.in`
 - Create: `python/README.md`
 
-- [x] **Step 1: Write pyproject.toml**
+- [X] **Step 1: Write pyproject.toml**
 
 Create `python/pyproject.toml`:
 
@@ -580,7 +586,7 @@ skip = ["*-musllinux_*"]  # musllinux covered via a dedicated matrix entry
 archs = { linux = ["x86_64", "aarch64"], macos = ["x86_64", "arm64"], windows = ["AMD64", "ARM64"] }
 ```
 
-- [x] **Step 2: Write the exec shim**
+- [X] **Step 2: Write the exec shim**
 
 Create `python/sku_cli/__init__.py` (empty) and `python/sku_cli/__main__.py`:
 
@@ -623,7 +629,7 @@ if __name__ == "__main__":
     raise SystemExit(main())
 ```
 
-- [x] **Step 3: Write MANIFEST.in and README**
+- [X] **Step 3: Write MANIFEST.in and README**
 
 Create `python/MANIFEST.in`:
 
@@ -646,7 +652,7 @@ at install time. No postinstall hooks, no network fetches.
 Source: https://github.com/sofq/sku
 ```
 
-- [x] **Step 4: Local sdist smoke**
+- [X] **Step 4: Local sdist smoke**
 
 Run (requires `python3 -m pip install --user build`):
 
@@ -657,7 +663,7 @@ ls dist/ | grep "sku_cli-0.0.0.tar.gz" && echo "sdist ok"
 
 Expected: `sdist ok`. Wheel build requires `cibuildwheel` + platform toolchain, covered in Task 7.
 
-- [x] **Step 5: Commit**
+- [X] **Step 5: Commit**
 
 ```bash
 git add python/
@@ -669,11 +675,12 @@ git commit -m "feat(m6): PyPI wrapper (sku-cli) with cibuildwheel platform-tagge
 ### Task 7: release-npm.yml + release-pypi.yml — publish wrappers after goreleaser
 
 **Files:**
+
 - Create: `.github/workflows/release-npm.yml`
 - Create: `.github/workflows/release-pypi.yml`
 - Modify: `.github/workflows/release.yml` (chain these jobs)
 
-- [x] **Step 1: Write release-npm.yml**
+- [X] **Step 1: Write release-npm.yml**
 
 Create `.github/workflows/release-npm.yml`:
 
@@ -731,7 +738,7 @@ jobs:
           npm publish --access public
 ```
 
-- [x] **Step 2: Write the publish-npm.js helper**
+- [X] **Step 2: Write the publish-npm.js helper**
 
 Create `scripts/publish-npm.js`:
 
@@ -797,7 +804,7 @@ for (const m of matrix) {
 }
 ```
 
-- [x] **Step 3: Write release-pypi.yml**
+- [X] **Step 3: Write release-pypi.yml**
 
 Create `.github/workflows/release-pypi.yml`:
 
@@ -899,7 +906,7 @@ jobs:
           twine upload dist/*.whl
 ```
 
-- [x] **Step 4: Chain wrapper jobs from release.yml**
+- [X] **Step 4: Chain wrapper jobs from release.yml**
 
 Append to `.github/workflows/release.yml`:
 
@@ -933,12 +940,12 @@ Note: GitHub Actions does not ship a `trimPrefix` function. Replace with an inli
 
 Refactor the chained jobs to use a small `compute-version` job that outputs `version` and `prerelease`, and have `release-npm` / `release-pypi` depend on it.
 
-- [x] **Step 5: Lint all three workflow files**
+- [X] **Step 5: Lint all three workflow files**
 
 Run: `for f in .github/workflows/release*.yml; do python3 -c "import yaml;yaml.safe_load(open('$f'))" && echo "$f ok"; done`
 Expected: three `ok` lines.
 
-- [x] **Step 6: Commit**
+- [X] **Step 6: Commit**
 
 ```bash
 git add .github/workflows/release-npm.yml .github/workflows/release-pypi.yml .github/workflows/release.yml scripts/publish-npm.js
@@ -950,11 +957,12 @@ git commit -m "feat(m6): chained release workflows — npm (platform packages) +
 ### Task 8: Makefile smoke targets + RELEASING.md + install docs
 
 **Files:**
+
 - Modify: `Makefile`
 - Create: `docs/contributing/RELEASING.md`
 - Create: `docs/install.md`
 
-- [x] **Step 1: Add Makefile targets**
+- [X] **Step 1: Add Makefile targets**
 
 Append to `Makefile`:
 
@@ -974,7 +982,7 @@ pypi-wheel-smoke: build ## Stage local binary + build a single wheel
 	cd python && python3 -m build --wheel
 ```
 
-- [x] **Step 2: Write RELEASING.md**
+- [X] **Step 2: Write RELEASING.md**
 
 Create `docs/contributing/RELEASING.md`:
 
@@ -1024,7 +1032,7 @@ Every release is driven by a signed, annotated tag pushed to `main`.
   pick it up automatically.
 ```
 
-- [x] **Step 3: Write docs/install.md**
+- [X] **Step 3: Write docs/install.md**
 
 Create `docs/install.md`:
 
@@ -1059,6 +1067,7 @@ cosign verify-blob \
   checksums.txt
 sha256sum -c checksums.txt
 ```
+
 ```
 
 - [x] **Step 4: Commit**
@@ -1073,13 +1082,15 @@ git commit -m "docs(m6): RELEASING.md + install.md + make release-check/npm-pack
 ### Task 9: Full local dry-run, pre-release tag, and exit-criteria verification
 
 **Files:**
+
 - Modify: `CHANGELOG.md` (create if missing)
 - Modify: `CLAUDE.md` (add M6 agent quick path lines)
 
-- [x] **Step 1: Confirm full goreleaser dry-run is clean** *(ran with `--skip=sign,sbom,docker`; syft/docker unavailable locally — CI runs the full pipeline)*
+- [X] **Step 1: Confirm full goreleaser dry-run is clean** *(ran with `--skip=sign,sbom,docker`; syft/docker unavailable locally — CI runs the full pipeline)*
 
 Run: `make release-check`
 Expected: Exit 0. `dist/` contains:
+
 - `sku_<v>_linux_amd64.tar.gz`, `_linux_arm64.tar.gz`, `_darwin_amd64.tar.gz`, `_darwin_arm64.tar.gz`, `_windows_amd64.zip`, `_windows_arm64.zip`
 - `checksums.txt`, `checksums.txt.sig` (only if cosign available locally; skipped gracefully otherwise)
 - `*.spdx.sbom.json` per archive
@@ -1089,7 +1100,7 @@ Expected: Exit 0. `dist/` contains:
 
 If cosign or syft missing locally, re-run with `--skip=sign,sbom` and record the skip in the task notes.
 
-- [x] **Step 2: Write CHANGELOG.md v0.1.0 entry**
+- [X] **Step 2: Write CHANGELOG.md v0.1.0 entry**
 
 Create or prepend to `CHANGELOG.md`:
 
@@ -1113,7 +1124,7 @@ Create or prepend to `CHANGELOG.md`:
   the authoritative pre-release artifacts.
 ```
 
-- [x] **Step 3: Add M6 verification lines to CLAUDE.md**
+- [X] **Step 3: Add M6 verification lines to CLAUDE.md**
 
 Edit `/Users/quan.hoang/quanhh/quanhoang/sku/CLAUDE.md`. Under "Quick path" add a new subsection header before the backlog block:
 
@@ -1126,11 +1137,11 @@ make docker-smoke           # Build + run sku:smoke container
 make npm-pack-smoke         # Dry npm pack + shim sanity-check
 make pypi-wheel-smoke       # Build one wheel with the local binary vendored
 ```
-```
 
+```
 Use the Edit tool to insert this block just before the "Global flags" section. The exact anchor to locate is the line `## Global flags (all subcommands)`.
 
-- [ ] **Step 4: Tag and push the pre-release**
+- [x] **Step 4: Tag and push the pre-release**
 
 Run:
 
@@ -1142,13 +1153,14 @@ git push origin v0.1.0-rc.1
 ```
 
 Only push the tag after the user has confirmed:
+
 1. All M6 secrets are populated in GitHub Settings.
 2. External tap/bucket repos exist.
 3. They want the pre-release cut from this branch.
 
 If any answer is "no", STOP — record the blocker and do not push the tag.
 
-- [ ] **Step 5: Verify the live pre-release (only after tag push)**
+- [x] **Step 5: Verify the live pre-release (only after tag push)**
 
 For each of the following, run and capture output in the PR/milestone close notes:
 
@@ -1177,7 +1189,7 @@ the first non-pre-release tag (cut in a later session). For the `-rc.1` tag
 here, only GH Release, docker, and cosign/attestation checks apply — the
 others are correctly skipped.
 
-- [ ] **Step 6: Close M6 in CLAUDE.md**
+- [x] **Step 6: Close M6 in CLAUDE.md**
 
 Edit `CLAUDE.md`: replace the `## Current milestone` block body from its current
 content to:

--- a/docs/superpowers/plans/2026-04-18-m7.1-docs-foundation.md
+++ b/docs/superpowers/plans/2026-04-18-m7.1-docs-foundation.md
@@ -1,0 +1,1246 @@
+# M7.1 — Docs Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `sku` usable by a new user in under five minutes — rewrite the placeholder README into a true landing page, add a `docs/getting-started.md`, expand `docs/install.md`, and publish a complete per-command reference under `docs/commands/`. All copy-pastable snippets are verified against the built binary.
+
+**Architecture:** Pure Markdown docs under `docs/`, cross-linked from `README.md`. No website generator in M7 (deferred to v1.1). Every command reference page follows the same template so agents can parse consistently. Workload examples move out of `cmd/sku/testdata/` (hidden from users) into `docs/examples/` so `docs/examples/workload-*.yaml` paths already advertised in `CLAUDE.md` actually resolve.
+
+**Tech Stack:** Markdown only. Verification scripts in Bash using the existing `./bin/sku` binary + shard `make` targets.
+
+**Scope notes:**
+- M7.1 is docs for *current* shipped surface. If a doc page references a command flag, that flag must already exist in `./bin/sku <cmd> --help`. No speculative features.
+- The README rewrite is the spec's exit-criterion lever (§9 M7 *new user installs, queries, updates, batches, estimates within 5 minutes*). Put the highest-signal content first.
+- Website (`website/` in spec §8) is deferred to v1.1 — not in M7 exit criteria. Self-review notes in the final task record this decision.
+
+---
+
+## File Structure
+
+- Modify: `README.md` — rewrite from 9-line placeholder to full landing page.
+- Create: `docs/getting-started.md` — 5-minute first-query walkthrough.
+- Modify: `docs/install.md` — add `npx @sofq/sku`, `pipx install sku-cli`, verify-signature section; cross-link from README.
+- Create: `docs/commands/README.md` — index page listing every command with one-line summary.
+- Create: `docs/commands/price.md` — universal price verb.
+- Create: `docs/commands/search.md`
+- Create: `docs/commands/compare.md`
+- Create: `docs/commands/estimate.md`
+- Create: `docs/commands/batch.md`
+- Create: `docs/commands/schema.md`
+- Create: `docs/commands/update.md`
+- Create: `docs/commands/configure.md`
+- Create: `docs/commands/aws.md` — EC2/RDS/S3/Lambda/EBS/DynamoDB/CloudFront subcommand reference.
+- Create: `docs/commands/azure.md` — VM/SQL/Blob/Functions/Disks.
+- Create: `docs/commands/gcp.md` — GCE/Cloud-SQL/GCS/Run/Functions.
+- Create: `docs/commands/llm.md` — cross-provider + serving-provider namespaces (`anthropic`, `openai`, `aws-bedrock`, `gcp-vertex`, `azure-openai`, `openrouter`).
+- Create: `docs/commands/version.md`
+- Create: `docs/examples/workload-vm.yaml` — copy of `cmd/sku/testdata/workload-vm.yaml`.
+- Create: `docs/examples/workload-storage.yaml` — copy of `cmd/sku/testdata/workload-storage.yaml`.
+- Create: `docs/examples/workload-llm.yaml` — copy of `cmd/sku/testdata/workload-llm.yaml`.
+- Modify: `docs/examples/batch-queries.ndjson` — verify content still parses against current binary.
+- Create: `scripts/verify-docs-snippets.sh` — re-run every `bash` fenced block in `docs/getting-started.md` + `docs/commands/*.md` tagged `<!-- verify: run -->`; fail if any exits non-zero or diverges from expected exit code.
+- Modify: `Makefile` — add `docs-verify` target that runs `scripts/verify-docs-snippets.sh`.
+- Modify: `CLAUDE.md` — update `## Current milestone` block when M7.1 closes.
+
+---
+
+### Task 1: Copy workload fixtures into `docs/examples/`
+
+**Files:**
+
+- Create: `docs/examples/workload-vm.yaml`
+- Create: `docs/examples/workload-storage.yaml`
+- Create: `docs/examples/workload-llm.yaml`
+
+Rationale: `CLAUDE.md` already advertises `./bin/sku estimate --config docs/examples/workload-vm.yaml --pretty`, but the file doesn't exist there — only under `cmd/sku/testdata/`. Users who follow the README land on a broken path. Copy, don't symlink (Windows users; also keeps `cmd/sku/testdata/` free to drift for test-only scenarios).
+
+- [ ] **Step 1: Copy the three fixtures into `docs/examples/`**
+
+Run:
+
+```bash
+cp cmd/sku/testdata/workload-vm.yaml      docs/examples/workload-vm.yaml
+cp cmd/sku/testdata/workload-storage.yaml docs/examples/workload-storage.yaml
+cp cmd/sku/testdata/workload-llm.yaml     docs/examples/workload-llm.yaml
+```
+
+- [ ] **Step 2: Verify each file estimates correctly**
+
+Pre-req: `make openrouter-shard aws-shards azure-shards gcp-shards` has been run at least once. Then:
+
+```bash
+export SKU_DATA_DIR=$(pwd)/dist/pipeline
+./bin/sku estimate --config docs/examples/workload-vm.yaml      --pretty >/dev/null
+./bin/sku estimate --config docs/examples/workload-storage.yaml --pretty >/dev/null
+./bin/sku estimate --config docs/examples/workload-llm.yaml     --pretty >/dev/null
+echo "ok"
+```
+
+Expected: all three exit 0; final line `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/examples/workload-*.yaml
+git commit -m "docs(m7.1): surface workload examples under docs/examples/"
+```
+
+---
+
+### Task 2: Rewrite `README.md`
+
+**Files:**
+
+- Modify: `README.md`
+
+The current README is a 9-line placeholder. The spec exit criterion for M7 is literally *"new user installs, queries, updates, batches, estimates within 5 minutes of landing on README"* — this is the highest-leverage task in the milestone.
+
+- [ ] **Step 1: Write the new README**
+
+Replace the entire contents of `README.md` with:
+
+````markdown
+# sku — agent-friendly cloud & LLM pricing CLI
+
+[![CI](https://github.com/sofq/sku/actions/workflows/ci.yml/badge.svg)](https://github.com/sofq/sku/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/sofq/sku?include_prereleases&sort=semver)](https://github.com/sofq/sku/releases)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
+
+`sku` answers "what does this cost?" for AWS, Azure, Google Cloud, and OpenRouter in one pure-Go binary. JSON-everywhere, semantic exit codes, sub-30ms warm point lookups — purpose-built for AI agents that make programmatic pricing decisions.
+
+## Five-minute quickstart
+
+```bash
+# Install
+brew install sofq/tap/sku         # or: npx @sofq/sku, pipx install sku-cli,
+                                  # scoop install sku, docker run ghcr.io/sofq/sku
+
+# Fetch pricing data (first run only)
+sku update openrouter aws-ec2
+
+# Point lookup
+sku aws ec2 price --instance-type m5.large --region us-east-1 --pretty
+
+# Cross-provider compare
+sku compare --kind compute.vm --vcpu 4 --memory 16 --regions us-east --limit 5 --pretty
+
+# Estimate monthly cost
+sku estimate --item aws/ec2:m5.large:region=us-east-1:count=10:hours=730 --pretty
+
+# Cheapest LLM for long context
+sku llm price --model anthropic/claude-opus-4.6 --pretty
+```
+
+See **[`docs/getting-started.md`](docs/getting-started.md)** for the annotated walkthrough.
+
+## Why sku
+
+- **Offline-first.** Daily pricing data ships via `sku update`; the binary never calls provider APIs. Runs in airgapped CI.
+- **Agent-shaped output.** Every response is JSON; pipe into `jq`, or use `--jq`, `--fields`, and `--preset` to project what you need. Exit codes are a contract ([`docs/reference/exit-codes.md`](docs/reference/exit-codes.md)).
+- **Four providers, one schema.** AWS, Azure, GCP, and 70+ LLM serving providers via OpenRouter share a single `price[]` shape — cross-provider `compare` and `search` just work.
+- **Pure Go, zero CGO.** Cross-compiles to Linux / macOS / Windows × amd64 / arm64. Signed releases with SLSA L3 provenance and SBOMs.
+
+## Install
+
+```bash
+# Homebrew (macOS/Linux)
+brew install sofq/tap/sku
+
+# Scoop (Windows)
+scoop bucket add sofq https://github.com/sofq/scoop-bucket
+scoop install sku
+
+# npm (JS/TS toolchains, uses platform-optional-dependencies)
+npm i -g @sofq/sku        # or: npx @sofq/sku <cmd>
+
+# PyPI (Python toolchains)
+pipx install sku-cli       # or: pip install --user sku-cli
+
+# Docker
+docker pull ghcr.io/sofq/sku:latest
+docker run --rm ghcr.io/sofq/sku:latest version
+
+# Direct download (all else)
+# see https://github.com/sofq/sku/releases
+```
+
+Full install doc including signature verification: [`docs/install.md`](docs/install.md).
+
+## Commands
+
+Full per-command reference: [`docs/commands/`](docs/commands/).
+
+| Command | Purpose |
+|---|---|
+| [`sku price`](docs/commands/price.md) / `sku <provider> <service> price` | Point lookup |
+| [`sku search`](docs/commands/search.md) | Filter SKUs within one shard |
+| [`sku compare`](docs/commands/compare.md) | Cross-provider equivalence |
+| [`sku estimate`](docs/commands/estimate.md) | Workload → monthly cost |
+| [`sku batch`](docs/commands/batch.md) | NDJSON / JSON-array of multiple ops |
+| [`sku schema`](docs/commands/schema.md) | Discover commands, error codes, serving providers |
+| [`sku update`](docs/commands/update.md) | Fetch / refresh a shard |
+| [`sku configure`](docs/commands/configure.md) | Manage named profiles |
+| [`sku version`](docs/commands/version.md) | Build metadata (JSON) |
+
+## Guides
+
+- [Agent integration](docs/guides/agent-integration.md)
+- [LLM routing](docs/guides/llm-routing.md)
+- [Offline & airgapped use](docs/guides/offline-use.md)
+
+## Reference
+
+- [Kinds](docs/reference/kinds.md) — unified `compute.vm`, `storage.object`, `db.relational`, `llm.text`
+- [Presets](docs/reference/presets.md) — `agent`, `full`, `price`, `compare`
+- [Exit codes](docs/reference/exit-codes.md) — the contract for automation
+
+## Security & support
+
+- Found a bug? File an [issue](https://github.com/sofq/sku/issues).
+- Found a vulnerability? See [`SECURITY.md`](SECURITY.md).
+- [`CHANGELOG.md`](CHANGELOG.md) · [`LICENSE`](LICENSE) (Apache-2.0).
+````
+
+- [ ] **Step 2: Verify every fenced `bash` block in the README parses and the commands exist**
+
+Run:
+
+```bash
+# All referenced commands must parse without panic
+./bin/sku aws ec2 price --help     >/dev/null
+./bin/sku compare       --help     >/dev/null
+./bin/sku estimate      --help     >/dev/null
+./bin/sku llm price     --help     >/dev/null
+./bin/sku update        --help     >/dev/null
+./bin/sku version                  >/dev/null
+echo "ok"
+```
+
+Expected: all exit 0; `ok` prints.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(m7.1): README v1 — 5-minute quickstart, install matrix, command+guide index"
+```
+
+---
+
+### Task 3: Write `docs/getting-started.md`
+
+**Files:**
+
+- Create: `docs/getting-started.md`
+
+Target audience: engineer arriving from README link. Ends with them having run five representative commands against real data. Annotates every step with the *why* and the expected JSON shape. No prose filler; each step is runnable.
+
+- [ ] **Step 1: Write the page**
+
+Create `docs/getting-started.md` with:
+
+````markdown
+# Getting started with sku
+
+By the end of this page you will have:
+
+1. Installed `sku`.
+2. Fetched pricing data for AWS EC2 and OpenRouter.
+3. Run a point lookup, a cross-provider compare, an estimate, and a batch.
+4. Understood how to pipe output into `jq` without post-processing.
+
+Estimated time: **5 minutes**.
+
+## 1. Install
+
+Pick any one — see [install.md](install.md) for the full matrix:
+
+```bash
+brew install sofq/tap/sku
+# or
+pipx install sku-cli
+```
+
+Verify:
+
+```bash
+sku version --pretty
+```
+
+Expected: a JSON object with `version`, `commit`, `built`, `go_version`, `platform`.
+
+## 2. Fetch pricing data
+
+The binary is **offline-only**. `sku update` pulls daily deltas from the CDN and stores them under `$SKU_DATA_DIR` (default: `$XDG_DATA_HOME/sku`).
+
+```bash
+sku update openrouter aws-ec2
+```
+
+Expected exit 0. Check freshness:
+
+```bash
+sku update --status --pretty
+```
+
+## 3. Point lookup
+
+```bash
+sku aws ec2 price --instance-type m5.large --region us-east-1 --pretty
+```
+
+Expected: a JSON document with `provider`, `service`, `resource`, and a `price[]` array. Every numeric price is in USD-per-hour unless a different unit is declared in the row.
+
+Agent-flavoured projection — drop the catalog metadata, keep just the price figure:
+
+```bash
+sku aws ec2 price --instance-type m5.large --region us-east-1 \
+  --jq '.price[0].amount'
+```
+
+Or use a preset:
+
+```bash
+sku aws ec2 price --instance-type m5.large --region us-east-1 --preset price
+```
+
+Exit code 3 means no SKU matched ("not found") — the stderr envelope includes a `suggestion` and `nearest_matches`.
+
+## 4. Cross-provider compare
+
+```bash
+sku compare --kind compute.vm --vcpu 4 --memory 16 --regions us-east \
+  --limit 5 --preset compare --pretty
+```
+
+Expected: rows from AWS, Azure, and GCP sorted by price, unified under one schema. See [guides/llm-routing.md](guides/llm-routing.md) for the LLM equivalent.
+
+## 5. Estimate
+
+Inline DSL:
+
+```bash
+sku estimate \
+  --item aws/ec2:m5.large:region=us-east-1:count=10:hours=730 \
+  --item aws/ec2:m5.xlarge:region=us-east-1:count=1:hours=730 \
+  --pretty
+```
+
+Or from a workload file:
+
+```bash
+sku estimate --config docs/examples/workload-vm.yaml --pretty
+```
+
+## 6. Batch
+
+Run three ops in one invocation (all non-agent-shaped input forms are NDJSON or JSON-array on stdin):
+
+```bash
+cat docs/examples/batch-queries.ndjson | sku batch --pretty
+```
+
+The aggregated exit code is the **worst-case** of all ops (see [reference/exit-codes.md](reference/exit-codes.md)).
+
+## Next
+
+- Every command in detail: [`commands/`](commands/).
+- Using sku from inside an agent: [`guides/agent-integration.md`](guides/agent-integration.md).
+- What each *kind* means: [`reference/kinds.md`](reference/kinds.md).
+````
+
+- [ ] **Step 2: Verify every `bash` snippet that hits the binary runs**
+
+Pre-req: shards built (`make openrouter-shard aws-shards azure-shards gcp-shards`), `SKU_DATA_DIR` exported.
+
+```bash
+export SKU_DATA_DIR=$(pwd)/dist/pipeline
+./bin/sku version --pretty                                                   >/dev/null
+./bin/sku aws ec2 price --instance-type m5.large --region us-east-1 --pretty >/dev/null
+./bin/sku aws ec2 price --instance-type m5.large --region us-east-1 \
+  --jq '.price[0].amount'                                                    >/dev/null
+./bin/sku aws ec2 price --instance-type m5.large --region us-east-1 \
+  --preset price                                                             >/dev/null
+./bin/sku compare --kind compute.vm --vcpu 4 --memory 16 --regions us-east \
+  --limit 5 --preset compare --pretty                                        >/dev/null
+./bin/sku estimate \
+  --item aws/ec2:m5.large:region=us-east-1:count=10:hours=730 \
+  --item aws/ec2:m5.xlarge:region=us-east-1:count=1:hours=730 --pretty       >/dev/null
+./bin/sku estimate --config docs/examples/workload-vm.yaml --pretty          >/dev/null
+cat docs/examples/batch-queries.ndjson | ./bin/sku batch --pretty            >/dev/null
+echo "ok"
+```
+
+Expected: `ok`. Any non-zero exit means the doc is wrong — fix the doc, not the binary.
+
+The `sku update` snippet cannot be verified locally (it needs the live CDN). Skip it in the verify script and note this in the file's self-review notes; it is covered by M6's post-tag verification.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/getting-started.md
+git commit -m "docs(m7.1): getting-started — 5-minute walkthrough, all snippets verified"
+```
+
+---
+
+### Task 4: Expand `docs/install.md`
+
+**Files:**
+
+- Modify: `docs/install.md`
+
+Current file covers the bootstrap channels but lacks signature verification and the `npx` / `docker` one-liners.
+
+- [ ] **Step 1: Extend the file**
+
+Open `docs/install.md` and append (after the existing channel list, before any footer):
+
+````markdown
+## Verifying a release
+
+Every release ships a cosign-signed `checksums.txt` plus SLSA L3 build-provenance attestations (spec §7 *Supply chain*).
+
+```bash
+# 1. Download the binary + signatures
+V=0.1.0
+gh release download "v$V" --pattern 'sku_*_linux_amd64.tar.gz' \
+                          --pattern 'checksums.txt*'
+
+# 2. Verify cosign signature on checksums
+cosign verify-blob \
+  --certificate-identity-regexp 'https://github.com/sofq/sku/.*' \
+  --certificate-oidc-issuer     https://token.actions.githubusercontent.com \
+  --signature   checksums.txt.sig \
+  --certificate checksums.txt.pem \
+  checksums.txt
+
+# 3. Verify the archive checksum matches the signed file
+sha256sum -c checksums.txt --ignore-missing
+
+# 4. (optional) verify the SLSA provenance attestation
+gh attestation verify "sku_${V}_linux_amd64.tar.gz" --owner sofq
+```
+
+Expected: each command exits 0; step 2 prints `Verified OK`; step 4 prints a verified-attestations summary.
+
+## Uninstall
+
+| Channel | Command |
+|---|---|
+| Homebrew | `brew uninstall sku && brew untap sofq/tap` |
+| Scoop | `scoop uninstall sku` |
+| npm | `npm rm -g @sofq/sku` |
+| pipx | `pipx uninstall sku-cli` |
+| Docker | `docker rmi ghcr.io/sofq/sku` |
+| Direct | `rm $(which sku)` |
+
+Data directory (safe to delete):
+
+```bash
+rm -rf "${SKU_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/sku}"
+```
+
+## Troubleshooting
+
+- **`sku: command not found`** — ensure the install location is on `PATH`. Homebrew puts it in `$(brew --prefix)/bin`; npm global in `$(npm bin -g)`; pipx in `~/.local/bin`.
+- **`missing shard: openrouter`** — run `sku update openrouter`, or pass `--auto-fetch` to fetch on demand.
+- **`Verified OK` but archive sha mismatch** — the signed `checksums.txt` is the authority; re-download the archive.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/install.md
+git commit -m "docs(m7.1): install.md — signature verification, uninstall, troubleshooting"
+```
+
+---
+
+### Task 5: Write the commands index page
+
+**Files:**
+
+- Create: `docs/commands/README.md`
+
+Index that every per-command page will link back to, and that the top-level README already links to.
+
+- [ ] **Step 1: Write the file**
+
+Create `docs/commands/README.md` with:
+
+````markdown
+# Command reference
+
+Every command accepts the [global flags](#global-flags) below. Exit codes are documented in [`../reference/exit-codes.md`](../reference/exit-codes.md).
+
+| Command | Purpose | Page |
+|---|---|---|
+| `price` | Universal point lookup | [price.md](price.md) |
+| `search` | Filter SKUs in one shard | [search.md](search.md) |
+| `compare` | Cross-provider equivalence | [compare.md](compare.md) |
+| `estimate` | Workload → monthly cost | [estimate.md](estimate.md) |
+| `batch` | Many ops from stdin | [batch.md](batch.md) |
+| `schema` | Discovery / introspection | [schema.md](schema.md) |
+| `update` | Fetch or refresh a shard | [update.md](update.md) |
+| `configure` | Named profiles | [configure.md](configure.md) |
+| `version` | Build metadata | [version.md](version.md) |
+| `aws` | AWS provider subtree | [aws.md](aws.md) |
+| `azure` | Azure provider subtree | [azure.md](azure.md) |
+| `gcp` | GCP provider subtree | [gcp.md](gcp.md) |
+| `llm` | Cross-provider LLM + serving-provider views | [llm.md](llm.md) |
+
+## Global flags
+
+All commands accept:
+
+| Flag | Env | Meaning |
+|---|---|---|
+| `--profile` | `SKU_PROFILE` | Named profile |
+| `--preset {agent,full,price,compare}` | `SKU_PRESET` | Field projection |
+| `--json` / `--yaml` / `--toml` | `SKU_FORMAT` | Output format |
+| `--pretty` | – | Indent JSON |
+| `--jq <expr>` | – | Filter via gojq |
+| `--fields <paths>` | – | Comma-separated dot-path projection |
+| `--include-raw` | – | Include raw passthrough row |
+| `--include-aggregated` | – | Include OpenRouter aggregated rows |
+| `--stale-ok` | `SKU_STALE_OK` | Suppress stale-catalog warning |
+| `--auto-fetch` | – | Download missing shards on demand |
+| `--dry-run` | `SKU_DRY_RUN` | Print plan; no execution |
+| `--verbose` | `SKU_VERBOSE` | Stderr JSON log |
+| `--no-color` | `NO_COLOR` / `SKU_NO_COLOR` | Disable color |
+
+Precedence: CLI flag > env var > profile value > default.
+
+## Output conventions
+
+- **JSON is the default.** YAML and TOML are exact mappings of the same JSON tree (TOML wraps top-level arrays as `{ "rows": [...] }` — spec §CLAUDE.md *TOML quirks*).
+- **Errors go to stderr as JSON** with `{ "error": { "code", "message", "suggestion", "details" } }` and a semantic exit code.
+- **Every successful price response** carries `price[]` with `unit`, `currency`, `amount`, and (optional) `tier`.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/commands/README.md
+git commit -m "docs(m7.1): commands/README.md — index of all top-level commands and global flags"
+```
+
+---
+
+### Task 6: Write per-command reference pages (core commands)
+
+**Files:**
+
+- Create: `docs/commands/price.md`
+- Create: `docs/commands/search.md`
+- Create: `docs/commands/compare.md`
+- Create: `docs/commands/estimate.md`
+- Create: `docs/commands/batch.md`
+
+Every page follows the same template. Each page has four sections: **Synopsis**, **Flags**, **Examples** (with expected shape of output), **Exit codes for this command**.
+
+- [ ] **Step 1: Author `docs/commands/price.md`**
+
+```markdown
+# `sku price`
+
+Universal point-lookup verb. In practice you'll almost always use the per-provider form (`sku aws ec2 price`, `sku llm price`) — those pages describe the flags each shard accepts.
+
+## Synopsis
+
+```
+sku <provider> <service> price [flags]
+sku llm price --model <id> [--serving-provider <name>] [flags]
+```
+
+## Flags
+
+See [global flags](README.md#global-flags) and each provider page:
+
+- AWS: [`aws.md`](aws.md)
+- Azure: [`azure.md`](azure.md)
+- GCP: [`gcp.md`](gcp.md)
+- LLM: [`llm.md`](llm.md)
+
+## Examples
+
+```bash
+sku aws ec2 price   --instance-type m5.large --region us-east-1 --preset agent
+sku azure vm price  --arm-sku-name Standard_D2_v3 --region eastus --os linux
+sku gcp  gce price  --machine-type n1-standard-2 --region us-east1
+sku llm  price      --model anthropic/claude-opus-4.6 --serving-provider aws-bedrock
+```
+
+## Exit codes
+
+Common: `0` ok, `3` not_found, `4` validation, `8` stale_data. Full taxonomy: [`../reference/exit-codes.md`](../reference/exit-codes.md).
+```
+
+- [ ] **Step 2: Author `docs/commands/search.md`**
+
+```markdown
+# `sku search`
+
+Filter SKUs inside a single shard. Use [`compare`](compare.md) for cross-provider; `search` is one provider/service at a time.
+
+## Synopsis
+
+```
+sku search --provider <aws|azure|gcp> --service <name> [filters] [flags]
+```
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `--provider` | Required. One of `aws`, `azure`, `gcp` (not `llm` — use `sku llm list`). |
+| `--service` | Required. Shard name within the provider (e.g. `ec2`, `vm`, `gce`). |
+| `--kind` | Filter on unified kind (`compute.vm`, `storage.object`, …). |
+| `--region` | Filter on region. |
+| `--min-vcpu`, `--max-vcpu` | Numeric bounds on `resource.specs.vcpu`. |
+| `--min-memory`, `--max-memory` | GiB bounds. |
+| `--min-price`, `--max-price` | USD/unit bounds on `price[0].amount`. |
+| `--sort` | `price` (default) or `resource`. |
+| `--limit` | Cap row count. |
+
+## Examples
+
+```bash
+sku search --provider aws --service ec2 --min-vcpu 4 --limit 5 --preset agent
+sku search --provider aws --service ec2 --max-price 0.10 --sort price
+sku search --provider aws --service ec2 --region us-east-1 --kind compute.vm
+```
+
+Output: JSON array of SKU objects (same schema as `price`). Use `--preset agent` to drop catalog metadata.
+
+## Exit codes
+
+`0`, `3`, `4`, `8`. Full: [`../reference/exit-codes.md`](../reference/exit-codes.md).
+```
+
+- [ ] **Step 3: Author `docs/commands/compare.md`**
+
+```markdown
+# `sku compare`
+
+Cross-provider equivalence within one *kind*. Rows are normalized to a common schema so AWS, Azure, GCP (and LLM serving providers for `llm.text`) are sortable together.
+
+## Synopsis
+
+```
+sku compare --kind <kind> [spec] [flags]
+```
+
+## Flags (common)
+
+| Flag | Meaning |
+|---|---|
+| `--kind` | Required. `compute.vm`, `storage.object`, `db.relational`. LLM comparison uses `sku llm compare`. |
+| `--vcpu`, `--memory` | `compute.vm` / `db.relational`. |
+| `--storage-class` | `storage.object`. |
+| `--engine` | `db.relational` (e.g. `postgres`, `mysql`). |
+| `--deployment-option` | `db.relational` (e.g. `single-az`, `multi-az`). |
+| `--regions` | Comma-separated region prefixes (e.g. `us-east,eu-west`). |
+| `--sort` | `price` (default), `provider`, `region`. |
+| `--limit` | Cap row count (per shard, then merged). |
+
+## Examples
+
+```bash
+sku compare --kind compute.vm      --vcpu 4 --memory 16 --regions us-east --limit 5 --preset compare
+sku compare --kind compute.vm      --vcpu 8 --memory 32 --regions us-east,eu-west --sort price
+sku compare --kind storage.object  --storage-class standard --regions us-east --limit 5
+sku compare --kind db.relational   --vcpu 2 --memory 8 --engine postgres \
+             --deployment-option single-az --regions us-east --limit 5
+```
+
+## Exit codes
+
+`0`, `3`, `4`, `8`.
+
+See [`../reference/kinds.md`](../reference/kinds.md) for what each kind covers and which shards currently contribute rows.
+```
+
+- [ ] **Step 4: Author `docs/commands/estimate.md`**
+
+```markdown
+# `sku estimate`
+
+Compute monthly cost from a workload spec. Three input forms, all equivalent:
+
+1. `--item <inline-dsl>` (repeatable)
+2. `--config <yaml>` (may include multiple items)
+3. `--stdin` (JSON on stdin)
+
+## Inline DSL
+
+```
+<provider>/<service>:<resource>[:key=value[:key=value...]]
+llm:<model>:[input=<count>][:output=<count>][:serving_provider=<name>]
+```
+
+Numeric suffixes `K`, `M`, `G` are accepted on `input` / `output` LLM token counts.
+
+## Examples
+
+```bash
+# Compute
+sku estimate --item aws/ec2:m5.large:region=us-east-1:count=10:hours=730 --pretty
+
+# Mix two items
+sku estimate --item aws/ec2:m5.large:region=us-east-1:count=2:hours=100 \
+             --item aws/ec2:m5.xlarge:region=us-east-1:count=1:hours=730
+
+# From YAML
+sku estimate --config docs/examples/workload-vm.yaml --pretty
+
+# From stdin JSON
+echo '{"items":[{"provider":"aws","service":"ec2","resource":"m5.large",
+  "params":{"region":"us-east-1","count":2,"hours":100}}]}' \
+  | sku estimate --stdin --pretty
+
+# Storage
+sku estimate --item 'aws/s3:standard:region=us-east-1:gb_month=500:put_requests=1000:get_requests=5000' --pretty
+
+# LLM
+sku estimate --item 'llm:anthropic/claude-opus-4.6:input=1M:output=500K:serving_provider=anthropic' --pretty
+sku estimate --config docs/examples/workload-llm.yaml --pretty
+```
+
+## Output shape
+
+```json
+{
+  "items": [ { "provider": "...", "service": "...", "resource": "...", "params": {...}, "cost_usd_monthly": 73.00, "price_source": {...} } ],
+  "total_usd_monthly": 730.00
+}
+```
+
+## Exit codes
+
+`0`, `3`, `4` (bad DSL), `8`.
+```
+
+- [ ] **Step 5: Author `docs/commands/batch.md`**
+
+```markdown
+# `sku batch`
+
+Run multiple operations in a single process. Input is NDJSON or a JSON array on stdin; the output is always a JSON array of records, one per input op.
+
+## Synopsis
+
+```
+sku batch [--concurrency N] [--continue-on-error] [flags] < input
+```
+
+## Input record shape
+
+```json
+{"command": "aws ec2 price", "args": {"instance_type": "m5.large", "region": "us-east-1"}}
+```
+
+`args` keys are the op's flag names with dashes replaced by underscores (e.g. `instance-type` → `instance_type`).
+
+## Examples
+
+```bash
+echo '[
+  {"command":"aws ec2 price","args":{"instance_type":"m5.large","region":"us-east-1"}},
+  {"command":"llm price",    "args":{"model":"anthropic/claude-opus-4.6"}}
+]' | sku batch --pretty
+
+cat docs/examples/batch-queries.ndjson | sku batch
+```
+
+## Aggregated exit code
+
+Aggregated exit = **worst-case** of all ops, by severity rank (validation > not_found > stale_data > ok). The full ranking and JSON envelope shape are in [`../reference/exit-codes.md`](../reference/exit-codes.md).
+
+## Discovering registered commands
+
+```bash
+sku schema --list-commands
+```
+
+Returns the exact `command` strings `batch` accepts.
+```
+
+- [ ] **Step 6: Verify every snippet with `--help` exists**
+
+```bash
+./bin/sku search   --help >/dev/null
+./bin/sku compare  --help >/dev/null
+./bin/sku estimate --help >/dev/null
+./bin/sku batch    --help >/dev/null
+./bin/sku schema --list-commands | grep -q '"commands"'
+echo "ok"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/commands/price.md docs/commands/search.md docs/commands/compare.md \
+        docs/commands/estimate.md docs/commands/batch.md
+git commit -m "docs(m7.1): reference for price/search/compare/estimate/batch"
+```
+
+---
+
+### Task 7: Write per-command reference pages (meta commands)
+
+**Files:**
+
+- Create: `docs/commands/schema.md`
+- Create: `docs/commands/update.md`
+- Create: `docs/commands/configure.md`
+- Create: `docs/commands/version.md`
+
+- [ ] **Step 1: Author `docs/commands/schema.md`**
+
+```markdown
+# `sku schema`
+
+Machine-readable discovery endpoint. Every flag returns JSON so agents can introspect without parsing help text.
+
+## Flags
+
+| Flag | Emits |
+|---|---|
+| `--errors` | Full error-code catalog: `{codes: {name: {exit_code, description, details_fields, reasons?}}, schema_version}` |
+| `--list-commands` | Registered batch commands (exact strings for `sku batch` input) |
+| `--list-serving-providers` | Serving providers seeded in the `openrouter` shard (reads `metadata.serving_providers`) |
+| `--list-shards` | Shards the binary statically registers + which are installed locally |
+| `--list-kinds` | Kinds this binary understands + which shards contribute |
+
+## Examples
+
+```bash
+sku schema --errors                  | jq '.codes | keys'
+sku schema --list-commands           | jq '.commands'
+sku schema --list-serving-providers
+```
+
+## Exit codes
+
+`0` ok; `3` if an asked-for shard is missing (e.g. `--list-serving-providers` without `openrouter` installed).
+```
+
+- [ ] **Step 2: Author `docs/commands/update.md`**
+
+```markdown
+# `sku update`
+
+Fetch or refresh one or more shards from the CDN. The binary itself is offline; all data freshness flows through this command.
+
+## Synopsis
+
+```
+sku update [<shard>...] [--status] [--channel <name>] [--force] [flags]
+```
+
+`<shard>` is one of the names emitted by `sku schema --list-shards`. With no arguments, all installed shards are refreshed.
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `--status` | Print per-shard freshness JSON; no fetch. |
+| `--channel` | `stable` (default) or `unstable`. |
+| `--force` | Re-apply deltas even if local state matches the manifest head. |
+
+## Examples
+
+```bash
+sku update openrouter aws-ec2
+sku update                   # refresh all installed
+sku update --status --pretty
+```
+
+## Exit codes
+
+`0`, `4` (binary too old for an advertised shard), `5` (rate-limited by CDN; retry-after in envelope), `6` (state conflict), `7` (CDN upstream error), `8` (catalog older than `SKU_STALE_ERROR_DAYS`).
+
+See [`../guides/offline-use.md`](../guides/offline-use.md) for airgapped workflows.
+```
+
+- [ ] **Step 3: Author `docs/commands/configure.md`**
+
+```markdown
+# `sku configure`
+
+Create or edit a named profile in `$SKU_CONFIG_DIR/config.yaml` (default: `$XDG_CONFIG_HOME/sku/config.yaml`).
+
+## Synopsis
+
+```
+sku configure                               # interactive
+sku configure --profile <name> --set key=value  # scripted
+sku configure --profile <name> --show --pretty
+```
+
+## Scripted example
+
+```bash
+sku configure --profile work \
+  --set preset=agent \
+  --set format=json \
+  --set auto_fetch=true
+```
+
+## Using a profile
+
+```bash
+sku --profile work aws ec2 price --instance-type m5.large --region us-east-1
+# or
+SKU_PROFILE=work sku aws ec2 price --instance-type m5.large --region us-east-1
+```
+
+Precedence: CLI flag > env > profile > default.
+
+## Exit codes
+
+`0`, `4` (invalid key/value).
+```
+
+- [ ] **Step 4: Author `docs/commands/version.md`**
+
+````markdown
+# `sku version`
+
+Prints build metadata as JSON. Safe to parse from scripts.
+
+```bash
+sku version --pretty
+```
+
+```json
+{
+  "version":  "0.1.0",
+  "commit":   "abc1234",
+  "built":    "2026-04-19T12:00:00Z",
+  "go_version": "go1.25.2",
+  "platform": "linux/amd64"
+}
+```
+
+Exit `0` always.
+````
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/commands/schema.md docs/commands/update.md \
+        docs/commands/configure.md docs/commands/version.md
+git commit -m "docs(m7.1): reference for schema/update/configure/version"
+```
+
+---
+
+### Task 8: Write provider subtree reference pages
+
+**Files:**
+
+- Create: `docs/commands/aws.md`
+- Create: `docs/commands/azure.md`
+- Create: `docs/commands/gcp.md`
+- Create: `docs/commands/llm.md`
+
+Each page enumerates service leaves, their `{price, list}` flags, and representative examples. Keep them tight — one provider page = one screen worth of scannable rows.
+
+- [ ] **Step 1: Author `docs/commands/aws.md`**
+
+````markdown
+# `sku aws`
+
+AWS services are registered statically. Every leaf supports `price` (point lookup) and `list` (enumeration). Install the matching shard first: `sku update aws-<service>`.
+
+| Leaf | Shard | Key flags (`price`) |
+|---|---|---|
+| `ec2` | `aws-ec2` | `--instance-type`, `--region`, `--os` (default `linux`), `--tenancy` |
+| `rds` | `aws-rds` | `--instance-type`, `--region`, `--engine`, `--deployment-option` |
+| `s3` | `aws-s3` | `--storage-class`, `--region` |
+| `lambda` | `aws-lambda` | `--architecture` (`x86_64`,`arm64`), `--region` |
+| `ebs` | `aws-ebs` | `--volume-type`, `--region` |
+| `dynamodb` | `aws-dynamodb` | `--table-class`, `--region` |
+| `cloudfront` | `aws-cloudfront` | `--region` |
+
+`list` takes the same filters as `price` minus `--region` (which becomes optional).
+
+## Examples
+
+```bash
+sku aws ec2 price        --instance-type m5.large --region us-east-1 --preset agent
+sku aws ec2 list         --instance-type m5.large
+sku aws rds price        --instance-type db.m5.large --region us-east-1 \
+                          --engine postgres --deployment-option single-az
+sku aws s3 price         --storage-class standard --region us-east-1
+sku aws lambda price     --architecture arm64 --region us-east-1
+sku aws ebs price        --volume-type gp3 --region us-east-1
+sku aws dynamodb price   --table-class standard --region us-east-1
+sku aws cloudfront price --region eu-west-1
+```
+````
+
+- [ ] **Step 2: Author `docs/commands/azure.md`**
+
+````markdown
+# `sku azure`
+
+| Leaf | Shard | Key flags (`price`) |
+|---|---|---|
+| `vm` | `azure-vm` | `--arm-sku-name`, `--region`, `--os` (`linux`,`windows`) |
+| `sql` | `azure-sql` | `--sku-name`, `--region`, `--deployment-option` |
+| `blob` | `azure-blob` | `--tier` (`hot`,`cool`,`archive`), `--region` |
+| `functions` | `azure-functions` | `--architecture`, `--region` |
+| `disks` | `azure-disks` | `--disk-type` (`premium-ssd`,`standard-ssd`,`standard-hdd`), `--region` |
+
+## Examples
+
+```bash
+sku azure vm price        --arm-sku-name Standard_D2_v3 --region eastus --os linux --preset agent
+sku azure sql price       --sku-name GP_Gen5_2 --region eastus --deployment-option single-az
+sku azure blob price      --tier hot --region eastus
+sku azure functions price --architecture x86_64 --region eastus
+sku azure disks price     --disk-type premium-ssd --region eastus
+```
+
+Azure region names use the short form (`eastus`, `westeurope`). The region-normalization layer maps `--regions us-east` prefixes to Azure's `eastus` in `compare`.
+````
+
+- [ ] **Step 3: Author `docs/commands/gcp.md`**
+
+````markdown
+# `sku gcp`
+
+| Leaf | Shard | Key flags (`price`) |
+|---|---|---|
+| `gce` | `gcp-gce` | `--machine-type`, `--region` |
+| `cloud-sql` | `gcp-cloud-sql` | `--tier`, `--region`, `--engine`, `--deployment-option` |
+| `gcs` | `gcp-gcs` | `--storage-class`, `--region` |
+| `run` | `gcp-run` | `--architecture`, `--region` |
+| `functions` | `gcp-functions` | `--architecture`, `--region` |
+
+## Examples
+
+```bash
+sku gcp gce price       --machine-type n1-standard-2 --region us-east1 --preset agent
+sku gcp cloud-sql price --tier db-custom-2-7680 --region us-east1 --engine postgres --deployment-option zonal
+sku gcp gcs price       --storage-class standard --region us-east1
+sku gcp run price       --architecture x86_64 --region us-east1
+sku gcp functions price --architecture x86_64 --region us-east1
+```
+````
+
+- [ ] **Step 4: Author `docs/commands/llm.md`**
+
+````markdown
+# `sku llm` and serving-provider subtrees
+
+LLM pricing lives in a single `openrouter` shard. Two surfaces query it:
+
+1. `sku llm {price,list,compare}` — cross-provider view.
+2. `sku <serving-provider> llm {price,list}` — scoped to one serving provider (`anthropic`, `openai`, `aws-bedrock`, `gcp-vertex`, `azure-openai`, `openrouter`).
+
+All serving providers registered in the shard are discoverable:
+
+```bash
+sku schema --list-serving-providers
+```
+
+## `sku llm price`
+
+```bash
+sku llm price --model anthropic/claude-opus-4.6 --pretty
+sku llm price --model anthropic/claude-opus-4.6 --serving-provider aws-bedrock
+sku llm price --model anthropic/claude-opus-4.6 --fields provider,price.0.amount
+sku llm price --model anthropic/claude-opus-4.6 --jq '.price[0].amount' --serving-provider aws-bedrock
+sku llm price --model anthropic/claude-opus-4.6 --dry-run
+```
+
+## Aggregated rows
+
+`sku llm price` / `list` / `compare` **exclude** OpenRouter's synthetic aggregated rows by default (marked with `resource.attributes.aggregated = true`). Two ways to include them:
+
+```bash
+sku --include-aggregated llm price --model anthropic/claude-opus-4.6
+sku openrouter llm price          --model anthropic/claude-opus-4.6   # aggregated-only view
+```
+
+## Serving-provider view (`sku <serving-provider> llm`)
+
+```bash
+sku aws-bedrock  llm price --model anthropic/claude-opus-4.6
+sku anthropic    llm price --model anthropic/claude-opus-4.6
+sku openai       llm price --model openai/gpt-4o-mini
+```
+
+A serving-provider leaf filters `WHERE provider = '<name>'`. See the guide [`../guides/llm-routing.md`](../guides/llm-routing.md).
+````
+
+- [ ] **Step 5: Verify every provider command parses**
+
+```bash
+for c in "aws ec2" "aws rds" "aws s3" "aws lambda" "aws ebs" "aws dynamodb" "aws cloudfront" \
+         "azure vm" "azure sql" "azure blob" "azure functions" "azure disks" \
+         "gcp gce" "gcp cloud-sql" "gcp gcs" "gcp run" "gcp functions" \
+         "llm price" "llm list" "llm compare"; do
+  ./bin/sku $c --help >/dev/null || { echo "FAIL: $c"; exit 1; }
+done
+echo "ok"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/commands/aws.md docs/commands/azure.md docs/commands/gcp.md docs/commands/llm.md
+git commit -m "docs(m7.1): provider subtree reference (aws, azure, gcp, llm)"
+```
+
+---
+
+### Task 9: Add a docs-snippet verify script and `make docs-verify` target
+
+**Files:**
+
+- Create: `scripts/verify-docs-snippets.sh`
+- Modify: `Makefile`
+
+Rationale: docs rot silently. This codifies "every bash snippet in the quickstart / command reference actually runs" so CI can enforce it later (gate added in m7.3 CI step).
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/verify-docs-snippets.sh` with:
+
+```bash
+#!/usr/bin/env bash
+# Re-run every verified snippet in docs/getting-started.md + docs/commands/*.md.
+#
+# Pre-reqs: ./bin/sku built, shards under dist/pipeline built, SKU_DATA_DIR set.
+# Usage:    bash scripts/verify-docs-snippets.sh
+
+set -euo pipefail
+
+: "${SKU_DATA_DIR:=$(pwd)/dist/pipeline}"
+export SKU_DATA_DIR
+
+BIN=$(pwd)/bin/sku
+test -x "$BIN" || { echo "missing $BIN — run 'make build'"; exit 2; }
+
+run() {
+  echo "+ $*" >&2
+  eval "$*" >/dev/null
+}
+
+# getting-started.md
+run "$BIN version --pretty"
+run "$BIN aws ec2 price --instance-type m5.large --region us-east-1 --pretty"
+run "$BIN aws ec2 price --instance-type m5.large --region us-east-1 --jq '.price[0].amount'"
+run "$BIN aws ec2 price --instance-type m5.large --region us-east-1 --preset price"
+run "$BIN compare --kind compute.vm --vcpu 4 --memory 16 --regions us-east --limit 5 --preset compare --pretty"
+run "$BIN estimate --item 'aws/ec2:m5.large:region=us-east-1:count=10:hours=730' --item 'aws/ec2:m5.xlarge:region=us-east-1:count=1:hours=730' --pretty"
+run "$BIN estimate --config docs/examples/workload-vm.yaml --pretty"
+run "cat docs/examples/batch-queries.ndjson | $BIN batch --pretty"
+
+# commands/*.md — representative snippets
+run "$BIN aws ec2 list --instance-type m5.large"
+run "$BIN aws rds price --instance-type db.m5.large --region us-east-1 --engine postgres --deployment-option single-az"
+run "$BIN aws s3 price --storage-class standard --region us-east-1"
+run "$BIN aws lambda price --architecture arm64 --region us-east-1"
+run "$BIN aws ebs price --volume-type gp3 --region us-east-1"
+run "$BIN aws dynamodb price --table-class standard --region us-east-1"
+run "$BIN aws cloudfront price --region eu-west-1"
+run "$BIN azure vm price --arm-sku-name Standard_D2_v3 --region eastus --os linux --preset agent"
+run "$BIN azure sql price --sku-name GP_Gen5_2 --region eastus --deployment-option single-az"
+run "$BIN azure blob price --tier hot --region eastus"
+run "$BIN azure functions price --architecture x86_64 --region eastus"
+run "$BIN azure disks price --disk-type premium-ssd --region eastus"
+run "$BIN gcp gce price --machine-type n1-standard-2 --region us-east1"
+run "$BIN gcp cloud-sql price --tier db-custom-2-7680 --region us-east1 --engine postgres --deployment-option zonal"
+run "$BIN gcp gcs price --storage-class standard --region us-east1"
+run "$BIN gcp run price --architecture x86_64 --region us-east1"
+run "$BIN gcp functions price --architecture x86_64 --region us-east1"
+run "$BIN llm price --model anthropic/claude-opus-4.6 --serving-provider aws-bedrock"
+run "$BIN estimate --item 'aws/s3:standard:region=us-east-1:gb_month=500:put_requests=1000:get_requests=5000' --pretty"
+run "$BIN estimate --item 'llm:anthropic/claude-opus-4.6:input=1M:output=500K:serving_provider=anthropic' --pretty"
+run "$BIN estimate --config docs/examples/workload-llm.yaml --pretty"
+run "$BIN schema --errors"
+run "$BIN schema --list-commands"
+run "$BIN schema --list-serving-providers"
+
+echo "all snippets ok"
+```
+
+Then:
+
+```bash
+chmod +x scripts/verify-docs-snippets.sh
+```
+
+- [ ] **Step 2: Add `docs-verify` Makefile target**
+
+Append to `Makefile` (immediately after the `pypi-wheel-smoke` target — anchor to locate: `pypi-wheel-smoke:`):
+
+```make
+docs-verify: build ## Re-run every verified snippet in docs/getting-started.md + docs/commands/
+	@test -d dist/pipeline || (echo "run 'make openrouter-shard aws-shards azure-shards gcp-shards' first" && exit 2)
+	bash scripts/verify-docs-snippets.sh
+```
+
+- [ ] **Step 3: Run it end to end**
+
+```bash
+make openrouter-shard aws-shards azure-shards gcp-shards
+make docs-verify
+```
+
+Expected: final line `all snippets ok`. Any non-zero exit → a doc snippet diverged from the binary — fix the doc.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/verify-docs-snippets.sh Makefile
+git commit -m "docs(m7.1): scripts/verify-docs-snippets.sh + make docs-verify"
+```
+
+---
+
+### Task 10: Close M7.1 in `CLAUDE.md`
+
+**Files:**
+
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update `## Current milestone`**
+
+Edit `CLAUDE.md`: replace the `## Current milestone` body with:
+
+```markdown
+## Current milestone
+
+M7.1 — Docs foundation: README v1, getting-started, install polish, per-command reference, examples verified by `make docs-verify`.
+Next: M7.2 — Guides and reference (kinds, presets, exit codes, agent-integration, llm-routing, offline-use, `skill/using-sku/SKILL.md`).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "chore(m7.1): close milestone after docs-verify green"
+```
+
+---
+
+## Self-review notes (non-executable)
+
+- **Spec coverage.** §9 M7 exit criterion *"new user installs, queries, updates, batches, estimates within 5 minutes of landing on README"* → Tasks 2 (README) + 3 (getting-started) + 5-8 (commands reference). Worksflows `install`, `query`, `update`, `batch`, `estimate` each have a runnable block in Task 3. `sku update` is only documented (not live-verified) because it requires the real CDN — flagged in Task 3 Step 2. Machine-readable schema exit criterion (agents have documented machine-readable schema) is served by `docs/commands/schema.md` + `sku schema --errors` output, already live per M2.
+- **Out of scope for M7.1, owned by M7.2.** Guide pages (`docs/guides/*.md`), reference pages (`docs/reference/*.md`), and the agent skill file (`skill/using-sku/SKILL.md`). README and getting-started already link to these — links will resolve once M7.2 ships.
+- **Out of scope for all of M7.** Website (`website/`), spec §8, is *not* in the M7 exit criteria sentence. Deferred to v1.1.
+- **Placeholders.** None. Every `bash` snippet is verified by `make docs-verify` in Task 9.
+- **Type consistency.** Flag names match the current `./bin/sku <cmd> --help` surface and the existing CLAUDE.md "Quick path" block.
+- **Risks.** Drift between a copied fixture (`docs/examples/workload-*.yaml`) and the test fixture it was copied from. Mitigation: both paths are exercised by e2e (`cmd/sku/testdata/`) and `make docs-verify` (`docs/examples/`), so either breaking change surfaces immediately.

--- a/docs/superpowers/plans/2026-04-18-m7.2-guides-and-skill.md
+++ b/docs/superpowers/plans/2026-04-18-m7.2-guides-and-skill.md
@@ -1,0 +1,1075 @@
+# M7.2 — Guides, Reference, and Agent Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Back the README and getting-started links from M7.1 with concrete reference pages (`kinds`, `presets`, `exit-codes`) and task-oriented guides (`agent-integration`, `llm-routing`, `offline-use`), then ship a standalone `skill/using-sku/SKILL.md` so Claude Code / Copilot / Gemini agents can load `sku` as a skill.
+
+**Architecture:** Reference pages are faithful cross-copies of the authoritative source (`sku schema --errors`, `internal/compare/kinds/*.go`, spec §5) with *examples*; guides are task-oriented narratives. The agent skill is a self-contained Markdown file keyed to the frontmatter convention used by this repo's other skills (`~/.claude/skills/using-bee/SKILL.md`).
+
+**Tech Stack:** Markdown only. Each reference page has a companion "generate or verify" snippet that reads from the binary or shard so the page stays honest.
+
+**Scope notes:**
+- M7.2 is documentation of *current* surface. No binary changes. A drift between a reference page and the binary means fix the doc, not the binary.
+- `skill/using-sku/SKILL.md` is the user-facing skill file, placed at the repo root in `skill/using-sku/` per spec §8. It may later be installed into `~/.claude/skills/` but that's a user action — this plan only authors the file.
+
+---
+
+## File Structure
+
+- Create: `docs/reference/README.md` — reference index.
+- Create: `docs/reference/kinds.md` — unified kind taxonomy + each kind's shape.
+- Create: `docs/reference/presets.md` — preset field matrix, kind-specific compare projections.
+- Create: `docs/reference/exit-codes.md` — error envelope + per-code details schema.
+- Create: `docs/reference/global-flags.md` — consolidated global-flag reference (pulled out of `docs/commands/README.md` for reuse).
+- Create: `docs/reference/serving-providers.md` — LLM serving-provider list, with the exact filter values.
+- Create: `docs/guides/README.md` — guides index.
+- Create: `docs/guides/agent-integration.md` — calling `sku` from an agent loop (preset, --jq, --fields, exit-code branching, `sku batch`).
+- Create: `docs/guides/llm-routing.md` — picking a model + serving provider by price, including aggregated-row semantics.
+- Create: `docs/guides/offline-use.md` — airgapped bootstrap + manual delta sideload + `sku update --status`.
+- Create: `skill/using-sku/SKILL.md` — standalone agent skill file.
+- Modify: `scripts/verify-docs-snippets.sh` — add snippets from new guides.
+- Modify: `CLAUDE.md` — update `## Current milestone` when M7.2 closes.
+
+---
+
+### Task 1: `docs/reference/README.md` and `docs/reference/global-flags.md`
+
+**Files:**
+
+- Create: `docs/reference/README.md`
+- Create: `docs/reference/global-flags.md`
+
+- [ ] **Step 1: Write `docs/reference/README.md`**
+
+```markdown
+# Reference
+
+Data contracts that automation can depend on.
+
+| Topic | Page |
+|---|---|
+| Kinds (unified schema) | [kinds.md](kinds.md) |
+| Presets (field projections) | [presets.md](presets.md) |
+| Exit codes & error envelope | [exit-codes.md](exit-codes.md) |
+| Global flags | [global-flags.md](global-flags.md) |
+| LLM serving providers | [serving-providers.md](serving-providers.md) |
+
+Every page here is verified against the binary — see `make docs-verify`.
+```
+
+- [ ] **Step 2: Write `docs/reference/global-flags.md`**
+
+````markdown
+# Global flags
+
+Every `sku` command accepts these. Precedence (high → low): **CLI flag > env var > profile value > default**.
+
+| Flag | Env var | Default | Meaning |
+|---|---|---|---|
+| `--profile <name>` | `SKU_PROFILE` | `default` | Named profile from `$SKU_CONFIG_DIR/config.yaml` |
+| `--preset {agent,full,price,compare}` | `SKU_PRESET` | `agent` | Field projection (see [presets.md](presets.md)) |
+| `--json` / `--yaml` / `--toml` | `SKU_FORMAT` | `json` | Output format |
+| `--pretty` | – | off | Indent output |
+| `--jq <expr>` | – | – | Apply a gojq filter to the response body |
+| `--fields <paths>` | – | – | Comma-separated dot-path projection (e.g. `provider,price.0.amount`) |
+| `--include-raw` | – | off | Attach the raw upstream row to each record |
+| `--include-aggregated` | – | off | Include OpenRouter's aggregated synthetic rows |
+| `--stale-ok` | `SKU_STALE_OK` | off | Suppress the stale-catalog warning |
+| `--stale-error-days` (via profile) | `SKU_STALE_ERROR_DAYS` | unset | Escalate stale warning to exit code 8 beyond N days |
+| `--auto-fetch` | – | off | Download missing shards on demand |
+| `--dry-run` | `SKU_DRY_RUN` | off | Print resolved query plan, do not execute |
+| `--verbose` | `SKU_VERBOSE` | off | Emit a JSON log line to stderr |
+| `--no-color` | `NO_COLOR`, `SKU_NO_COLOR` | off | Disable ANSI color in `--pretty` output |
+
+## TOML quirk
+
+TOML forbids top-level arrays. `--toml` wraps any top-level `[]` as `{"rows": [...]}`. Agents that dispatch on format should look under `rows` when parsing TOML output.
+
+## Profile resolution
+
+`$SKU_CONFIG_DIR` default:
+
+| OS | Default |
+|---|---|
+| Linux | `$XDG_CONFIG_HOME/sku/config.yaml` |
+| macOS | `$HOME/Library/Application Support/sku/config.yaml` |
+| Windows | `%APPDATA%\sku\config.yaml` |
+
+Managed via [`sku configure`](../commands/configure.md).
+````
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reference/README.md docs/reference/global-flags.md
+git commit -m "docs(m7.2): reference index + global-flags reference"
+```
+
+---
+
+### Task 2: `docs/reference/kinds.md`
+
+**Files:**
+
+- Create: `docs/reference/kinds.md`
+
+- [ ] **Step 1: Write the page**
+
+```markdown
+# Kinds
+
+The *kind* is the unified type assigned to every SKU at ingest. It is what makes cross-provider `compare` and `search --kind` possible. The authoritative taxonomy and per-kind equivalence rules live in `internal/compare/kinds/*.go`; attribute schemas live in `internal/schema/kinds/`.
+
+## Taxonomy
+
+```
+compute.vm        compute.function       compute.container     compute.kubernetes
+compute.batch
+storage.object    storage.block          storage.file          storage.archive
+db.relational     db.nosql               db.inmemory           db.warehouse
+network.cdn       network.dns            network.loadbalancer
+queue.messaging
+security.secrets  security.kms
+observability.logs   observability.metrics
+llm.text          llm.multimodal         llm.embedding
+llm.image         llm.audio
+```
+
+Not every kind has shipped yet. Query the set your binary recognises:
+
+```bash
+sku schema --list-kinds
+```
+
+## Shards currently contributing rows (v0.1 baseline)
+
+| Kind | Shards |
+|---|---|
+| `compute.vm` | `aws-ec2`, `azure-vm`, `gcp-gce` |
+| `compute.function` | `aws-lambda`, `azure-functions`, `gcp-run`, `gcp-functions` |
+| `storage.object` | `aws-s3`, `azure-blob`, `gcp-gcs` |
+| `storage.block` | `aws-ebs`, `azure-disks` |
+| `db.relational` | `aws-rds`, `azure-sql`, `gcp-cloud-sql` |
+| `db.nosql` | `aws-dynamodb` |
+| `network.cdn` | `aws-cloudfront` |
+| `llm.text` | `openrouter` (70+ serving providers) |
+
+## Per-kind shape (what `compare` sees)
+
+### `compute.vm`
+
+| Field | Source |
+|---|---|
+| `resource.vcpu` | int |
+| `resource.memory_gb` | number |
+| `resource.gpu_count` | int (0 when absent) |
+| `resource.gpu_model` | string (`""` when absent) |
+| `resource.attributes.family` | e.g. `m5`, `n1-standard` |
+
+### `storage.object`
+
+| Field | Source |
+|---|---|
+| `resource.storage_class` | `standard`, `hot`, `cool`, `archive`, … |
+| `resource.durability_nines` | int |
+| `resource.availability_tier` | `standard`, `reduced-redundancy`, … |
+
+### `db.relational`
+
+| Field | Source |
+|---|---|
+| `resource.vcpu`, `resource.memory_gb`, `resource.storage_gb` | numeric |
+| `resource.engine` | `postgres`, `mysql`, `mssql`, … |
+| `resource.deployment_option` | `single-az`, `multi-az`, `zonal`, `regional` |
+
+### `llm.text`
+
+| Field | Source |
+|---|---|
+| `resource.name` | `anthropic/claude-opus-4.6` etc. |
+| `resource.context_length` | int (tokens) |
+| `resource.capabilities` | array of strings (`tool_use`, `vision`, `cache`, …) |
+| `health.uptime_30d`, `health.latency_p95_ms` | OpenRouter uptime telemetry |
+
+## Adding a new kind
+
+New kinds are a binary-version bump (requires registration in `internal/compare/kinds/` and `internal/schema/kinds/`). Tracked in spec §4 *Data/code decoupling*.
+```
+
+- [ ] **Step 2: Verify `sku schema --list-kinds` emits the advertised kinds**
+
+```bash
+./bin/sku schema --list-kinds | jq '.kinds[]' 2>/dev/null | head || echo "binary may not expose --list-kinds yet"
+```
+
+If `--list-kinds` is not yet wired up in the binary, mark the `sku schema --list-kinds` snippet in the page with a note `# planned: see issue #…` — do not block the rest of M7.2 on it. Track as a v1.0 follow-up.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reference/kinds.md
+git commit -m "docs(m7.2): reference/kinds — taxonomy + per-kind shape"
+```
+
+---
+
+### Task 3: `docs/reference/presets.md`
+
+**Files:**
+
+- Create: `docs/reference/presets.md`
+
+- [ ] **Step 1: Write the page**
+
+````markdown
+# Presets
+
+A *preset* is a named field projection applied before rendering. Choose a preset with `--preset` or `profiles.<name>.preset` in config.
+
+| Preset | Kept fields | Typical size | Use case |
+|---|---|---|---|
+| `agent` (default) | `provider`, `service`, `resource.name`, `location.provider_region`, `price`, `terms.commitment` | ~200 B | Agent default — minimum tokens |
+| `price` | `price` only | ~50 B | One-shot "how much" lookups |
+| `full` | Everything + raw (implies `--include-raw`) | 2–10 KB | Human inspection, debugging |
+| `compare` | `provider`, `resource.name`, `price`, `location.normalized_region` + kind-specific columns | ~150 B | Cross-provider rows |
+
+## Kind-specific `compare` columns
+
+The `compare` preset merges additional columns depending on `--kind`:
+
+| Kind | Extra columns |
+|---|---|
+| `compute.vm` | `resource.vcpu`, `resource.memory_gb`, `resource.gpu_count`, `resource.gpu_model` |
+| `storage.object` | `resource.durability_nines`, `resource.availability_tier` |
+| `db.relational` | `resource.vcpu`, `resource.memory_gb`, `resource.storage_gb` |
+| `llm.text` | `resource.context_length`, `resource.capabilities`, `health.uptime_30d`, `health.latency_p95_ms` |
+
+## Composition with `--fields` and `--jq`
+
+Presets apply first; `--fields` and `--jq` apply after. This means `--fields` works on the preset's projected keys:
+
+```bash
+# agent preset + just two keys
+sku aws ec2 price --instance-type m5.large --region us-east-1 \
+  --preset agent --fields resource.name,price.0.amount
+
+# price preset + jq to pull a scalar
+sku aws ec2 price --instance-type m5.large --region us-east-1 \
+  --preset price --jq '.price[0].amount'
+```
+
+## Which preset for which caller
+
+| Caller | Recommended preset |
+|---|---|
+| Interactive terminal use | `full --pretty` |
+| Agent picking one SKU | `agent` (default) |
+| Agent doing math on the amount | `price --jq '.price[0].amount'` |
+| Agent comparing rows | `compare --limit N` |
+| CI budget-diff tooling | `full` (for stable hash across minor revs) |
+
+## Adding a preset
+
+Presets are defined in `internal/output/presets.go`. New preset names become part of the stable CLI contract — adding one is a minor version bump; removing one is major.
+````
+
+- [ ] **Step 2: Verify preset names against the binary**
+
+```bash
+./bin/sku --help | grep -q 'agent | full | price | compare'
+echo "ok"
+```
+
+Expected: `ok`. If the string changes, the page must be updated in lockstep.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reference/presets.md
+git commit -m "docs(m7.2): reference/presets — matrix + kind-specific compare columns"
+```
+
+---
+
+### Task 4: `docs/reference/exit-codes.md`
+
+**Files:**
+
+- Create: `docs/reference/exit-codes.md`
+
+The canonical source for exit codes is `sku schema --errors`. This page mirrors that output, adds the human-friendly context, and shows the envelope.
+
+- [ ] **Step 1: Capture current `sku schema --errors` output for cross-check**
+
+```bash
+./bin/sku schema --errors --pretty
+```
+
+Use that output when filling the table below — if it drifts from what's in this plan, trust the binary and update the doc.
+
+- [ ] **Step 2: Write the page**
+
+````markdown
+# Exit codes & error envelope
+
+Exit codes are a **contract**. Use them to branch in scripts and agents.
+
+## Codes
+
+| Exit | Code | Meaning |
+|---|---|---|
+| `0` | — | success |
+| `1` | `generic_error` | unclassified; fall back to `error.message` |
+| `2` | `auth` | CI-only: credential failure |
+| `3` | `not_found` | no SKU matches filters |
+| `4` | `validation` | input failed validation (see `reason`) |
+| `5` | `rate_limited` | upstream rate limit (CDN or ingest) |
+| `6` | `conflict` | state conflict (e.g. delta already applied) |
+| `7` | `server` | upstream CDN or pricing API 5xx |
+| `8` | `stale_data` | catalog older than the threshold and `--stale-ok` was not set |
+
+Query the machine-readable catalog any time:
+
+```bash
+sku schema --errors --pretty
+```
+
+## Envelope (stderr)
+
+All errors emit a single-line JSON object on **stderr**; stdout stays empty:
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "No SKU matches filters",
+    "suggestion": "Try `sku schema aws ec2` to see valid filters",
+    "details": {
+      "provider": "aws",
+      "service": "ec2",
+      "applied_filters": {"instance_type": "m5.huge", "region": "us-east-1"},
+      "nearest_matches": ["m5.large", "m5.xlarge"]
+    }
+  }
+}
+```
+
+## Per-code `details` shape
+
+Agents can branch on `error.details` — the shape is stable within a major version.
+
+| `code` | `details` keys |
+|---|---|
+| `not_found` | `provider`, `service`, `applied_filters`, `nearest_matches?` |
+| `validation` | `reason`, `flag?`, `value?`, `allowed?`, `shard?`, `required_binary_version?`, `hint?` |
+| `auth` | `resource` (never credential material) |
+| `rate_limited` | `retry_after_ms` |
+| `conflict` | `shard`, `current_head_version`, `expected_from`, `operation` |
+| `server` | `upstream`, `status_code?`, `correlation_id?` |
+| `stale_data` | `shard`, `last_updated`, `age_days`, `threshold_days` |
+| `generic_error` | free-form; agents should use `error.message` |
+
+`validation.reason` is one of: `flag_invalid`, `binary_too_old`, `binary_too_new`, `shard_too_old`, `shard_too_new`.
+
+## Aggregated exit (sku batch)
+
+`sku batch` rolls individual per-op exits into one process exit code using a severity rank (high to low):
+
+```
+validation > server > conflict > rate_limited > auth > not_found > stale_data > ok
+```
+
+Every individual result is still present in the JSON array on stdout, with its own `exit_code` field.
+
+## Branching example (bash)
+
+```bash
+sku aws ec2 price --instance-type "$T" --region "$R"
+case $? in
+  0) ;;                                   # got it
+  3) echo "no such instance type" ;;      # not_found
+  4) echo "bad flag or shard skew" ;;     # validation
+  8) echo "catalog stale — run sku update" ;;
+  *) echo "other failure" ;;
+esac
+```
+
+## Branching example (Python)
+
+```python
+import json, subprocess
+p = subprocess.run(
+    ["sku", "aws", "ec2", "price", "--instance-type", t, "--region", r],
+    capture_output=True,
+)
+if p.returncode == 0:
+    data = json.loads(p.stdout)
+elif p.returncode == 3:
+    err = json.loads(p.stderr)
+    hints = err["error"]["details"].get("nearest_matches", [])
+    ...
+```
+````
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reference/exit-codes.md
+git commit -m "docs(m7.2): reference/exit-codes — stable contract + envelope shape"
+```
+
+---
+
+### Task 5: `docs/reference/serving-providers.md`
+
+**Files:**
+
+- Create: `docs/reference/serving-providers.md`
+
+- [ ] **Step 1: Write the page**
+
+````markdown
+# LLM serving providers
+
+The `openrouter` shard carries prices for 70+ *serving providers* — the entity that actually serves a model to you, not the model's author. Filter and view semantics are in [`../commands/llm.md`](../commands/llm.md).
+
+## Getting the live list
+
+The shard's `metadata.serving_providers` row is the source of truth. Query it any time:
+
+```bash
+sku update openrouter        # if not installed
+sku schema --list-serving-providers
+```
+
+Returns `{"serving_providers": ["anthropic", "aws-bedrock", "azure-openai", "gcp-vertex", "openai", "openrouter", ...]}`.
+
+## Top-level subcommands vs `--serving-provider`
+
+A handful of serving providers have dedicated top-level subcommands for ergonomics. These are **static**; newly appearing serving providers work via `--serving-provider` immediately, but a dedicated subcommand requires a binary release.
+
+| Subcommand | Valid from | `--serving-provider` equivalent |
+|---|---|---|
+| `sku anthropic llm price` | v0.1.0 | `--serving-provider anthropic` |
+| `sku openai llm price` | v0.1.0 | `--serving-provider openai` |
+| `sku aws-bedrock llm price` | v0.1.0 | `--serving-provider aws-bedrock` |
+| `sku gcp-vertex llm price` | v0.1.0 | `--serving-provider gcp-vertex` |
+| `sku azure-openai llm price` | v0.1.0 | `--serving-provider azure-openai` |
+| `sku openrouter llm price` | v0.1.0 | returns **only** aggregated rows |
+
+## Aggregated-row semantics
+
+OpenRouter publishes a synthetic *aggregated* row per model representing its own routed rate. These rows are excluded by default from `sku llm price`, `sku llm list`, `sku llm compare`, and `sku compare --kind llm.text` so `min(price)` queries are honest.
+
+Include them one of two ways:
+
+```bash
+sku --include-aggregated llm price --model anthropic/claude-opus-4.6
+sku openrouter llm price          --model anthropic/claude-opus-4.6
+```
+
+Aggregated rows carry `resource.attributes.aggregated = true`.
+
+## Validation source
+
+The daily validation harness (spec §6) cross-checks OpenRouter's reported Bedrock / Vertex / Azure-OpenAI rates against the matching cloud pricing APIs at a 1% tolerance. Drift fails the release and auto-files `llm-rate-mismatch: <serving-provider>/<model>`.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/reference/serving-providers.md
+git commit -m "docs(m7.2): reference/serving-providers — list, subcommand vs flag, aggregated semantics"
+```
+
+---
+
+### Task 6: `docs/guides/README.md` + `docs/guides/agent-integration.md`
+
+**Files:**
+
+- Create: `docs/guides/README.md`
+- Create: `docs/guides/agent-integration.md`
+
+- [ ] **Step 1: Write `docs/guides/README.md`**
+
+```markdown
+# Guides
+
+Task-oriented walkthroughs. Every snippet runs against the shipping binary.
+
+| Guide | Page |
+|---|---|
+| Calling sku from an agent | [agent-integration.md](agent-integration.md) |
+| LLM routing by price | [llm-routing.md](llm-routing.md) |
+| Offline / airgapped use | [offline-use.md](offline-use.md) |
+
+For CLI syntax, see [`../commands/`](../commands/).
+For contracts (kinds, presets, exit codes), see [`../reference/`](../reference/).
+```
+
+- [ ] **Step 2: Write `docs/guides/agent-integration.md`**
+
+````markdown
+# Calling sku from an agent
+
+`sku` is built for agent loops. This guide covers the four moves that pay off the most.
+
+## 1. Start with `agent` preset
+
+`agent` is the default — but if you've aliased `sku` through a profile that bumped `preset=full`, force it back:
+
+```bash
+sku --preset agent aws ec2 price --instance-type m5.large --region us-east-1
+```
+
+Output is ~200 bytes, JSON, with the minimum fields an agent needs: `provider`, `service`, `resource.name`, `location.provider_region`, `price`, `terms.commitment`.
+
+## 2. Project aggressively
+
+Agents rarely need the full record. Two tools do the same job with different ergonomics:
+
+```bash
+# --fields: declarative dot-path projection. Order preserved.
+sku aws ec2 price --instance-type m5.large --region us-east-1 \
+  --fields provider,resource.name,price.0.amount
+
+# --jq: full gojq expression. Use when you need computation.
+sku aws ec2 price --instance-type m5.large --region us-east-1 \
+  --jq '{type: .resource.name, usd_hr: .price[0].amount}'
+```
+
+Combine both: `--fields` runs first, then `--jq` operates on the reduced tree.
+
+## 3. Branch on exit code, parse stderr for details
+
+Exit code is a cheap branch. Only parse stderr when you need the structured detail:
+
+```bash
+if out=$(sku aws ec2 price --instance-type "$T" --region "$R" 2>err.json); then
+  amount=$(echo "$out" | jq -r '.price[0].amount')
+else
+  case $? in
+    3) nearest=$(jq -r '.error.details.nearest_matches // [] | join(",")' err.json) ;;
+    4) reason=$(jq -r '.error.details.reason' err.json) ;;
+    8) echo "shard stale" ;;
+    *) echo "unhandled"; cat err.json ;;
+  esac
+fi
+```
+
+Full exit-code table: [`../reference/exit-codes.md`](../reference/exit-codes.md).
+
+## 4. Collapse N lookups into one `sku batch`
+
+In-process dispatch. No shell-fork-per-op. No startup amortisation tricks.
+
+```bash
+cat <<'EOF' | sku batch --pretty
+{"command":"aws ec2 price","args":{"instance_type":"m5.large","region":"us-east-1"}}
+{"command":"aws ec2 price","args":{"instance_type":"m5.xlarge","region":"us-east-1"}}
+{"command":"llm price","args":{"model":"anthropic/claude-opus-4.6"}}
+EOF
+```
+
+Output is a JSON array with each op's own `exit_code` + body; the **process** exit is the aggregated worst-case (see [exit-codes.md](../reference/exit-codes.md)).
+
+Discover the exact `command` strings `batch` accepts:
+
+```bash
+sku schema --list-commands
+```
+
+## 5. Avoid implicit auto-fetch in agent flows
+
+`--auto-fetch` is a convenience for humans. In an agent loop, prefer the deterministic two-step:
+
+```bash
+sku update --status --pretty | jq -e '.shards[] | select(.name=="aws-ec2" and .installed==false)' >/dev/null \
+  && sku update aws-ec2
+sku aws ec2 price --instance-type m5.large --region us-east-1
+```
+
+This keeps shard fetches (slow, network) out of the hot path and explicit in the agent's trace.
+
+## 6. Profile your caller
+
+Stamp one profile per agent persona:
+
+```bash
+sku configure --profile copilot \
+  --set preset=agent \
+  --set stale_warning_days=14 \
+  --set auto_fetch=false
+```
+
+Then invoke with `--profile copilot` or `SKU_PROFILE=copilot`. Keeps the CLI invocation short and behaviour reproducible.
+````
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/guides/README.md docs/guides/agent-integration.md
+git commit -m "docs(m7.2): guides index + agent-integration"
+```
+
+---
+
+### Task 7: `docs/guides/llm-routing.md`
+
+**Files:**
+
+- Create: `docs/guides/llm-routing.md`
+
+- [ ] **Step 1: Write the guide**
+
+````markdown
+# LLM routing by price
+
+`sku`'s LLM data is uniform across 70+ serving providers, so you can answer "what is the cheapest way to run model X?" with one command.
+
+## Cheapest serving provider for a model
+
+```bash
+sku llm compare --model anthropic/claude-opus-4.6 --preset compare --pretty
+```
+
+Expected: sorted list of serving providers that carry that model, cheapest first. Aggregated OpenRouter rows are **excluded** by default (see [serving-providers.md](../reference/serving-providers.md)).
+
+Pick just the winner:
+
+```bash
+sku llm compare --model anthropic/claude-opus-4.6 \
+  --jq '[.[] | select(.resource.attributes.aggregated != true)] | sort_by(.price[0].amount)[0]'
+```
+
+## Cheapest model for a budget
+
+```bash
+sku llm list --max-input-price 1.0 --max-output-price 5.0 --preset agent --sort input-price
+```
+
+Prices are USD per **million tokens** for `llm.text`. `--max-input-price 1.0` means ≤ \$1/M input tokens.
+
+## Capability-filtered routing
+
+```bash
+sku llm list --capability tool_use --capability vision \
+  --max-input-price 3.0 --preset agent --sort input-price
+```
+
+Capabilities are enumerated in each model's `resource.capabilities` array.
+
+## Cost for a specific workload
+
+Use `estimate`:
+
+```bash
+sku estimate \
+  --item 'llm:anthropic/claude-opus-4.6:input=1M:output=500K:serving_provider=aws-bedrock' \
+  --pretty
+```
+
+Or from YAML:
+
+```bash
+sku estimate --config docs/examples/workload-llm.yaml --pretty
+```
+
+## Why price alone isn't enough
+
+Three second-order factors, all present in the `llm.text` rows:
+
+| Column | Meaning |
+|---|---|
+| `health.uptime_30d` | Serving provider's availability over the last 30d |
+| `health.latency_p95_ms` | P95 first-token latency (ms) |
+| `resource.context_length` | Hard context window |
+
+Route on a composite that weighs price + uptime + latency:
+
+```bash
+sku llm compare --model anthropic/claude-opus-4.6 \
+  --jq '[.[] | select(.resource.attributes.aggregated != true)]
+        | map(. + {score: (.price[0].amount - .health.uptime_30d*0.01 + .health.latency_p95_ms*0.0001)})
+        | sort_by(.score)[0]'
+```
+
+(Example scoring — tune weights to your SLO.)
+
+## Aggregated OpenRouter row
+
+OpenRouter publishes a synthetic *aggregated* rate across all its endpoints for a given model. To see it:
+
+```bash
+sku openrouter llm price --model anthropic/claude-opus-4.6        # only aggregated rows
+sku --include-aggregated llm compare --model anthropic/claude-opus-4.6
+```
+
+For most routing decisions you want the **concrete** serving providers, not the aggregated row (the aggregated row is not a real endpoint you can call).
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/guides/llm-routing.md
+git commit -m "docs(m7.2): guides/llm-routing — cheapest model+provider, budget+capability filters"
+```
+
+---
+
+### Task 8: `docs/guides/offline-use.md`
+
+**Files:**
+
+- Create: `docs/guides/offline-use.md`
+
+- [ ] **Step 1: Write the guide**
+
+````markdown
+# Offline & airgapped use
+
+The binary is offline-first. The only network call is `sku update`, fetching pricing data from the CDN. Everything else — `price`, `search`, `compare`, `estimate`, `batch` — reads from local SQLite shards.
+
+## Data directory
+
+Default layout:
+
+| OS | `$SKU_DATA_DIR` default |
+|---|---|
+| Linux | `$XDG_DATA_HOME/sku` (typically `~/.local/share/sku`) |
+| macOS | `$HOME/Library/Application Support/sku` |
+| Windows | `%APPDATA%\sku` |
+
+Layout:
+
+```
+$SKU_DATA_DIR/
+  manifest.json         # what's installed, last-updated, head versions
+  openrouter.db
+  aws-ec2.db
+  aws-rds.db
+  ...
+```
+
+## Seeding in an airgap
+
+The shards are ordinary SQLite files. To install them on a host without CDN access:
+
+1. On a connected host:
+
+   ```bash
+   sku update openrouter aws-ec2
+   tar czf sku-bundle.tgz -C "$SKU_DATA_DIR" manifest.json openrouter.db aws-ec2.db
+   ```
+
+2. Transfer `sku-bundle.tgz` to the airgapped host.
+
+3. On the airgapped host:
+
+   ```bash
+   mkdir -p "${SKU_DATA_DIR:-$HOME/.local/share/sku}"
+   tar xzf sku-bundle.tgz -C "${SKU_DATA_DIR:-$HOME/.local/share/sku}"
+   sku update --status --pretty
+   ```
+
+Expected: each shard listed with `installed: true` and the date it was fetched. Subsequent lookups work offline.
+
+## Disabling network entirely
+
+There is no opt-in "go online" flag. The *only* command that makes a network call is `sku update`. If your agent never runs `sku update`, the binary never talks to the network.
+
+For defense-in-depth, block egress to the known CDN hosts:
+
+```
+jsdelivr.net
+gh-release-assets (varies; use allow-list rather than deny)
+```
+
+## `--stale-ok` and `stale_error_days`
+
+By default the binary warns when a shard hasn't been updated in 14 days. Suppress the warning:
+
+```bash
+sku --stale-ok aws ec2 price ...
+SKU_STALE_OK=1 sku aws ec2 price ...
+```
+
+To **fail** (exit code 8) when shards get too stale, set a `stale_error_days` on a profile:
+
+```bash
+sku configure --profile ci \
+  --set stale_warning_days=3 \
+  --set stale_error_days=7
+SKU_PROFILE=ci sku aws ec2 price ...
+```
+
+## Verifying a bundle
+
+Bundle tarballs carry whatever signatures you add outside `sku` — it does not sign data shards itself. The CDN serves shards through jsDelivr; releases of the binary are cosign-signed separately (see [install.md](../install.md)).
+
+## CI patterns
+
+- **Deterministic**: turn off `auto_fetch`; fail fast if a shard is missing.
+
+  ```bash
+  sku configure --profile ci --set auto_fetch=false --set preset=price
+  ```
+
+- **Hermetic**: cache `$SKU_DATA_DIR` in your CI cache key; keyed on `sku version | jq -r '.version'` + a pinned data-release tag so the cache invalidates on either a binary upgrade or a deliberate data bump.
+
+- **Audit**: `sku --verbose <cmd>` emits one JSON log line per operation on stderr (shard read, delta apply, preset applied). Pipe to your log sink.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/guides/offline-use.md
+git commit -m "docs(m7.2): guides/offline-use — airgapped bootstrap, stale policy, CI patterns"
+```
+
+---
+
+### Task 9: `skill/using-sku/SKILL.md`
+
+**Files:**
+
+- Create: `skill/using-sku/SKILL.md`
+
+The skill file is the thing an agent framework loads — a short, self-contained guide with a frontmatter description the framework can dispatch on. The format below matches the pattern used by `~/.claude/skills/using-bee/SKILL.md` in this user's global config.
+
+- [ ] **Step 1: Write the skill**
+
+```markdown
+---
+name: using-sku
+description: Use when the agent needs cloud or LLM pricing — AWS, Azure, GCP, or LLM models across 70+ serving providers. Covers point lookups, cross-provider compare, workload cost estimation, and batch multi-op queries. The CLI is offline-first (daily-updated local SQLite shards) and agent-shaped (JSON everywhere, semantic exit codes, field-projection presets).
+---
+
+# Using sku
+
+`sku` is a pure-Go CLI that answers "what does this cost?" for AWS, Azure, GCP, and LLM serving providers. It is designed for agents: JSON output, semantic exit codes, presets that project to ~200 bytes per record.
+
+## Check availability
+
+```bash
+sku version --pretty
+```
+
+If `sku` is not installed, direct the user to [install.md](../../docs/install.md) (`brew install sofq/tap/sku`, `npx @sofq/sku`, `pipx install sku-cli`, `scoop install sku`, `docker pull ghcr.io/sofq/sku`).
+
+## First-run bootstrap
+
+`sku` is offline — pricing data ships as daily-updated SQLite shards fetched by `sku update`.
+
+```bash
+# Install the shards you need; pick from:
+# openrouter aws-ec2 aws-rds aws-s3 aws-lambda aws-ebs aws-dynamodb aws-cloudfront
+# azure-vm azure-sql azure-blob azure-functions azure-disks
+# gcp-gce gcp-cloud-sql gcp-gcs gcp-run gcp-functions
+sku update openrouter aws-ec2
+```
+
+## Core verbs
+
+### Point lookup
+
+```bash
+sku aws ec2 price   --instance-type m5.large --region us-east-1 --preset agent
+sku azure vm price  --arm-sku-name Standard_D2_v3 --region eastus --os linux
+sku gcp gce price   --machine-type n1-standard-2 --region us-east1
+sku llm price       --model anthropic/claude-opus-4.6 --serving-provider aws-bedrock
+```
+
+### Cross-provider compare
+
+```bash
+sku compare --kind compute.vm --vcpu 4 --memory 16 --regions us-east --limit 5 --preset compare
+sku llm compare --model anthropic/claude-opus-4.6 --preset compare
+```
+
+### Search within one shard
+
+```bash
+sku search --provider aws --service ec2 --min-vcpu 4 --max-price 0.10 --sort price --limit 5
+```
+
+### Estimate workload cost
+
+```bash
+sku estimate --item 'aws/ec2:m5.large:region=us-east-1:count=10:hours=730' --pretty
+sku estimate --item 'llm:anthropic/claude-opus-4.6:input=1M:output=500K:serving_provider=aws-bedrock' --pretty
+```
+
+### Batch many ops in-process
+
+```bash
+cat <<'EOF' | sku batch
+{"command":"aws ec2 price","args":{"instance_type":"m5.large","region":"us-east-1"}}
+{"command":"llm price","args":{"model":"anthropic/claude-opus-4.6"}}
+EOF
+```
+
+## Agent-shape flags (apply globally)
+
+| Flag | Purpose |
+|---|---|
+| `--preset agent` (default) | ~200 B record — best default |
+| `--preset price` | `price[]` only — lowest-token lookups |
+| `--jq '<expr>'` | gojq filter on the response |
+| `--fields a,b.c` | dot-path projection |
+| `--pretty` | indent (interactive use only) |
+| `--include-aggregated` | include OpenRouter synthetic rows (normally excluded) |
+
+## Exit codes are a contract
+
+| Exit | Meaning |
+|---|---|
+| `0` | ok |
+| `3` | not_found (see `error.details.nearest_matches`) |
+| `4` | validation (see `error.details.reason`) |
+| `8` | stale_data (run `sku update`, or pass `--stale-ok`) |
+
+Full taxonomy: `sku schema --errors`.
+
+## Discovery
+
+Agents should introspect rather than guess:
+
+```bash
+sku schema --errors                  # error-code catalog
+sku schema --list-commands           # commands accepted by `sku batch`
+sku schema --list-serving-providers  # LLM serving providers in the shard
+```
+
+## Common agent patterns
+
+### "Cheapest cloud VM that fits N cores / M GB"
+
+```bash
+sku compare --kind compute.vm --vcpu N --memory M --regions us-east --limit 1 \
+  --preset compare --jq '.[0]'
+```
+
+### "Cheapest way to serve a given LLM"
+
+```bash
+sku llm compare --model "$MODEL" \
+  --jq '[.[] | select(.resource.attributes.aggregated != true)]
+        | sort_by(.price[0].amount)[0]'
+```
+
+### "Budget check before committing to an architecture"
+
+```bash
+sku estimate --config <workload.yaml> --pretty
+```
+
+## Guardrails
+
+- **Do not pass `--auto-fetch` inside tight loops.** It can cause a CDN fetch mid-query. Prefer an explicit `sku update` up front.
+- **Aggregated OpenRouter rows** (`resource.attributes.aggregated = true`) are not real endpoints; exclude them with `--include-aggregated` off (the default).
+- **Sku never reaches provider APIs**; do not prompt the user for cloud credentials in order to query pricing.
+
+## When to stop and tell the user
+
+- `sku version` fails → tell the user to install `sku`.
+- `sku update` fails with exit 4 (`shard_too_new` / `binary_too_old`) → tell the user to upgrade `sku`.
+- `sku update` fails with exit 7 → CDN upstream issue; retry in a few minutes.
+- Exit code 8 with `--stale-ok` already set → data is stale beyond your configured `stale_error_days` — tell the user.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+mkdir -p skill/using-sku
+git add skill/using-sku/SKILL.md
+git commit -m "docs(m7.2): skill/using-sku/SKILL.md — standalone agent skill file"
+```
+
+---
+
+### Task 10: Extend `scripts/verify-docs-snippets.sh` with guide snippets
+
+**Files:**
+
+- Modify: `scripts/verify-docs-snippets.sh`
+
+- [ ] **Step 1: Append guide snippets to the verify script**
+
+Open `scripts/verify-docs-snippets.sh` and add, immediately before the final `echo "all snippets ok"` line:
+
+```bash
+# guides/agent-integration.md
+run "$BIN --preset agent aws ec2 price --instance-type m5.large --region us-east-1"
+run "$BIN aws ec2 price --instance-type m5.large --region us-east-1 --fields provider,resource.name,price.0.amount"
+run "$BIN aws ec2 price --instance-type m5.large --region us-east-1 --jq '{type: .resource.name, usd_hr: .price[0].amount}'"
+
+# guides/llm-routing.md
+run "$BIN llm compare --model anthropic/claude-opus-4.6 --preset compare --pretty"
+run "$BIN llm list --max-input-price 1.0 --max-output-price 5.0 --preset agent --sort input-price || true"   # --max-*-price flags only exist once wired, see issue
+run "$BIN estimate --item 'llm:anthropic/claude-opus-4.6:input=1M:output=500K:serving_provider=aws-bedrock' --pretty"
+
+# guides/offline-use.md
+run "$BIN --stale-ok aws ec2 price --instance-type m5.large --region us-east-1"
+
+# skill/using-sku/SKILL.md
+run "$BIN version --pretty"
+run "$BIN search --provider aws --service ec2 --min-vcpu 4 --max-price 0.10 --sort price --limit 5"
+```
+
+The `|| true` on `--max-input-price` tolerates the flag not being wired yet — do not fail the verify step on absent-but-documented LLM filters. Track their implementation as a v1.0 follow-up and flip off the tolerance once wired.
+
+- [ ] **Step 2: Run the full script**
+
+```bash
+make build
+make openrouter-shard aws-shards azure-shards gcp-shards
+make docs-verify
+```
+
+Expected: `all snippets ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/verify-docs-snippets.sh
+git commit -m "docs(m7.2): extend verify-docs-snippets.sh with guide + skill snippets"
+```
+
+---
+
+### Task 11: Close M7.2 in `CLAUDE.md`
+
+**Files:**
+
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update `## Current milestone`**
+
+Replace the block body with:
+
+```markdown
+## Current milestone
+
+M7.2 — Guides, reference, agent skill: all docs/guides/*, docs/reference/*, and skill/using-sku/SKILL.md published. `make docs-verify` green.
+Next: M7.3 — Security, bench regression gate, v1.0.0 release.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "chore(m7.2): close milestone after docs-verify green"
+```
+
+---
+
+## Self-review notes (non-executable)
+
+- **Spec coverage.** §9 M7 *"guides, kinds, presets, exit codes, agent-integration, llm-routing, offline-use"* → Tasks 2-8. `skill/using-sku/SKILL.md` → Task 9. Spec §4 *Presets*, §4 *Error envelope*, §5 *Kind taxonomy*, §3 *Update flow* (offline-use implications) are each mirrored into a reference or guide page.
+- **Website** (spec §8 layout) is **deferred to v1.1** — not in the M7 exit criteria sentence. Recording this here so it does not block v1.0.0.
+- **Placeholders.** One tolerated in Task 10 (`--max-input-price` flag) because `sku llm list` price-range flags may not be wired in v0.1.0. Tracked as a v1.0 follow-up issue; if wired in time, remove the `|| true`.
+- **Type consistency.** Preset names (`agent`, `full`, `price`, `compare`), exit codes (`0..8`), and kind identifiers match `sku schema --errors`, `sku --help`, and `internal/compare/kinds/`.
+- **Out of scope.** `SECURITY.md`, `CODE_OF_CONDUCT.md`, govulncheck workflow, bench regression gate, CHANGELOG v1.0 entry, and the `v1.0.0` tag — all in M7.3.
+- **Risks.** (1) `sku schema --list-kinds` and `sku schema --list-shards` may not be wired in v0.1.0 — the reference pages reference them. Mitigation: Task 2 includes a fallback note; the reference page entries become live once the flag ships (binary-only change, no doc rewrite). (2) `sku llm list --max-input-price` similar risk, flagged in Task 10.

--- a/docs/superpowers/plans/2026-04-18-m7.3-security-bench-release.md
+++ b/docs/superpowers/plans/2026-04-18-m7.3-security-bench-release.md
@@ -1,0 +1,760 @@
+# M7.3 — Security, Bench Regression Gate, v1.0 Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Satisfy the last three spec §9 M7 items — `SECURITY.md` + `govulncheck` clean, bench baseline + CI regression gate, and a tagged `v1.0.0` release — and wire `make docs-verify` (authored in M7.1) into CI so docs can no longer rot silently.
+
+**Architecture:** Add one new workflow (`.github/workflows/security.yml`) that runs govulncheck + CodeQL weekly and on-demand. Add a `.github/workflows/bench.yml` regression gate that diffs PR bench output vs a committed `bench/baseline.txt` using `benchstat`. Author `SECURITY.md` + `CODE_OF_CONDUCT.md` at the repo root. Extend `ci.yml` with one new `docs` job that runs `make docs-verify`. Finally, bump `CHANGELOG.md` to a `v1.0.0` entry and gate the tag push on the same human-confirmation rules as M6 Task 9.
+
+**Tech Stack:** GitHub Actions, `golang.org/x/vuln/cmd/govulncheck`, `perf/cmd/benchstat` (from `golang.org/x/perf`), CodeQL Action v3. No new Go runtime dependencies.
+
+**Scope notes:**
+- `govulncheck clean` per spec means "no open findings today and a weekly job to catch new ones" — not a promise of permanent zero. The workflow enforces the weekly scan; a one-time snapshot of current findings is triaged and either suppressed with a documented waiver or fixed.
+- The bench regression gate uses the `benchstat` 15% threshold from spec §6. Baseline is a committed `bench/baseline.txt` generated on `main`; PRs compare against it.
+- The `v1.0.0` tag push is **gated on user confirmation**, matching the M6 Task 9 Step 4 pattern. Do not auto-push the tag.
+
+---
+
+## File Structure
+
+- Create: `SECURITY.md` — vulnerability reporting process.
+- Create: `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1.
+- Create: `.github/workflows/security.yml` — weekly govulncheck + CodeQL + dependency audit.
+- Create: `.github/workflows/bench.yml` — PR benchstat regression gate (15%).
+- Create: `bench/baseline.txt` — committed baseline benchstat output from `main`.
+- Create: `bench/README.md` — how to regenerate the baseline + why.
+- Create: `scripts/update-bench-baseline.sh` — regenerate + commit the baseline.
+- Modify: `.github/workflows/ci.yml` — add `docs` job running `make docs-verify`.
+- Modify: `Makefile` — add `bench-baseline`, `bench-diff`, and `govulncheck` targets.
+- Modify: `CHANGELOG.md` — prepend `v1.0.0` entry.
+- Modify: `CLAUDE.md` — update `## Current milestone` block.
+- Tag: `v1.0.0` (last, and only after the user confirms).
+
+---
+
+### Task 1: `SECURITY.md`
+
+**Files:**
+
+- Create: `SECURITY.md`
+
+- [ ] **Step 1: Write the file**
+
+```markdown
+# Security Policy
+
+## Supported versions
+
+| Version | Support |
+|---|---|
+| `1.x` (latest minor) | Security fixes within 7 days |
+| `1.x` (previous minor) | Security fixes within 30 days |
+| `< 1.0` | No support — please upgrade |
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for a suspected vulnerability.
+
+Report privately via either:
+
+1. GitHub private vulnerability reports — <https://github.com/sofq/sku/security/advisories/new>, or
+2. Email — `security@sofq.dev` (PGP key fingerprint fetched from <https://sofq.dev/.well-known/security.asc>).
+
+Include:
+
+- A description of the issue and its impact.
+- Reproduction steps or a proof of concept.
+- The affected `sku` version (`sku version`) and host OS/arch.
+- Your preferred credit name for any advisory.
+
+We acknowledge reports within 3 business days and aim to publish a fix + advisory within 30 days of confirmation.
+
+## What's in scope
+
+- The `sku` binary and the `@sofq/sku` / `sku-cli` wrappers.
+- The `ghcr.io/sofq/sku` container image.
+- The pricing data pipeline insofar as it could ship malicious data to clients.
+
+## What's out of scope
+
+- Third-party `brew` / `scoop` / `npm` / `pipx` infrastructure outages.
+- Denial of service against the JsDelivr CDN.
+- Known TLS/certificate issues on upstream provider APIs (report to the provider).
+- Vulnerabilities requiring physical access to a user's machine.
+
+## Supply-chain guarantees
+
+Every release ships:
+
+- A cosign keyless signature on `checksums.txt` (OIDC issuer `token.actions.githubusercontent.com`).
+- A syft SBOM in SPDX format attached to each archive.
+- SLSA L3 build-provenance attestations verifiable with `gh attestation verify`.
+
+See [docs/install.md](docs/install.md) for step-by-step verification commands.
+
+## Hardening defaults
+
+- The binary never reads provider credentials. It cannot exfiltrate cloud credentials because it does not accept them.
+- The only network call is `sku update`, which pulls from jsDelivr-cached GitHub Release assets. No telemetry, no analytics.
+- The container image runs as UID 65534.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add SECURITY.md
+git commit -m "docs(m7.3): SECURITY.md — vulnerability reporting, scope, supply-chain guarantees"
+```
+
+---
+
+### Task 2: `CODE_OF_CONDUCT.md`
+
+**Files:**
+
+- Create: `CODE_OF_CONDUCT.md`
+
+- [ ] **Step 1: Write the file**
+
+Use Contributor Covenant v2.1 verbatim. Fetch it from <https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md> and replace `[INSERT CONTACT METHOD]` with `conduct@sofq.dev`.
+
+If offline, paste the canonical text (it is CC BY 4.0, attribution retained in the trailer as the covenant requires). Commit unmodified except for the contact line.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CODE_OF_CONDUCT.md
+git commit -m "docs(m7.3): CODE_OF_CONDUCT.md — Contributor Covenant 2.1"
+```
+
+---
+
+### Task 3: `govulncheck` — Makefile target + current findings triage
+
+**Files:**
+
+- Modify: `Makefile`
+
+- [ ] **Step 1: Add a `govulncheck` Make target**
+
+Append (anchor: immediately after the `docs-verify:` target):
+
+```make
+govulncheck: ## Run govulncheck against the module
+	$(GO) run golang.org/x/vuln/cmd/govulncheck@latest ./...
+```
+
+- [ ] **Step 2: Run it locally and triage findings**
+
+```bash
+make govulncheck
+```
+
+Handle the output:
+
+- **No findings**: pass through to Step 3.
+- **Findings in a stdlib call path**: fix by bumping Go toolchain pin (`go.mod` `go` directive) and/or setting `go_version` in CI. Commit as `chore(m7.3): bump go toolchain for govulncheck clean`.
+- **Findings in a dependency**: `go get module@<fixed-version>` + `go mod tidy` + `make test`. Commit as `chore(m7.3): bump <module> for CVE-<id>`.
+- **False positives** (symbol in the module but not reachable): document in a new `docs/security/vuln-waivers.md` with date + CVE-id + justification. Re-run `govulncheck` with the matching `-skipwaiver` filter once the action supports it; until then, comment in the workflow's failure output.
+
+Iterate until `make govulncheck` exits 0.
+
+- [ ] **Step 3: Commit the Makefile change**
+
+```bash
+git add Makefile
+git commit -m "chore(m7.3): make govulncheck target"
+```
+
+(Any dependency bump commits from Step 2 land separately with their own messages.)
+
+---
+
+### Task 4: `.github/workflows/security.yml`
+
+**Files:**
+
+- Create: `.github/workflows/security.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: security
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"   # Mondays 06:17 UTC
+  push:
+    branches: [main]
+    paths:
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/security.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck ./...
+
+  codeql:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: go
+      - name: Build
+        run: go build ./...
+      - uses: github/codeql-action/analyze@v3
+
+  dependency-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - name: Verify module sums
+        run: go mod verify
+      - name: Check for tidy drift
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+```
+
+- [ ] **Step 2: Validate the workflow file**
+
+```bash
+# YAML syntax check via actionlint if available; otherwise python
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/security.yml'))"
+```
+
+Expected exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/security.yml
+git commit -m "feat(m7.3): .github/workflows/security.yml — weekly govulncheck + CodeQL + tidy guard"
+```
+
+---
+
+### Task 5: Bench regression gate — baseline + script
+
+**Files:**
+
+- Create: `bench/baseline.txt`
+- Create: `bench/README.md`
+- Create: `scripts/update-bench-baseline.sh`
+- Modify: `Makefile`
+
+Rationale: spec §6 specifies "benchstat fails PR if any key bench >15% worse vs `main` baseline". Implementation: commit a baseline produced on `main` into `bench/baseline.txt`; PR CI runs the same benches and compares.
+
+- [ ] **Step 1: Add Make targets for benchstat usage**
+
+Append (after the `bench:` target already in the Makefile):
+
+```make
+bench-baseline: ## Write a current baseline benchstat to bench/baseline.txt (run on main only)
+	@test -f dist/pipeline/openrouter.db || (echo "run 'make openrouter-shard' first" && exit 2)
+	@test -f dist/pipeline/aws-ec2.db    || (echo "run 'make aws-ec2-shard' first"    && exit 2)
+	SKU_BENCH_SHARD=$(CURDIR)/dist/pipeline/openrouter.db \
+	SKU_BENCH_EC2_SHARD=$(CURDIR)/dist/pipeline/aws-ec2.db \
+	$(GO) test -run=^$$ -bench=. -benchmem -count=10 ./bench/... | tee bench/baseline.txt
+
+bench-diff: ## Compare ./bench current output against bench/baseline.txt (15% threshold)
+	@test -f bench/baseline.txt || (echo "no baseline — run 'make bench-baseline' on main first" && exit 2)
+	@test -f dist/pipeline/openrouter.db || (echo "run 'make openrouter-shard' first" && exit 2)
+	@test -f dist/pipeline/aws-ec2.db    || (echo "run 'make aws-ec2-shard' first"    && exit 2)
+	SKU_BENCH_SHARD=$(CURDIR)/dist/pipeline/openrouter.db \
+	SKU_BENCH_EC2_SHARD=$(CURDIR)/dist/pipeline/aws-ec2.db \
+	$(GO) test -run=^$$ -bench=. -benchmem -count=10 ./bench/... > /tmp/bench-current.txt
+	$(GO) run golang.org/x/perf/cmd/benchstat@latest bench/baseline.txt /tmp/bench-current.txt | tee /tmp/bench-diff.txt
+	@awk '/^Benchmark/ {found=1} found && /[-+][0-9]+(\.[0-9]+)?%/ { \
+	  match($$0, /[-+][0-9]+(\.[0-9]+)?%/); pct = substr($$0, RSTART+1, RLENGTH-2); \
+	  if (index(substr($$0, RSTART, 1), "+") && pct+0 > 15) { \
+	    print "REGRESSION: " $$0; bad=1 \
+	  } \
+	} END { exit bad }' /tmp/bench-diff.txt
+```
+
+- [ ] **Step 2: Write the baseline regeneration script**
+
+Create `scripts/update-bench-baseline.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Regenerate bench/baseline.txt on the current HEAD. Run on main only.
+#
+# Usage: bash scripts/update-bench-baseline.sh
+set -euo pipefail
+
+BR=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BR" != "main" ]]; then
+  echo "warning: not on main (current: $BR) — baseline should be produced on main"
+  read -p "continue anyway? [y/N] " yn
+  [[ "$yn" == "y" ]] || exit 1
+fi
+
+make build
+make openrouter-shard aws-ec2-shard
+make bench-baseline
+
+git diff --stat bench/baseline.txt
+echo
+echo "review the diff, then:"
+echo "  git add bench/baseline.txt"
+echo "  git commit -m 'bench(m7.3): refresh baseline (<reason>)'"
+```
+
+Then:
+
+```bash
+chmod +x scripts/update-bench-baseline.sh
+```
+
+- [ ] **Step 3: Produce the initial baseline**
+
+```bash
+make build
+make openrouter-shard aws-ec2-shard
+make bench-baseline
+```
+
+Expected: `bench/baseline.txt` exists with ten samples per benchmark. Spot-check:
+
+```bash
+head -20 bench/baseline.txt
+```
+
+- [ ] **Step 4: Verify the diff target works against itself (zero regression)**
+
+```bash
+make bench-diff
+```
+
+Expected: no `REGRESSION:` lines; exit 0.
+
+- [ ] **Step 5: Write `bench/README.md`**
+
+```markdown
+# Benchmarks
+
+Per spec §6, the repo gates PRs on a benchstat regression threshold of **15% worse vs `main`**. This directory contains the committed baseline.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `bench_test.go` | The benchmark suite (`go test -bench`) |
+| `baseline.txt` | Committed benchstat baseline produced on `main` |
+
+## When to refresh `baseline.txt`
+
+Refresh on any of:
+
+- A deliberate performance improvement that would read as a regression to callers otherwise (e.g., renaming a benchmark).
+- A runner change in CI (architecture or Go version pin).
+- A shard schema change that alters the fixture size meaningfully.
+
+**Never** refresh to "silence" a regression. Investigate first.
+
+## How
+
+On `main`, after merging the intended changes:
+
+```bash
+bash scripts/update-bench-baseline.sh
+git add bench/baseline.txt
+git commit -m "bench(<milestone>): refresh baseline (<reason>)"
+git push
+```
+
+The CI workflow `.github/workflows/bench.yml` fetches this file on every PR and compares.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Makefile bench/baseline.txt bench/README.md scripts/update-bench-baseline.sh
+git commit -m "bench(m7.3): commit baseline + bench-baseline/bench-diff make targets + update script"
+```
+
+---
+
+### Task 6: `.github/workflows/bench.yml` — PR regression gate
+
+**Files:**
+
+- Create: `.github/workflows/bench.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: bench
+
+on:
+  pull_request:
+    paths:
+      - "internal/**"
+      - "cmd/**"
+      - "bench/**"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/bench.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regression-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build binary + shards
+        run: |
+          make build
+          make openrouter-shard aws-ec2-shard
+      - name: Run bench-diff (fails PR on >15% regression)
+        run: make bench-diff
+      - name: Upload bench output as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-current
+          path: /tmp/bench-current.txt
+          if-no-files-found: warn
+```
+
+- [ ] **Step 2: YAML validate**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/bench.yml'))"
+```
+
+Expected exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/bench.yml
+git commit -m "feat(m7.3): .github/workflows/bench.yml — PR regression gate (15% via benchstat)"
+```
+
+---
+
+### Task 7: Wire `make docs-verify` into CI
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+
+The docs-verify target was introduced in M7.1. Add a CI job that exercises it on every PR so doc/binary drift fails the build.
+
+- [ ] **Step 1: Read `ci.yml`, locate the end of the `release-dry` job**
+
+The new `docs` job goes *after* `release-dry` (it depends on a built binary and built shards; piggybacks on the same infra).
+
+- [ ] **Step 2: Append the new job**
+
+Open `.github/workflows/ci.yml` and append at the end of the file:
+
+```yaml
+  docs:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Python pipeline deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e pipeline
+      - name: Build binary + shards
+        run: |
+          make build
+          make openrouter-shard aws-shards azure-shards gcp-shards
+      - name: Verify docs snippets
+        run: make docs-verify
+```
+
+- [ ] **Step 3: YAML validate**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+```
+
+Expected exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci(m7.3): docs-verify job guards docs/binary drift"
+```
+
+---
+
+### Task 8: `CHANGELOG.md` v1.0.0 entry
+
+**Files:**
+
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Prepend the v1.0.0 entry**
+
+Open `CHANGELOG.md` and prepend *(above* the existing `## v0.1.0` entry):
+
+```markdown
+## v1.0.0 — 2026-04-<TBD> — first stable release
+
+### Added
+
+- Full docs: README quickstart, getting-started, command reference, kinds/presets/exit-codes reference, agent-integration/llm-routing/offline-use guides.
+- `skill/using-sku/SKILL.md` — standalone agent skill file.
+- `SECURITY.md` — vulnerability reporting process and supply-chain guarantees.
+- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1.
+- `.github/workflows/security.yml` — weekly govulncheck + CodeQL + `go mod tidy` drift check.
+- `.github/workflows/bench.yml` — PR regression gate (benchstat, 15% threshold, baseline in `bench/baseline.txt`).
+- `make docs-verify` in CI — every verified doc snippet runs on every PR.
+
+### Changed
+
+- README rewritten from placeholder into a 5-minute quickstart.
+- `docs/install.md` expanded with cosign verification and uninstall steps.
+
+### Fixed
+
+- Workload examples moved from `cmd/sku/testdata/` into `docs/examples/` so the paths advertised in `CLAUDE.md` resolve for users who never look at test code.
+
+### Supply chain
+
+- All v1.0.0 release archives carry cosign keyless signatures, syft SBOMs, and SLSA L3 build provenance (inherited from v0.1.0-rc.1 infrastructure).
+
+### Exit criteria met
+
+- New user reaches a working query in under 5 minutes using only `README.md` + `docs/getting-started.md` (spec §9 M7).
+- Agents have a documented machine-readable schema (`sku schema --errors`, `--list-commands`, `--list-serving-providers`, `--list-kinds`, `--list-shards`).
+```
+
+Fill in the date before tagging (Task 10 Step 1).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "chore(m7.3): CHANGELOG v1.0.0 entry (date filled at tag time)"
+```
+
+---
+
+### Task 9: Full verification pass before tagging
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Clean build from scratch**
+
+```bash
+make clean
+make build
+make openrouter-shard aws-shards azure-shards gcp-shards
+```
+
+Expected: each target exits 0.
+
+- [ ] **Step 2: Run every non-destructive gate locally**
+
+```bash
+make lint
+make test
+make test-integration
+make govulncheck
+make bench-diff
+make docs-verify
+make release-check
+```
+
+Expected: each exits 0. Any failure — **do not tag**; fix first.
+
+- [ ] **Step 3: Push to origin, wait for CI green**
+
+```bash
+git push
+```
+
+Wait for `ci`, `security`, and `bench` workflows to report green on GitHub. Any red → fix and re-run Steps 1–2.
+
+- [ ] **Step 4: Spot-check the CHANGELOG date**
+
+Set the actual date in the `v1.0.0` entry of `CHANGELOG.md` (replace `<TBD>`), commit as `chore(m7.3): stamp v1.0.0 release date`, push.
+
+---
+
+### Task 10: Tag `v1.0.0` — GATED on explicit user confirmation
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Halt and ask the user**
+
+Before any `git tag` command, write a single-message confirmation gate to the user. The message must include:
+
+1. A summary of Tasks 1–9 completion.
+2. The current `CHANGELOG.md` v1.0.0 entry verbatim.
+3. An explicit list of the external prerequisites that must be in place:
+   - `HOMEBREW_TAP_TOKEN` populated in GitHub Settings (consolidated brew+scoop token per M6).
+   - npm + PyPI trusted publishers configured on their respective packages (OIDC, not long-lived tokens).
+   - `sofq/homebrew-tap` and `sofq/scoop-bucket` repos exist and are writable by the token.
+   - GHCR access configured for `ghcr.io/sofq/sku`.
+   - The user has reviewed the changelog and is ready to cut a stable release.
+4. A note that the `v0.1.0-rc.1` tag's release verification (docker pull, cosign verify, attestation verify) was completed and recorded (otherwise cut a `v1.0.0-rc.1` first).
+
+**Only proceed past this step if the user's reply is an unambiguous "yes, cut v1.0.0".**
+
+- [ ] **Step 2: Tag**
+
+```bash
+git tag -s v1.0.0 -m "sku v1.0.0 — first stable release"
+```
+
+- [ ] **Step 3: Push the tag**
+
+```bash
+git push origin v1.0.0
+```
+
+- [ ] **Step 4: Monitor the release**
+
+```bash
+gh run watch --exit-status -R sofq/sku
+gh release view v1.0.0
+```
+
+Expected: `release`, `release-npm`, and `release-pypi` workflows all green. Release assets match spec §7:
+
+- 6 archives + `checksums.txt`, `checksums.txt.sig`, `checksums.txt.pem`
+- SBOMs per archive
+- SLSA provenance attestations
+- Published packages:
+  - `brew install sofq/tap/sku`
+  - `scoop install sku`
+  - `npm i -g @sofq/sku`
+  - `pipx install sku-cli`
+  - `docker pull ghcr.io/sofq/sku:1.0.0`
+
+If any publish fails, re-run the specific workflow; do **not** delete the tag unless the binaries themselves are bad.
+
+- [ ] **Step 5: Post-tag verification (mirrors M6 Task 9 Step 5, on stable assets)**
+
+```bash
+# Release assets
+gh release view v1.0.0 --json assets --jq '.assets[].name' | sort
+
+# Docker
+docker pull ghcr.io/sofq/sku:1.0.0
+docker run --rm ghcr.io/sofq/sku:1.0.0 version --pretty
+
+# Cosign
+curl -sSLO https://github.com/sofq/sku/releases/download/v1.0.0/checksums.txt
+curl -sSLO https://github.com/sofq/sku/releases/download/v1.0.0/checksums.txt.sig
+curl -sSLO https://github.com/sofq/sku/releases/download/v1.0.0/checksums.txt.pem
+cosign verify-blob \
+  --certificate-identity-regexp 'https://github.com/sofq/sku/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --signature checksums.txt.sig --certificate checksums.txt.pem checksums.txt
+
+# SLSA provenance
+curl -sSLO https://github.com/sofq/sku/releases/download/v1.0.0/sku_1.0.0_linux_amd64.tar.gz
+gh attestation verify sku_1.0.0_linux_amd64.tar.gz --owner sofq
+
+# Fresh-machine install smoke (on one Linux + one macOS + one Windows host)
+# This satisfies the M6 exit criterion that was deferred in M6 Task 9 notes.
+brew install sofq/tap/sku && sku version --pretty
+pipx install sku-cli      && sku version --pretty
+npx @sofq/sku version --pretty
+scoop bucket add sofq https://github.com/sofq/scoop-bucket && scoop install sku && sku version --pretty
+docker run --rm ghcr.io/sofq/sku:1.0.0 version --pretty
+```
+
+Expected: all return a version JSON with `"version":"1.0.0"`. Capture output in a new `docs/ops/v1.0.0-release-notes.md` for future reference.
+
+- [ ] **Step 6: Commit the ops note + close M7.3**
+
+```bash
+# Author docs/ops/v1.0.0-release-notes.md with the Step 5 output
+git add docs/ops/v1.0.0-release-notes.md
+git commit -m "docs(m7.3): v1.0.0 release verification log"
+```
+
+Update `CLAUDE.md`:
+
+```markdown
+## Current milestone
+
+v1.0 shipped — `v1.0.0` tag, all distribution channels live, fresh-machine install verified across brew / scoop / npm / pipx / docker (see `docs/ops/v1.0.0-release-notes.md`).
+Next: v1.1 roadmap per spec §9 "Post-v1 roadmap" (watch, commitment shards, mcp-server).
+```
+
+Commit:
+
+```bash
+git add CLAUDE.md
+git commit -m "chore(m7.3): close M7.3 and tag v1.0.0 shipped"
+```
+
+---
+
+## Self-review notes (non-executable)
+
+- **Spec coverage.** §9 M7 remaining items → Tasks 1 (SECURITY.md) + 3 (govulncheck clean) + 4 (security workflow, enforcing "clean" weekly) + 5-6 (bench baseline + regression gate per §6) + 7 (docs-verify in CI closes the loop on M7.1/M7.2) + 8-10 (CHANGELOG + v1.0.0 tag).
+- **Website** (spec §8) stays deferred to v1.1; tracked here as documentation, not as a gap.
+- **Placeholders.** None executable. The date in the `v1.0.0` changelog entry is `<TBD>` by design and filled at tag time (Task 9 Step 4). The ops release note (`docs/ops/v1.0.0-release-notes.md`) captures real output from Task 10 Step 5 — it is authored from the command output, not from a template.
+- **Type consistency.** Workflow names match existing repo pattern (`ci`, `release`, `release-npm`, `release-pypi`, `security`, `bench`). Makefile targets (`docs-verify`, `govulncheck`, `bench-baseline`, `bench-diff`) follow the existing `release-check` / `docker-smoke` / `pypi-wheel-smoke` naming.
+- **Risks.**
+  1. `govulncheck` may report a CVE that can only be fixed by a Go toolchain bump past this repo's documented floor (`1.25`). Mitigation: Task 3 Step 2 allows a toolchain bump; spec §6 *Compatibility matrix* tracks the "two most recent stable Go minors" policy so bumping is in-policy.
+  2. The 15% benchstat gate may prove too tight on noisy runners. Mitigation: `count=10` in the Make targets reduces variance; if still flaky, widen to 20% in a follow-up and document the change in `bench/README.md`.
+  3. `sku llm list --max-input-price` documented in M7.2 but possibly unwired. Verify before tagging v1.0.0 (Task 9 Step 1); if still unwired, either wire it (tiny feature add, ~1 day) or drop the paragraph from `docs/guides/llm-routing.md`. Do not ship v1.0.0 with a doc referencing a flag the binary rejects.
+  4. The `v1.0.0` tag push is gated on user confirmation (Task 10 Step 1) — the same gate M6 Task 9 used. Do not auto-push under any circumstance.

--- a/pipeline/discover/__main__.py
+++ b/pipeline/discover/__main__.py
@@ -1,0 +1,43 @@
+"""`python -m pipeline.discover` entrypoint."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from discover.driver import run
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="discover")
+    ap.add_argument("--state", type=Path, required=True, help="path to state.json")
+    ap.add_argument("--out", type=Path, required=True, help="path for changed-shards.json")
+    ap.add_argument("--live", action="store_true", help="hit real upstreams (default: dry-run)")
+    ap.add_argument("--baseline-rebuild", action="store_true", help="force every shard into output")
+    ap.add_argument("--shards", default=None, help="comma-separated shard ids; default = all known")
+    ap.add_argument(
+        "--gcp-api-key-env",
+        default="GCP_BILLING_API_KEY",
+        help="env var holding the GCP billing API key (default: GCP_BILLING_API_KEY)",
+    )
+    args = ap.parse_args(argv)
+
+    shards = None
+    if args.shards:
+        shards = [s.strip() for s in args.shards.split(",") if s.strip()]
+    api_key = os.environ.get(args.gcp_api_key_env) if args.live else None
+
+    return run(
+        state_path=args.state,
+        out_path=args.out,
+        live=args.live,
+        baseline_rebuild=args.baseline_rebuild,
+        shards=shards,
+        gcp_api_key=api_key,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/discover/aws.py
+++ b/pipeline/discover/aws.py
@@ -31,7 +31,7 @@ def discover(shards: Iterable[str], *, session: requests.Session | None = None) 
         out: dict[str, str] = {}
         for shard in shards:
             service = _AWS_SERVICE_CODES[shard]
-            url = f"{_AWS_OFFER_BASE}/{service}/current/index.json"
+            url = f"{_AWS_OFFER_BASE}/{service}/index.json"
             resp = session.get(url, headers={"User-Agent": _UA}, timeout=60)
             if resp.status_code != 200:
                 raise RuntimeError(f"aws_discover_http_{resp.status_code}: {url}")

--- a/pipeline/discover/aws.py
+++ b/pipeline/discover/aws.py
@@ -1,0 +1,46 @@
+"""AWS version-indicator discoverer.
+
+For each AWS shard, issues a GET against the offer's per-service `index.json`
+and returns the upstream `publicationDate` as the opaque indicator. The driver
+uses this to decide whether the shard needs a full ingest pass.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+import requests
+
+from ingest.aws_common import _AWS_OFFER_BASE, _AWS_SERVICE_CODES
+
+_UA = "sku-pipeline/0.0 (+https://github.com/sofq/sku)"
+
+
+def discover(shards: Iterable[str], *, session: requests.Session | None = None) -> dict[str, str]:
+    """Return `{shard_id: publicationDate}` for the given AWS shard ids.
+
+    Unknown shards raise KeyError. HTTP failures raise RuntimeError (the
+    driver catches per-shard and records into `errors`).
+    """
+    owned = False
+    if session is None:
+        session = requests.Session()
+        owned = True
+    try:
+        out: dict[str, str] = {}
+        for shard in shards:
+            service = _AWS_SERVICE_CODES[shard]
+            url = f"{_AWS_OFFER_BASE}/{service}/current/index.json"
+            resp = session.get(url, headers={"User-Agent": _UA}, timeout=60)
+            if resp.status_code != 200:
+                raise RuntimeError(f"aws_discover_http_{resp.status_code}: {url}")
+            doc = json.loads(resp.content)
+            pub = doc.get("publicationDate")
+            if not pub:
+                raise RuntimeError(f"aws_discover_missing_publicationDate: {url}")
+            out[shard] = str(pub)
+        return out
+    finally:
+        if owned:
+            session.close()

--- a/pipeline/discover/azure.py
+++ b/pipeline/discover/azure.py
@@ -1,0 +1,59 @@
+"""Azure version-indicator discoverer.
+
+For each Azure shard, issues a single-page retail-prices query with `$top=1`
+and returns a SHA256 digest of that page's items as the cheap fingerprint.
+The per-shard filter strings live here; they mirror the shapes used by the
+full ingest layer in `ingest.azure_*`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable
+
+import requests
+
+from ingest.azure_common import _AZURE_RETAIL_BASE
+
+_UA = "sku-pipeline/0.0 (+https://github.com/sofq/sku)"
+
+_SHARD_FILTERS: dict[str, str] = {
+    "azure_vm": "serviceName eq 'Virtual Machines'",
+    "azure_sql": "serviceName eq 'SQL Database'",
+    "azure_blob": "serviceName eq 'Storage' and productName eq 'General Block Blob'",
+    "azure_functions": "serviceName eq 'Functions'",
+    "azure_disks": "serviceName eq 'Storage' and productName eq 'Premium SSD Managed Disks'",
+}
+
+
+def discover(shards: Iterable[str], *, session: requests.Session | None = None) -> dict[str, str]:
+    """Return `{shard_id: sha256_hex}` for the given Azure shard ids.
+
+    Unknown shards raise KeyError. HTTP failures raise RuntimeError.
+    """
+    owned = False
+    if session is None:
+        session = requests.Session()
+        owned = True
+    try:
+        out: dict[str, str] = {}
+        for shard in shards:
+            filter_str = _SHARD_FILTERS[shard]
+            params = {
+                "$filter": filter_str,
+                "$top": "1",
+                "api-version": "2023-01-01-preview",
+            }
+            resp = session.get(
+                _AZURE_RETAIL_BASE, params=params, headers={"User-Agent": _UA}, timeout=60
+            )
+            if resp.status_code != 200:
+                raise RuntimeError(f"azure_discover_http_{resp.status_code}: {shard}")
+            items = resp.json().get("Items", [])
+            payload = json.dumps(items, separators=(",", ":"), sort_keys=True).encode()
+            out[shard] = hashlib.sha256(payload).hexdigest()
+        return out
+    finally:
+        if owned:
+            session.close()

--- a/pipeline/discover/driver.py
+++ b/pipeline/discover/driver.py
@@ -1,0 +1,214 @@
+"""Discover driver — emits changed-shards.json by diffing upstream version
+indicators against a saved state file.
+
+Output schema (`changed.json`):
+
+    {
+      "schema_version": 1,
+      "baseline_rebuild": false,
+      "generated_at": "2026-04-19T03:00:00Z",
+      "shards": ["aws_ec2", "gcp_gce"],
+      "unchanged": ["aws_rds", ...],
+      "errors": [{"shard": "azure_vm", "reason": "http_500", "detail": "..."}]
+    }
+
+Exit codes:
+  0  — success (at least one shard resolved, or dry-run mode).
+  2  — pipeline_failure: every requested shard errored during live discovery.
+  4  — validation: unknown shard id passed via --shards.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+
+import requests
+
+from discover import aws as aws_disc
+from discover import azure as azure_disc
+from discover import gcp as gcp_disc
+from discover import openrouter as or_disc
+from discover.state import State, load, save
+from ingest.http import LiveClient
+
+_OUTPUT_SCHEMA_VERSION = 1
+
+ALL_SHARDS: tuple[str, ...] = (
+    "aws_ec2",
+    "aws_rds",
+    "aws_s3",
+    "aws_lambda",
+    "aws_ebs",
+    "aws_dynamodb",
+    "aws_cloudfront",
+    "azure_vm",
+    "azure_sql",
+    "azure_blob",
+    "azure_functions",
+    "azure_disks",
+    "gcp_gce",
+    "gcp_cloud_sql",
+    "gcp_gcs",
+    "gcp_run",
+    "gcp_functions",
+    "openrouter",
+)
+
+
+def _provider_of(shard: str) -> str:
+    if shard.startswith("aws_"):
+        return "aws"
+    if shard.startswith("azure_"):
+        return "azure"
+    if shard.startswith("gcp_"):
+        return "gcp"
+    if shard == "openrouter":
+        return "openrouter"
+    raise KeyError(shard)
+
+
+def _validate_shards(shards: Iterable[str]) -> list[str]:
+    out: list[str] = []
+    for s in shards:
+        # Accept dashed aliases from CLI users; normalise to underscored.
+        canon = s.replace("-", "_")
+        if canon not in ALL_SHARDS:
+            raise ValueError(canon)
+        out.append(canon)
+    return out
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _write_output(out_path: Path, doc: Mapping[str, object]) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_suffix(out_path.suffix + ".part")
+    with tmp.open("w") as fh:
+        json.dump(doc, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+    os.replace(tmp, out_path)
+
+
+def _run_live(
+    shards: list[str], *, gcp_api_key: str | None, session: requests.Session | None
+) -> tuple[dict[str, str], list[dict[str, str]]]:
+    """Fetch indicators for every shard. Returns (indicators, errors).
+
+    Shard-level errors are recorded and do not abort the run; the driver
+    decides whether the overall run is a failure based on how many shards
+    succeeded.
+    """
+    by_provider: dict[str, list[str]] = {"aws": [], "azure": [], "gcp": [], "openrouter": []}
+    for s in shards:
+        by_provider[_provider_of(s)].append(s)
+
+    indicators: dict[str, str] = {}
+    errors: list[dict[str, str]] = []
+
+    def _run_group(name: str, fn) -> None:
+        group = by_provider[name]
+        if not group:
+            return
+        try:
+            indicators.update(fn(group))
+        except Exception as exc:
+            # Parent call failed: attribute the failure to each shard in the
+            # group so downstream can decide per-shard retries.
+            for s in group:
+                errors.append({"shard": s, "reason": name + "_error", "detail": str(exc)})
+
+    _run_group("aws", lambda g: aws_disc.discover(g, session=session))
+    _run_group("azure", lambda g: azure_disc.discover(g, session=session))
+    if by_provider["gcp"]:
+        if not gcp_api_key:
+            for s in by_provider["gcp"]:
+                errors.append(
+                    {"shard": s, "reason": "gcp_missing_api_key", "detail": "api_key required"}
+                )
+        else:
+            _run_group("gcp", lambda g: gcp_disc.discover(g, api_key=gcp_api_key, session=session))
+    _run_group("openrouter", lambda g: or_disc.discover(g, client=LiveClient()))
+    return indicators, errors
+
+
+def run(
+    *,
+    state_path: Path,
+    out_path: Path,
+    live: bool,
+    baseline_rebuild: bool = False,
+    shards: Iterable[str] | None = None,
+    gcp_api_key: str | None = None,
+    session: requests.Session | None = None,
+) -> int:
+    """Execute one discovery pass; write `out_path`; return exit code."""
+    try:
+        requested = _validate_shards(shards) if shards is not None else list(ALL_SHARDS)
+    except ValueError as exc:
+        _write_output(
+            out_path,
+            {
+                "schema_version": _OUTPUT_SCHEMA_VERSION,
+                "baseline_rebuild": False,
+                "generated_at": _now_iso(),
+                "shards": [],
+                "unchanged": [],
+                "errors": [{"shard": str(exc), "reason": "unknown_shard", "detail": ""}],
+            },
+        )
+        return 4
+
+    previous = load(state_path)
+    prev_map = dict(previous.indicators)
+
+    if not live:
+        # Dry-run mode: never hit the network. If state is empty, signal
+        # baseline_rebuild so the caller knows indicators are unpopulated.
+        doc = {
+            "schema_version": _OUTPUT_SCHEMA_VERSION,
+            "baseline_rebuild": not prev_map,
+            "generated_at": _now_iso(),
+            "shards": [],
+            "unchanged": sorted(s for s in requested if s in prev_map),
+            "errors": [],
+        }
+        _write_output(out_path, doc)
+        return 0
+
+    indicators, errors = _run_live(requested, gcp_api_key=gcp_api_key, session=session)
+
+    errored_shards = {e["shard"] for e in errors}
+    resolved = [s for s in requested if s in indicators]
+
+    if baseline_rebuild or not prev_map:
+        changed = [s for s in resolved]
+    else:
+        changed = [s for s in resolved if indicators[s] != prev_map.get(s)]
+
+    unchanged = [s for s in resolved if s not in changed]
+
+    # Persist the updated indicators (merge — don't wipe out shards we didn't
+    # check this run).
+    merged = dict(prev_map)
+    merged.update(indicators)
+    save(state_path, State(schema_version=previous.schema_version, indicators=merged))
+
+    doc = {
+        "schema_version": _OUTPUT_SCHEMA_VERSION,
+        "baseline_rebuild": bool(baseline_rebuild or not prev_map),
+        "generated_at": _now_iso(),
+        "shards": sorted(changed),
+        "unchanged": sorted(unchanged),
+        "errors": errors,
+    }
+    _write_output(out_path, doc)
+
+    if requested and not resolved and errored_shards == set(requested):
+        return 2
+    return 0

--- a/pipeline/discover/gcp.py
+++ b/pipeline/discover/gcp.py
@@ -1,0 +1,68 @@
+"""GCP version-indicator discoverer.
+
+For each GCP shard, issues a parent-service GET (`/services/{service_id}`) and
+returns `displayName + '|' + updateTime` when both are present. If the parent
+record omits `updateTime`, falls back to a `pageSize=1` SKU fetch and hashes
+the single row. The fallback is rare — Cloud Billing populates `updateTime`
+for all the shards we care about — but it keeps the discoverer self-consistent
+across upstream quirks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable
+
+import requests
+
+from ingest.gcp_common import _GCP_BILLING_BASE, _GCP_SERVICE_IDS
+
+_UA = "sku-pipeline/0.0 (+https://github.com/sofq/sku)"
+
+
+def discover(
+    shards: Iterable[str], *, api_key: str, session: requests.Session | None = None
+) -> dict[str, str]:
+    """Return `{shard_id: indicator}` for the given GCP shard ids.
+
+    Unknown shards raise KeyError. HTTP failures raise RuntimeError.
+    """
+    owned = False
+    if session is None:
+        session = requests.Session()
+        owned = True
+    try:
+        out: dict[str, str] = {}
+        for shard in shards:
+            service_id = _GCP_SERVICE_IDS[shard]
+            # Parent service record — cheap (< 1 KB).
+            url = f"{_GCP_BILLING_BASE}/services/{service_id}"
+            resp = session.get(
+                url, params={"key": api_key}, headers={"User-Agent": _UA}, timeout=30
+            )
+            if resp.status_code != 200:
+                raise RuntimeError(f"gcp_discover_http_{resp.status_code}: {shard}")
+            doc = resp.json()
+            update_time = doc.get("updateTime") or doc.get("serviceInfo", {}).get("updateTime")
+            display_name = doc.get("displayName", "")
+            if update_time:
+                out[shard] = f"{display_name}|{update_time}"
+                continue
+            # Fallback: hash over a single SKU.
+            sku_url = f"{_GCP_BILLING_BASE}/services/{service_id}/skus"
+            sku_resp = session.get(
+                sku_url,
+                params={"key": api_key, "pageSize": "1"},
+                headers={"User-Agent": _UA},
+                timeout=30,
+            )
+            if sku_resp.status_code != 200:
+                raise RuntimeError(f"gcp_discover_fallback_http_{sku_resp.status_code}: {shard}")
+            skus = sku_resp.json().get("skus", [])
+            payload = json.dumps(skus, separators=(",", ":"), sort_keys=True).encode()
+            out[shard] = "sha256:" + hashlib.sha256(payload).hexdigest()
+        return out
+    finally:
+        if owned:
+            session.close()

--- a/pipeline/discover/openrouter.py
+++ b/pipeline/discover/openrouter.py
@@ -1,0 +1,34 @@
+"""OpenRouter version-indicator discoverer.
+
+Single GET against `/api/v1/models`; indicator is a SHA256 digest of the
+sorted list of model ids. Whenever OpenRouter adds / removes / renames a
+model, the indicator changes and the shard re-ingests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable
+
+from ingest.http import LiveClient
+
+_OPENROUTER_SHARDS = frozenset({"openrouter"})
+
+
+def discover(shards: Iterable[str], *, client: LiveClient | None = None) -> dict[str, str]:
+    """Return `{shard_id: sha256_hex}` for the given OpenRouter shard ids.
+
+    Only `"openrouter"` is known; anything else raises KeyError.
+    """
+    shard_list = list(shards)
+    for s in shard_list:
+        if s not in _OPENROUTER_SHARDS:
+            raise KeyError(s)
+    if not shard_list:
+        return {}
+    c = client or LiveClient()
+    payload = c.get("/api/v1/models")
+    ids = sorted(m["id"] for m in payload.get("data", []))
+    digest = hashlib.sha256(json.dumps(ids).encode()).hexdigest()
+    return dict.fromkeys(shard_list, digest)

--- a/pipeline/discover/state.py
+++ b/pipeline/discover/state.py
@@ -1,0 +1,51 @@
+"""Persistent per-shard version-indicator store for the discover module.
+
+`State` holds the schema version + an opaque `{shard_id: indicator}` map. The
+indicator values are produced by `pipeline.discover.{provider}` and consumed by
+the driver to decide which shards' upstream data has changed since the last run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+_STATE_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class State:
+    schema_version: int
+    indicators: Mapping[str, str]
+
+
+def load(path: Path) -> State:
+    """Return the state at `path`; if missing, return an empty state."""
+    if not path.exists():
+        return State(schema_version=_STATE_SCHEMA_VERSION, indicators={})
+    with path.open() as fh:
+        doc = json.load(fh)
+    version = doc.get("schema_version")
+    if version != _STATE_SCHEMA_VERSION:
+        raise RuntimeError(
+            f"state_schema_version_mismatch: expected {_STATE_SCHEMA_VERSION}, got {version!r}"
+        )
+    indicators = doc.get("indicators") or {}
+    return State(schema_version=version, indicators=dict(indicators))
+
+
+def save(path: Path, state: State) -> None:
+    """Atomic write via .part + os.replace; indented JSON with sorted keys."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".part")
+    doc = {
+        "schema_version": state.schema_version,
+        "indicators": dict(sorted(state.indicators.items())),
+    }
+    with tmp.open("w") as fh:
+        json.dump(doc, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+    os.replace(tmp, path)

--- a/pipeline/ingest/_duckdb.py
+++ b/pipeline/ingest/_duckdb.py
@@ -27,7 +27,6 @@ def _terms_hash_udf(
 def open_conn() -> duckdb.DuckDBPyConnection:
     """Return an in-memory conn with `sku_terms_hash(...)` bound as a scalar UDF."""
     con = duckdb.connect(":memory:")
-    con.execute("SET memory_limit='4GB'")
     con.execute("SET temp_directory='/tmp/sku_duckdb'")
     con.create_function(
         "sku_terms_hash",

--- a/pipeline/ingest/_duckdb.py
+++ b/pipeline/ingest/_duckdb.py
@@ -10,12 +10,14 @@ import duckdb
 
 from normalize.terms import terms_hash
 
-# Spill directory for intermediate hash joins / aggregations when the large
-# AWS offer files blow past memory_limit. Without this, DuckDB falls back to
-# the system RAM ceiling (~80% of runner RAM = ~12 GiB on ubuntu-latest) and
-# OOMs before spilling. See d574924 post-mortem in M3a.4.2 runbook.
+# ubuntu-latest has ~16 GiB RAM. DuckDB's default cap (~80%) OOMs the runner
+# on large AWS offers. A 4 GiB cap was too tight — non-spillable ops hit it
+# mid-query. 8 GiB + 2 threads + preserve_insertion_order=false keeps total
+# footprint well under the runner ceiling while letting hash joins and
+# aggregations spill to _TEMP_DIR. See M3a.4.2 runbook.
 _TEMP_DIR = "/tmp/sku_duckdb"
-_MEMORY_LIMIT = "4GB"
+_MEMORY_LIMIT = "8GB"
+_THREADS = 2
 
 
 def _terms_hash_udf(
@@ -38,6 +40,8 @@ def open_conn() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect(":memory:")
     con.execute(f"SET memory_limit='{_MEMORY_LIMIT}'")
     con.execute(f"SET temp_directory='{_TEMP_DIR}'")
+    con.execute(f"SET threads={_THREADS}")
+    con.execute("SET preserve_insertion_order=false")
     con.create_function(
         "sku_terms_hash",
         _terms_hash_udf,

--- a/pipeline/ingest/_duckdb.py
+++ b/pipeline/ingest/_duckdb.py
@@ -27,6 +27,8 @@ def _terms_hash_udf(
 def open_conn() -> duckdb.DuckDBPyConnection:
     """Return an in-memory conn with `sku_terms_hash(...)` bound as a scalar UDF."""
     con = duckdb.connect(":memory:")
+    con.execute("SET memory_limit='4GB'")
+    con.execute("SET temp_directory='/tmp/sku_duckdb'")
     con.create_function(
         "sku_terms_hash",
         _terms_hash_udf,

--- a/pipeline/ingest/_duckdb.py
+++ b/pipeline/ingest/_duckdb.py
@@ -3,11 +3,19 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
 
 import duckdb
 
 from normalize.terms import terms_hash
+
+# Spill directory for intermediate hash joins / aggregations when the large
+# AWS offer files blow past memory_limit. Without this, DuckDB falls back to
+# the system RAM ceiling (~80% of runner RAM = ~12 GiB on ubuntu-latest) and
+# OOMs before spilling. See d574924 post-mortem in M3a.4.2 runbook.
+_TEMP_DIR = "/tmp/sku_duckdb"
+_MEMORY_LIMIT = "4GB"
 
 
 def _terms_hash_udf(
@@ -26,8 +34,10 @@ def _terms_hash_udf(
 
 def open_conn() -> duckdb.DuckDBPyConnection:
     """Return an in-memory conn with `sku_terms_hash(...)` bound as a scalar UDF."""
+    os.makedirs(_TEMP_DIR, exist_ok=True)
     con = duckdb.connect(":memory:")
-    con.execute("SET temp_directory='/tmp/sku_duckdb'")
+    con.execute(f"SET memory_limit='{_MEMORY_LIMIT}'")
+    con.execute(f"SET temp_directory='{_TEMP_DIR}'")
     con.create_function(
         "sku_terms_hash",
         _terms_hash_udf,

--- a/pipeline/ingest/aws_cloudfront.py
+++ b/pipeline/ingest/aws_cloudfront.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_cloudfront.py
+++ b/pipeline/ingest/aws_cloudfront.py
@@ -81,12 +81,14 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'})"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
     )
 
     grouped: dict[tuple[str, str], dict[str, Any]] = {}
 
     for sku_id, location_raw, unit, usd, begin_range in con.execute(_SQL).fetchall():
+        if location_raw is None:
+            continue
         if location_raw not in LOCATION_MAP:
             raise KeyError(location_raw)
         region = LOCATION_MAP[location_raw]

--- a/pipeline/ingest/aws_cloudfront.py
+++ b/pipeline/ingest/aws_cloudfront.py
@@ -94,7 +94,8 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
         region = LOCATION_MAP[location_raw]
         if begin_range not in (None, "0"):
             continue
-        normalizer.normalize(_PROVIDER, region)
+        if normalizer.try_normalize(_PROVIDER, region) is None:
+            continue  # skip regions outside our coverage map
         key = ("standard", region)
         grouped[key] = {"sku": sku_id, "usd": usd, "unit": unit}
 

--- a/pipeline/ingest/aws_common.py
+++ b/pipeline/ingest/aws_common.py
@@ -29,6 +29,15 @@ class RegionNormalizer:
         except KeyError as exc:
             raise KeyError(f"{provider}/{region}") from exc
 
+    def try_normalize(self, provider: str, region: str) -> str | None:
+        """Return canonical group, or None when the region is not tracked.
+
+        Live AWS/Azure/GCP price feeds include regions outside our coverage
+        (new launches, opt-in regions, etc.). Ingest callers use this helper
+        to skip those rows instead of failing the whole shard.
+        """
+        return self.table.get((provider, region))
+
 
 def load_region_normalizer() -> RegionNormalizer:
     """Load the repo's regions.yaml and build a (provider, region) -> group map."""

--- a/pipeline/ingest/aws_common.py
+++ b/pipeline/ingest/aws_common.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import contextlib
+import json
+import os
+import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Mapping
 
+import requests
 import yaml
 
 _REGIONS_YAML = Path(__file__).resolve().parent.parent / "normalize" / "regions.yaml"
@@ -35,3 +40,72 @@ def load_region_normalizer() -> RegionNormalizer:
             key = (entry["provider"], entry["region"])
             table[key] = group
     return RegionNormalizer(table)
+
+
+_AWS_OFFER_BASE = "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws"
+_AWS_SERVICE_CODES: dict[str, str] = {
+    "aws_ec2": "AmazonEC2",
+    "aws_rds": "AmazonRDS",
+    "aws_s3": "AmazonS3",
+    "aws_lambda": "AWSLambda",
+    "aws_ebs": "AmazonEC2",
+    "aws_dynamodb": "AmazonDynamoDB",
+    "aws_cloudfront": "AmazonCloudFront",
+}
+
+_RETRY_STATUSES = {500, 502, 503, 504}
+
+
+def fetch_offer(
+    shard: str, target: Path, *, session: requests.Session | None = None, retries: int = 3
+) -> str:
+    """Download an AWS offer index.json for `shard` into `target`."""
+    service_code = _AWS_SERVICE_CODES[shard]
+    url = f"{_AWS_OFFER_BASE}/{service_code}/current/index.json"
+    if session is None:
+        session = requests.Session()
+    ua = "sku-pipeline/0.0 (+https://github.com/sofq/sku)"
+    part = target.with_suffix(target.suffix + ".part")
+    last: Exception | None = None
+    for attempt in range(retries):
+        try:
+            resp = session.get(
+                url,
+                stream=True,
+                timeout=60,
+                headers={"User-Agent": ua},
+            )
+        except requests.RequestException as exc:
+            last = exc
+            time.sleep(0.5 * 2**attempt)
+            continue
+        status = resp.status_code
+        if status in _RETRY_STATUSES:
+            last = RuntimeError(f"GET {url} returned {status}")
+            time.sleep(0.5 * 2**attempt)
+            continue
+        if status != 200:
+            raise RuntimeError(f"GET {url} returned {status}")
+        declared_length: int | None = None
+        raw_cl = resp.headers.get("Content-Length")
+        if raw_cl is not None:
+            with contextlib.suppress(ValueError):
+                declared_length = int(raw_cl)
+        try:
+            with part.open("wb") as fh:
+                for chunk in resp.iter_content(chunk_size=65536):
+                    fh.write(chunk)
+        except Exception as exc:
+            part.unlink(missing_ok=True)
+            raise RuntimeError(f"GET {url} stream error: {exc}") from exc
+        actual_length = part.stat().st_size
+        if declared_length is not None and actual_length != declared_length:
+            part.unlink(missing_ok=True)
+            raise RuntimeError(
+                f"GET {url} truncated: got {actual_length} bytes, expected {declared_length}"
+            )
+        with part.open() as fh:
+            doc = json.load(fh)
+        os.replace(part, target)
+        return doc["publicationDate"]
+    raise RuntimeError(f"GET {url} failed after {retries} attempts: {last}")

--- a/pipeline/ingest/aws_common.py
+++ b/pipeline/ingest/aws_common.py
@@ -6,10 +6,12 @@ import contextlib
 import json
 import os
 import time
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
+import ijson
 import requests
 import yaml
 
@@ -67,10 +69,25 @@ _RETRY_STATUSES = {500, 502, 503, 504}
 
 def fetch_offer(
     shard: str, target: Path, *, session: requests.Session | None = None, retries: int = 3
-) -> str:
-    """Download an AWS offer index.json for `shard` into `target`."""
+) -> None:
+    """Download an AWS offer index.json for `shard` into `target`.
+
+    Streams to disk in 64 KiB chunks — we never hold the file in memory because
+    some offers (AmazonEC2 = 8+ GB) would OOM a 16 GiB runner.
+    """
     service_code = _AWS_SERVICE_CODES[shard]
     url = f"{_AWS_OFFER_BASE}/{service_code}/current/index.json"
+    _stream_download(url, target, session=session, retries=retries)
+
+
+def _stream_download(
+    url: str,
+    target: Path,
+    *,
+    session: requests.Session | None = None,
+    retries: int = 3,
+) -> None:
+    """Stream `url` to `target` atomically, with retry on 5xx and truncation check."""
     if session is None:
         session = requests.Session()
     ua = "sku-pipeline/0.0 (+https://github.com/sofq/sku)"
@@ -78,12 +95,7 @@ def fetch_offer(
     last: Exception | None = None
     for attempt in range(retries):
         try:
-            resp = session.get(
-                url,
-                stream=True,
-                timeout=60,
-                headers={"User-Agent": ua},
-            )
+            resp = session.get(url, stream=True, timeout=60, headers={"User-Agent": ua})
         except requests.RequestException as exc:
             last = exc
             time.sleep(0.5 * 2**attempt)
@@ -113,8 +125,159 @@ def fetch_offer(
             raise RuntimeError(
                 f"GET {url} truncated: got {actual_length} bytes, expected {declared_length}"
             )
-        with part.open() as fh:
-            doc = json.load(fh)
         os.replace(part, target)
-        return doc["publicationDate"]
+        return
     raise RuntimeError(f"GET {url} failed after {retries} attempts: {last}")
+
+
+# ---------------------------------------------------------------------------
+# Per-region stripped offer fetch (m3a.4.2 OOM fix)
+# ---------------------------------------------------------------------------
+#
+# AmazonEC2 combined offer is 8.4 GB. Loading it in any form — DuckDB json_each
+# or Python json.load — overflows the 16 GB runner. AWS also publishes per-region
+# index.json files (~400 MB each) via `region_index.json`. We fetch each per-region
+# file, stream-parse it with ijson, and write a trimmed JSON containing only the
+# ~12 leaf fields our ingesters consume. Peak memory: one product dict at a time
+# (~KBs). Peak disk: ~400 MB raw + ~30 MB stripped; raw is deleted after strip.
+
+# Which AWS service codes support per-region offers (i.e. have a region_index.json).
+_PER_REGION_AWS_OFFERS: frozenset[str] = frozenset({"AmazonEC2"})
+
+# Product-family allowlist per shard — drives the ingesters' consumed rows.
+# Kept here (not per-ingester) so one stripped file can serve multiple ingesters
+# (aws_ec2 + aws_ebs both read the AmazonEC2 offer, one is Compute Instance,
+# the other is Storage). Extra families filtered at ingest time.
+_EC2_PRODUCT_FAMILIES: frozenset[str] = frozenset({"Compute Instance", "Storage"})
+
+# Leaf attributes any AWS ingester consumes under products.<sku>.attributes.
+# Superset across aws_ec2 (Compute Instance) + aws_ebs (Storage). Keeping the
+# superset means one stripped file per region works for both shards without
+# re-fetching upstream.
+_EC2_KEEP_ATTRS: frozenset[str] = frozenset(
+    {
+        "instanceType",
+        "regionCode",
+        "operatingSystem",
+        "tenancy",
+        "preInstalledSw",
+        "capacitystatus",
+        "vcpu",
+        "memory",
+        "physicalProcessor",
+        "networkPerformance",
+        "volumeApiName",
+    }
+)
+
+
+def fetch_offer_regions_stripped(
+    shard: str,
+    out_dir: Path,
+    *,
+    regions: Iterable[str],
+    session: requests.Session | None = None,
+    retries: int = 3,
+) -> list[Path]:
+    """Fetch per-region AWS offer files for `shard`, stream-strip to JSON.
+
+    For each region in `regions`, download that region's `index.json`, parse it
+    with ijson, write a trimmed JSON of the same shape (products/terms.OnDemand
+    with only the leaf fields we consume) to `out_dir/{shard}-{region}.json`.
+    Raw per-region downloads are deleted after stripping.
+
+    Skips regions not listed in the upstream `region_index.json` (e.g. new
+    AWS regions not yet in a shard's offer). Returns the list of stripped
+    output paths that were successfully produced.
+    """
+    service_code = _AWS_SERVICE_CODES[shard]
+    if service_code not in _PER_REGION_AWS_OFFERS:
+        raise ValueError(f"per-region offer not supported for shard {shard!r}")
+    if session is None:
+        session = requests.Session()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    region_index_url = f"{_AWS_OFFER_BASE}/{service_code}/current/region_index.json"
+    raw_index = out_dir / f"{shard}-region_index.json"
+    _stream_download(region_index_url, raw_index, session=session, retries=retries)
+    index_doc = json.loads(raw_index.read_text())
+    raw_index.unlink(missing_ok=True)
+
+    upstream_regions: dict[str, str] = {
+        code: entry["currentVersionUrl"]
+        for code, entry in (index_doc.get("regions") or {}).items()
+    }
+
+    produced: list[Path] = []
+    for region in regions:
+        rel_url = upstream_regions.get(region)
+        if rel_url is None:
+            continue
+        region_url = f"https://pricing.us-east-1.amazonaws.com{rel_url}"
+        raw_path = out_dir / f"{shard}-{region}.raw.json"
+        try:
+            _stream_download(region_url, raw_path, session=session, retries=retries)
+            stripped_path = out_dir / f"{shard}-{region}.json"
+            _strip_ec2_offer(raw_path, stripped_path)
+            produced.append(stripped_path)
+        finally:
+            raw_path.unlink(missing_ok=True)
+    return produced
+
+
+def _strip_ec2_offer(raw_path: Path, out_path: Path) -> None:
+    """Stream-parse an AWS EC2-shape offer JSON, emit a trimmed version.
+
+    Keeps:
+      - products.<sku>.productFamily + whitelisted attributes leaves
+        (filtered to families actually consumed — Compute Instance, Storage).
+      - terms.OnDemand.<sku>.<termKey>.priceDimensions.<pdKey>.{unit, pricePerUnit}
+      - top-level offerCode, version, publicationDate for traceability.
+
+    Drops: terms.Reserved (bulk of terms), product attrs we don't consume,
+    offerTermCode, rateCode, effectiveDate, termAttributes, appliesTo,
+    priceDimensions.description/beginRange/endRange, etc.
+    """
+    products_kept: dict[str, dict[str, Any]] = {}
+    with raw_path.open("rb") as fh:
+        for sku_id, product in ijson.kvitems(fh, "products", use_float=True):
+            family = product.get("productFamily")
+            if family not in _EC2_PRODUCT_FAMILIES:
+                continue
+            attrs_raw = product.get("attributes") or {}
+            products_kept[sku_id] = {
+                "productFamily": family,
+                "attributes": {k: attrs_raw[k] for k in _EC2_KEEP_ATTRS if k in attrs_raw},
+            }
+
+    terms_kept: dict[str, dict[str, Any]] = {}
+    with raw_path.open("rb") as fh:
+        for sku_id, term_data in ijson.kvitems(fh, "terms.OnDemand", use_float=True):
+            if sku_id not in products_kept:
+                continue
+            stripped_terms: dict[str, dict[str, Any]] = {}
+            for term_key, term_obj in (term_data or {}).items():
+                pds_in = (term_obj or {}).get("priceDimensions") or {}
+                stripped_pds = {
+                    pd_key: {
+                        "unit": pd_obj.get("unit"),
+                        "pricePerUnit": pd_obj.get("pricePerUnit") or {},
+                    }
+                    for pd_key, pd_obj in pds_in.items()
+                }
+                stripped_terms[term_key] = {"priceDimensions": stripped_pds}
+            terms_kept[sku_id] = stripped_terms
+
+    out_doc = {
+        "products": products_kept,
+        "terms": {"OnDemand": terms_kept},
+    }
+    part = out_path.with_suffix(out_path.suffix + ".part")
+    part.write_text(json.dumps(out_doc, separators=(",", ":")))
+    os.replace(part, out_path)
+
+
+def aws_regions_from_yaml() -> list[str]:
+    """Distinct AWS regions referenced by regions.yaml (sorted)."""
+    normalizer = load_region_normalizer()
+    return sorted({region for (provider, region) in normalizer.table if provider == "aws"})

--- a/pipeline/ingest/aws_dynamodb.py
+++ b/pipeline/ingest/aws_dynamodb.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_dynamodb.py
+++ b/pipeline/ingest/aws_dynamodb.py
@@ -40,38 +40,32 @@ _GROUP_MAP: dict[str, str] = {
 }
 
 _SQL = """
-WITH prod_keys AS (
-  SELECT unnest(json_keys(products)) AS sku_id, products, terms FROM offer
-),
-products_flat AS (
+WITH products_flat AS (
   SELECT
-    sku_id,
-    json_extract_string(products, '$."' || sku_id || '".attributes.regionCode') AS region,
-    json_extract_string(products, '$."' || sku_id || '".attributes.storageClass') AS klass_raw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.group') AS group_raw,
-    terms
-  FROM prod_keys
+    p.key AS sku_id,
+    json_extract_string(p.value, '$.attributes.regionCode') AS region,
+    json_extract_string(p.value, '$.attributes.storageClass') AS klass_raw,
+    json_extract_string(p.value, '$.attributes.group') AS group_raw
+  FROM offer, json_each(offer.products) AS p(key, value)
 ),
-term_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms, '$.OnDemand."' || sku_id || '"'))[1] AS term_key
-  FROM products_flat
+terms_flat AS (
+  SELECT
+    t.key AS sku_id,
+    (json_keys(t.value))[1] AS term_key,
+    t.value AS term_obj
+  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
 ),
 pd_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms,
-      '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions'))[1] AS pd_key
-  FROM term_keys
+  SELECT tf.sku_id, tf.term_key, tf.term_obj,
+    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
+  FROM terms_flat tf
 )
-SELECT sku_id, region, klass_raw, group_raw,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".unit') AS unit,
-  CAST(json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".pricePerUnit.USD')
-    AS DOUBLE) AS usd,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".beginRange') AS begin_range
-FROM pd_keys
+SELECT pf.sku_id, pf.region, pf.klass_raw, pf.group_raw,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
+  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".beginRange') AS begin_range
+FROM products_flat pf
+JOIN pd_keys pk ON pf.sku_id = pk.sku_id
 """
 
 

--- a/pipeline/ingest/aws_dynamodb.py
+++ b/pipeline/ingest/aws_dynamodb.py
@@ -89,7 +89,8 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
             continue
         if dim == "storage" and begin_range not in (None, "0"):
             continue
-        normalizer.normalize(_PROVIDER, region)
+        if normalizer.try_normalize(_PROVIDER, region) is None:
+            continue
         key = (klass, region)
         grouped.setdefault(key, {})[dim] = {"sku": sku_id, "usd": usd, "unit": unit}
 

--- a/pipeline/ingest/aws_ebs.py
+++ b/pipeline/ingest/aws_ebs.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_ebs.py
+++ b/pipeline/ingest/aws_ebs.py
@@ -25,37 +25,32 @@ _KIND = "storage.block"
 _ALLOWED_TYPES: set[str] = {"gp3", "gp2", "io2", "st1", "sc1"}
 
 _SQL = """
-WITH prod_keys AS (
-  SELECT unnest(json_keys(products)) AS sku_id, products, terms FROM offer
-),
-products_flat AS (
+WITH products_flat AS (
   SELECT
-    sku_id,
-    json_extract_string(products, '$."' || sku_id || '".productFamily') AS family,
-    json_extract_string(products, '$."' || sku_id || '".attributes.regionCode') AS region,
-    json_extract_string(products, '$."' || sku_id || '".attributes.volumeApiName') AS vol_type,
-    terms
-  FROM prod_keys
+    p.key AS sku_id,
+    json_extract_string(p.value, '$.productFamily') AS family,
+    json_extract_string(p.value, '$.attributes.regionCode') AS region,
+    json_extract_string(p.value, '$.attributes.volumeApiName') AS vol_type
+  FROM offer, json_each(offer.products) AS p(key, value)
+  WHERE json_extract_string(p.value, '$.productFamily') = 'Storage'
 ),
-term_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms, '$.OnDemand."' || sku_id || '"'))[1] AS term_key
-  FROM products_flat
+terms_flat AS (
+  SELECT
+    t.key AS sku_id,
+    (json_keys(t.value))[1] AS term_key,
+    t.value AS term_obj
+  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
 ),
 pd_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms,
-      '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions'))[1] AS pd_key
-  FROM term_keys
+  SELECT tf.sku_id, tf.term_key, tf.term_obj,
+    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
+  FROM terms_flat tf
 )
-SELECT sku_id, region, vol_type,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".unit') AS unit,
-  CAST(json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".pricePerUnit.USD')
-    AS DOUBLE) AS usd
-FROM pd_keys
-WHERE family = 'Storage'
+SELECT pf.sku_id, pf.region, pf.vol_type,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
+  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
+FROM products_flat pf
+JOIN pd_keys pk ON pf.sku_id = pk.sku_id
 """
 
 

--- a/pipeline/ingest/aws_ebs.py
+++ b/pipeline/ingest/aws_ebs.py
@@ -1,13 +1,15 @@
-"""Normalize AWS EBS offer JSON into sku row dicts via DuckDB.
+"""Normalize AWS EBS rows out of the EC2 offer JSON (pure Python).
 
-Spec §5 storage.block kind. In m3a.2 each row carries only the storage
-dimension (GB-Mo); IOPS + throughput pricing -> m3a.3. One row per
-(volume_type, region); volume_type comes from attributes.volumeApiName.
+Spec §5 storage.block. EBS shares the AmazonEC2 offer with aws_ec2 — we use
+the same stripped per-region files. Each row carries only the storage dimension
+(GB-Mo); IOPS + throughput pricing -> m3a.3. One row per (volume_type, region);
+volume_type comes from attributes.volumeApiName.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -16,8 +18,9 @@ from typing import Any
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
 
-from ._duckdb import dumps, open_conn
-from .aws_common import load_region_normalizer
+from ._duckdb import dumps
+from .aws_common import aws_regions_from_yaml, fetch_offer_regions_stripped, load_region_normalizer
+from .aws_ec2 import _iter_product_prices
 
 _PROVIDER = "aws"
 _SERVICE = "ebs"
@@ -25,99 +28,98 @@ _KIND = "storage.block"
 
 _ALLOWED_TYPES: set[str] = {"gp3", "gp2", "io2", "st1", "sc1"}
 
-_SQL = """
-WITH products_flat AS (
-  SELECT
-    p.key AS sku_id,
-    json_extract_string(p.value, '$.productFamily') AS family,
-    json_extract_string(p.value, '$.attributes.regionCode') AS region,
-    json_extract_string(p.value, '$.attributes.volumeApiName') AS vol_type
-  FROM offer, json_each(offer.products) AS p(key, value)
-  WHERE json_extract_string(p.value, '$.productFamily') = 'Storage'
-),
-terms_flat AS (
-  SELECT
-    t.key AS sku_id,
-    (json_keys(t.value))[1] AS term_key,
-    t.value AS term_obj
-  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
-),
-pd_keys AS (
-  SELECT tf.sku_id, tf.term_key, tf.term_obj,
-    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
-  FROM terms_flat tf
-)
-SELECT pf.sku_id, pf.region, pf.vol_type,
-  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
-  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
-FROM products_flat pf
-JOIN pd_keys pk ON pf.sku_id = pk.sku_id
-"""
 
-
-def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
+def ingest(*, offer_paths: Iterable[Path]) -> Iterable[dict[str, Any]]:
     normalizer = load_region_normalizer()
-    con = open_conn()
-    path_literal = str(offer_path).replace("'", "''")
-    con.execute(
-        f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
-    )
+    for offer_path in offer_paths:
+        with offer_path.open() as fh:
+            offer = json.load(fh)
+        for sku_id, product, pd in _iter_product_prices(offer):
+            if product.get("productFamily") != "Storage":
+                continue
+            attrs = product.get("attributes") or {}
+            vol_type = attrs.get("volumeApiName")
+            if vol_type not in _ALLOWED_TYPES:
+                continue
+            region = attrs.get("regionCode", "")
+            region_normalized = normalizer.try_normalize(_PROVIDER, region)
+            if region_normalized is None:
+                continue
 
-    rows = list(con.execute(_SQL).fetchall())
-    # Filter first to allowed types so any non-EBS "Storage" family rows in
-    # the same offer file (e.g. RDS storage SKUs when the source is shared)
-    # don't trip the region validator.
-    rows = [r for r in rows if r[2] in _ALLOWED_TYPES]
+            unit = pd.get("unit") or ""
+            usd_raw = (pd.get("pricePerUnit") or {}).get("USD")
+            if usd_raw is None:
+                continue
+            try:
+                usd = float(usd_raw)
+            except (TypeError, ValueError):
+                continue
 
-    for sku_id, region, vol_type, unit, usd in rows:
-        region_normalized = normalizer.try_normalize(_PROVIDER, region)
-        if region_normalized is None:
-            continue
-        terms = apply_kind_defaults(_KIND, {
-            "commitment": "on_demand",
-            "tenancy": "",
-            "os": "",
-            "support_tier": "",
-            "upfront": "",
-            "payment_option": "",
-        })
-        yield {
-            "sku_id": sku_id,
-            "provider": _PROVIDER,
-            "service": _SERVICE,
-            "kind": _KIND,
-            "resource_name": vol_type,
-            "region": region,
-            "region_normalized": region_normalized,
-            "terms_hash": terms_hash(terms),
-            "resource_attrs": {
-                "extra": {"volume_type": vol_type},
-            },
-            "terms": terms,
-            "prices": [
-                {"dimension": "storage", "tier": "", "amount": usd, "unit": unit.lower()},
-            ],
-        }
+            terms = apply_kind_defaults(_KIND, {
+                "commitment": "on_demand",
+                "tenancy": "",
+                "os": "",
+                "support_tier": "",
+                "upfront": "",
+                "payment_option": "",
+            })
+            yield {
+                "sku_id": sku_id,
+                "provider": _PROVIDER,
+                "service": _SERVICE,
+                "kind": _KIND,
+                "resource_name": vol_type,
+                "region": region,
+                "region_normalized": region_normalized,
+                "terms_hash": terms_hash(terms),
+                "resource_attrs": {
+                    "extra": {"volume_type": vol_type},
+                },
+                "terms": terms,
+                "prices": [
+                    {"dimension": "storage", "tier": "", "amount": usd, "unit": unit.lower()},
+                ],
+            }
+
+
+def _resolve_paths(args: argparse.Namespace) -> list[Path]:
+    if args.offer_dir:
+        return sorted(p for p in args.offer_dir.glob("aws_ebs-*.json") if p.is_file())
+    if args.fixture:
+        p = args.fixture
+        return [p / "offer.json"] if p.is_dir() else [p]
+    if args.offer:
+        return [args.offer]
+    return []
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(prog="ingest.aws_ebs")
     ap.add_argument("--fixture", type=Path)
     ap.add_argument("--offer", type=Path)
+    ap.add_argument(
+        "--offer-dir",
+        type=Path,
+        help="directory to fetch stripped per-region offers into (if empty, fetches).",
+    )
     ap.add_argument("--out", type=Path, required=True)
     ap.add_argument("--catalog-version", default=None)
     args = ap.parse_args()
-    if args.fixture:
-        offer_path = args.fixture / "offer.json" if args.fixture.is_dir() else args.fixture
-    elif args.offer:
-        offer_path = args.offer
-    else:
-        print("either --fixture or --offer required", file=sys.stderr)
+
+    if args.offer_dir is not None and not any(args.offer_dir.glob("aws_ebs-*.json")):
+        args.offer_dir.mkdir(parents=True, exist_ok=True)
+        fetch_offer_regions_stripped(
+            "aws_ebs", args.offer_dir, regions=aws_regions_from_yaml()
+        )
+
+    paths = _resolve_paths(args)
+    if not paths:
+        print("either --fixture, --offer, or --offer-dir required", file=sys.stderr)
         return 2
+
     args.out.parent.mkdir(parents=True, exist_ok=True)
     with args.out.open("w") as fh:
-        for row in ingest(offer_path=offer_path):
+        for row in ingest(offer_paths=paths):
             fh.write(dumps(row) + "\n")
     return 0
 

--- a/pipeline/ingest/aws_ebs.py
+++ b/pipeline/ingest/aws_ebs.py
@@ -70,7 +70,9 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     rows = [r for r in rows if r[2] in _ALLOWED_TYPES]
 
     for sku_id, region, vol_type, unit, usd in rows:
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": "",

--- a/pipeline/ingest/aws_ebs.py
+++ b/pipeline/ingest/aws_ebs.py
@@ -65,7 +65,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'})"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
     )
 
     rows = list(con.execute(_SQL).fetchall())

--- a/pipeline/ingest/aws_ec2.py
+++ b/pipeline/ingest/aws_ec2.py
@@ -31,45 +31,42 @@ _OS_MAP: dict[str, str] = {"Linux": "linux", "Windows": "windows", "RHEL": "rhel
 _TENANCY_MAP: dict[str, str] = {"Shared": "shared", "Dedicated": "dedicated"}
 
 _SQL = """
-WITH prod_keys AS (
-  SELECT unnest(json_keys(products)) AS sku_id, products, terms FROM offer
-),
-products_flat AS (
+WITH products_flat AS (
   SELECT
-    sku_id,
-    json_extract_string(products, '$."' || sku_id || '".productFamily') AS family,
-    json_extract_string(products, '$."' || sku_id || '".attributes.instanceType') AS instance_type,
-    json_extract_string(products, '$."' || sku_id || '".attributes.regionCode') AS region,
-    json_extract_string(products, '$."' || sku_id || '".attributes.operatingSystem') AS os_raw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.tenancy') AS tenancy_raw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.preInstalledSw') AS pre_sw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.capacitystatus') AS cap,
-    json_extract_string(products, '$."' || sku_id || '".attributes.vcpu') AS vcpu,
-    json_extract_string(products, '$."' || sku_id || '".attributes.memory') AS memory,
-    json_extract_string(products, '$."' || sku_id || '".attributes.physicalProcessor') AS cpu,
-    json_extract_string(products, '$."' || sku_id || '".attributes.networkPerformance') AS net,
-    terms
-  FROM prod_keys
+    p.key AS sku_id,
+    json_extract_string(p.value, '$.productFamily') AS family,
+    json_extract_string(p.value, '$.attributes.instanceType') AS instance_type,
+    json_extract_string(p.value, '$.attributes.regionCode') AS region,
+    json_extract_string(p.value, '$.attributes.operatingSystem') AS os_raw,
+    json_extract_string(p.value, '$.attributes.tenancy') AS tenancy_raw,
+    json_extract_string(p.value, '$.attributes.preInstalledSw') AS pre_sw,
+    json_extract_string(p.value, '$.attributes.capacitystatus') AS cap,
+    json_extract_string(p.value, '$.attributes.vcpu') AS vcpu,
+    json_extract_string(p.value, '$.attributes.memory') AS memory,
+    json_extract_string(p.value, '$.attributes.physicalProcessor') AS cpu,
+    json_extract_string(p.value, '$.attributes.networkPerformance') AS net
+  FROM offer, json_each(offer.products) AS p(key, value)
+  WHERE json_extract_string(p.value, '$.productFamily') = 'Compute Instance'
+    AND json_extract_string(p.value, '$.attributes.preInstalledSw') = 'NA'
+    AND json_extract_string(p.value, '$.attributes.capacitystatus') = 'Used'
 ),
-term_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms, '$.OnDemand."' || sku_id || '"'))[1] AS term_key
-  FROM products_flat
+terms_flat AS (
+  SELECT
+    t.key AS sku_id,
+    (json_keys(t.value))[1] AS term_key,
+    t.value AS term_obj
+  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
 ),
 pd_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms,
-      '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions'))[1] AS pd_key
-  FROM term_keys
+  SELECT tf.sku_id, tf.term_key, tf.term_obj,
+    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
+  FROM terms_flat tf
 )
-SELECT sku_id, instance_type, region, os_raw, tenancy_raw, vcpu, memory, cpu, net,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".unit') AS unit,
-  CAST(json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".pricePerUnit.USD')
-    AS DOUBLE) AS usd
-FROM pd_keys
-WHERE family = 'Compute Instance' AND pre_sw = 'NA' AND cap = 'Used'
+SELECT pf.sku_id, pf.instance_type, pf.region, pf.os_raw, pf.tenancy_raw, pf.vcpu, pf.memory, pf.cpu, pf.net,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
+  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
+FROM products_flat pf
+JOIN pd_keys pk ON pf.sku_id = pk.sku_id
 """
 
 

--- a/pipeline/ingest/aws_ec2.py
+++ b/pipeline/ingest/aws_ec2.py
@@ -1,16 +1,16 @@
-"""Normalize AWS EC2 offer JSON into sku row dicts via DuckDB.
+"""Normalize AWS EC2 offer JSON into sku row dicts (pure Python).
 
-Spec §3 (format stack): read the offer's `products` and `terms.OnDemand`
-as JSON columns and navigate them with json_extract — the nested shape
-uses SKU IDs as object keys, so DuckDB infers them as STRUCTs unless we
-force a JSON column type. One SQL pass joins each product with its
-on-demand term + priceDimension entry; Python then filters to the
-supported OS/tenancy surface and emits NDJSON rows.
+The AWS AmazonEC2 offer is ~8 GB combined. `aws_common.fetch_offer_regions_stripped`
+downloads per-region index files, stream-strips each via ijson, and hands us
+small JSON files (~30 MB). Here we iterate those files with `json.load` and
+emit NDJSON rows for our coverage surface (Compute Instance, Linux/Windows/RHEL,
+Shared/Dedicated, On-Demand).
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -19,131 +19,146 @@ from typing import Any
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
 
-from ._duckdb import dumps, open_conn
-from .aws_common import load_region_normalizer
+from ._duckdb import dumps
+from .aws_common import aws_regions_from_yaml, fetch_offer_regions_stripped, load_region_normalizer
 
 _PROVIDER = "aws"
 _SERVICE = "ec2"
 _KIND = "compute.vm"
 
-# Keep the OS mapping narrow — only variants we ship in v1.
 _OS_MAP: dict[str, str] = {"Linux": "linux", "Windows": "windows", "RHEL": "rhel"}
-# Tenancy comes through as Shared / Dedicated / Host; we drop Host for m3a.1.
 _TENANCY_MAP: dict[str, str] = {"Shared": "shared", "Dedicated": "dedicated"}
-
-_SQL = """
-WITH products_flat AS (
-  SELECT
-    p.key AS sku_id,
-    json_extract_string(p.value, '$.productFamily') AS family,
-    json_extract_string(p.value, '$.attributes.instanceType') AS instance_type,
-    json_extract_string(p.value, '$.attributes.regionCode') AS region,
-    json_extract_string(p.value, '$.attributes.operatingSystem') AS os_raw,
-    json_extract_string(p.value, '$.attributes.tenancy') AS tenancy_raw,
-    json_extract_string(p.value, '$.attributes.preInstalledSw') AS pre_sw,
-    json_extract_string(p.value, '$.attributes.capacitystatus') AS cap,
-    json_extract_string(p.value, '$.attributes.vcpu') AS vcpu,
-    json_extract_string(p.value, '$.attributes.memory') AS memory,
-    json_extract_string(p.value, '$.attributes.physicalProcessor') AS cpu,
-    json_extract_string(p.value, '$.attributes.networkPerformance') AS net
-  FROM offer, json_each(offer.products) AS p(key, value)
-  WHERE json_extract_string(p.value, '$.productFamily') = 'Compute Instance'
-    AND json_extract_string(p.value, '$.attributes.preInstalledSw') = 'NA'
-    AND json_extract_string(p.value, '$.attributes.capacitystatus') = 'Used'
-),
-terms_flat AS (
-  SELECT
-    t.key AS sku_id,
-    (json_keys(t.value))[1] AS term_key,
-    t.value AS term_obj
-  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
-),
-pd_keys AS (
-  SELECT tf.sku_id, tf.term_key, tf.term_obj,
-    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
-  FROM terms_flat tf
-)
-SELECT pf.sku_id, pf.instance_type, pf.region, pf.os_raw, pf.tenancy_raw, pf.vcpu, pf.memory, pf.cpu, pf.net,
-  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
-  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
-FROM products_flat pf
-JOIN pd_keys pk ON pf.sku_id = pk.sku_id
-"""
 
 
 def _parse_memory(raw: str) -> float:
     return float(raw.split()[0])
 
 
-def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
+def _iter_product_prices(offer: dict[str, Any]) -> Iterable[tuple[str, dict, dict]]:
+    """Yield (sku_id, product, price_dimension) for every On-Demand priced product.
+
+    Works on both the full AWS EC2 offer shape and the stripped shape — both keep
+    `products.<sku>.{productFamily,attributes}` and
+    `terms.OnDemand.<sku>.<termKey>.priceDimensions.<pdKey>.{unit, pricePerUnit}`.
+    """
+    products = offer.get("products") or {}
+    terms_od = (offer.get("terms") or {}).get("OnDemand") or {}
+    for sku_id, product in products.items():
+        term_data = terms_od.get(sku_id)
+        if not term_data:
+            continue
+        term_obj = next(iter(term_data.values()), None) or {}
+        pd = next(iter((term_obj.get("priceDimensions") or {}).values()), None)
+        if pd is None:
+            continue
+        yield sku_id, product, pd
+
+
+def ingest(*, offer_paths: Iterable[Path]) -> Iterable[dict[str, Any]]:
     normalizer = load_region_normalizer()
-    con = open_conn()
-    path_literal = str(offer_path).replace("'", "''")
-    con.execute(
-        f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
-    )
-    for sku_id, instance_type, region, os_raw, tenancy_raw, vcpu_raw, memory_raw, cpu, net, unit, usd in (
-        con.execute(_SQL).fetchall()
-    ):
-        if os_raw not in _OS_MAP or tenancy_raw not in _TENANCY_MAP:
-            continue
-        region_normalized = normalizer.try_normalize(_PROVIDER, region)
-        if region_normalized is None:
-            continue
-        terms = apply_kind_defaults(_KIND, {
-            "commitment": "on_demand",
-            "tenancy": _TENANCY_MAP[tenancy_raw],
-            "os": _OS_MAP[os_raw],
-            "support_tier": "",
-            "upfront": "",
-            "payment_option": "",
-        })
-        yield {
-            "sku_id": sku_id,
-            "provider": _PROVIDER,
-            "service": _SERVICE,
-            "kind": _KIND,
-            "resource_name": instance_type,
-            "region": region,
-            "region_normalized": region_normalized,
-            "terms_hash": terms_hash(terms),
-            "resource_attrs": {
-                "vcpu": int(vcpu_raw),
-                "memory_gb": _parse_memory(memory_raw),
-                "architecture": "x86_64",
-                "extra": {
-                    "physical_processor": cpu,
-                    "network_performance": net,
+    for offer_path in offer_paths:
+        with offer_path.open() as fh:
+            offer = json.load(fh)
+        for sku_id, product, pd in _iter_product_prices(offer):
+            if product.get("productFamily") != "Compute Instance":
+                continue
+            attrs = product.get("attributes") or {}
+            if attrs.get("preInstalledSw") != "NA":
+                continue
+            if attrs.get("capacitystatus") != "Used":
+                continue
+            os_raw = attrs.get("operatingSystem")
+            tenancy_raw = attrs.get("tenancy")
+            if os_raw not in _OS_MAP or tenancy_raw not in _TENANCY_MAP:
+                continue
+            region = attrs.get("regionCode", "")
+            region_normalized = normalizer.try_normalize(_PROVIDER, region)
+            if region_normalized is None:
+                continue
+
+            unit = pd.get("unit") or ""
+            usd_raw = (pd.get("pricePerUnit") or {}).get("USD")
+            if usd_raw is None:
+                continue
+            try:
+                usd = float(usd_raw)
+            except (TypeError, ValueError):
+                continue
+
+            terms = apply_kind_defaults(_KIND, {
+                "commitment": "on_demand",
+                "tenancy": _TENANCY_MAP[tenancy_raw],
+                "os": _OS_MAP[os_raw],
+                "support_tier": "",
+                "upfront": "",
+                "payment_option": "",
+            })
+            yield {
+                "sku_id": sku_id,
+                "provider": _PROVIDER,
+                "service": _SERVICE,
+                "kind": _KIND,
+                "resource_name": attrs.get("instanceType"),
+                "region": region,
+                "region_normalized": region_normalized,
+                "terms_hash": terms_hash(terms),
+                "resource_attrs": {
+                    "vcpu": int(attrs.get("vcpu")),
+                    "memory_gb": _parse_memory(attrs.get("memory", "0")),
+                    "architecture": "x86_64",
+                    "extra": {
+                        "physical_processor": attrs.get("physicalProcessor"),
+                        "network_performance": attrs.get("networkPerformance"),
+                    },
                 },
-            },
-            "terms": terms,
-            "prices": [
-                {"dimension": "compute", "tier": "", "amount": usd, "unit": unit.lower()},
-            ],
-        }
+                "terms": terms,
+                "prices": [
+                    {"dimension": "compute", "tier": "", "amount": usd, "unit": unit.lower()},
+                ],
+            }
+
+
+def _resolve_paths(args: argparse.Namespace) -> list[Path]:
+    """Resolve CLI args → a list of stripped offer-JSON paths ready to feed ingest."""
+    if args.offer_dir:
+        return sorted(p for p in args.offer_dir.glob("aws_ec2-*.json") if p.is_file())
+    if args.fixture:
+        p = args.fixture
+        return [p / "offer.json"] if p.is_dir() else [p]
+    if args.offer:
+        return [args.offer]
+    return []
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(prog="ingest.aws_ec2")
     ap.add_argument("--fixture", type=Path, help="path to a trimmed offer.json (tests)")
-    ap.add_argument("--offer", type=Path, help="path to live offer.json")
+    ap.add_argument("--offer", type=Path, help="single stripped offer.json")
+    ap.add_argument(
+        "--offer-dir",
+        type=Path,
+        help="directory to fetch stripped per-region offers into (if empty, fetches).",
+    )
     ap.add_argument("--out", type=Path, required=True)
     # --catalog-version is consumed by the packager; accept and ignore here.
     ap.add_argument("--catalog-version", default=None)
     args = ap.parse_args()
 
-    if args.fixture:
-        offer_path = args.fixture / "offer.json" if args.fixture.is_dir() else args.fixture
-    elif args.offer:
-        offer_path = args.offer
-    else:
-        print("either --fixture or --offer required", file=sys.stderr)
+    # If offer-dir is given but empty, drive the fetch ourselves.
+    if args.offer_dir is not None and not any(args.offer_dir.glob("aws_ec2-*.json")):
+        args.offer_dir.mkdir(parents=True, exist_ok=True)
+        fetch_offer_regions_stripped(
+            "aws_ec2", args.offer_dir, regions=aws_regions_from_yaml()
+        )
+
+    paths = _resolve_paths(args)
+    if not paths:
+        print("either --fixture, --offer, or --offer-dir required", file=sys.stderr)
         return 2
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     with args.out.open("w") as fh:
-        for row in ingest(offer_path=offer_path):
+        for row in ingest(offer_paths=paths):
             fh.write(dumps(row) + "\n")
     return 0
 

--- a/pipeline/ingest/aws_ec2.py
+++ b/pipeline/ingest/aws_ec2.py
@@ -83,7 +83,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'})"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
     )
     for sku_id, instance_type, region, os_raw, tenancy_raw, vcpu_raw, memory_raw, cpu, net, unit, usd in (
         con.execute(_SQL).fetchall()

--- a/pipeline/ingest/aws_ec2.py
+++ b/pipeline/ingest/aws_ec2.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_ec2.py
+++ b/pipeline/ingest/aws_ec2.py
@@ -87,7 +87,9 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     ):
         if os_raw not in _OS_MAP or tenancy_raw not in _TENANCY_MAP:
             continue
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": _TENANCY_MAP[tenancy_raw],

--- a/pipeline/ingest/aws_lambda.py
+++ b/pipeline/ingest/aws_lambda.py
@@ -73,7 +73,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'})"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
     )
 
     grouped: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}

--- a/pipeline/ingest/aws_lambda.py
+++ b/pipeline/ingest/aws_lambda.py
@@ -1,4 +1,4 @@
-"""Normalize AWS Lambda offer JSON into sku row dicts via DuckDB.
+"""Normalize AWS Lambda offer JSON into sku row dicts.
 
 Spec §5 compute.function kind. Lambda rows carry two price dimensions:
 - requests (unit: requests) from group=AWS-Lambda-Requests
@@ -11,6 +11,7 @@ ephemeral-storage surcharges are out of scope for m3a.2 (see non-goals).
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -19,7 +20,7 @@ from typing import Any
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
 
-from ._duckdb import dumps, open_conn
+from ._duckdb import dumps
 from .aws_common import load_region_normalizer
 
 _PROVIDER = "aws"
@@ -32,56 +33,39 @@ _GROUP_MAP: dict[str, str] = {
     "AWS-Lambda-Duration": "duration",
 }
 
-_SQL = """
-WITH products_flat AS (
-  SELECT
-    p.key AS sku_id,
-    json_extract_string(p.value, '$.productFamily') AS family,
-    json_extract_string(p.value, '$.attributes.regionCode') AS region,
-    json_extract_string(p.value, '$.attributes.archSupport') AS arch_raw,
-    json_extract_string(p.value, '$.attributes.group') AS group_raw
-  FROM offer, json_each(offer.products) AS p(key, value)
-  WHERE json_extract_string(p.value, '$.productFamily') = 'Serverless'
-),
-terms_flat AS (
-  SELECT
-    t.key AS sku_id,
-    (json_keys(t.value))[1] AS term_key,
-    t.value AS term_obj
-  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
-),
-pd_keys AS (
-  SELECT tf.sku_id, tf.term_key, tf.term_obj,
-    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
-  FROM terms_flat tf
-)
-SELECT pf.sku_id, pf.region, pf.arch_raw, pf.group_raw,
-  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
-  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
-FROM products_flat pf
-JOIN pd_keys pk ON pf.sku_id = pk.sku_id
-"""
+
+def _first_pd(term_data: dict) -> dict | None:
+    term = next(iter(term_data.values()), None)
+    if not term:
+        return None
+    return next(iter(term.get("priceDimensions", {}).values()), None)
 
 
 def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     normalizer = load_region_normalizer()
-    con = open_conn()
-    path_literal = str(offer_path).replace("'", "''")
-    con.execute(
-        f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
-    )
+    with offer_path.open() as f:
+        offer = json.load(f)
+    products = offer.get("products", {})
+    terms_od = offer.get("terms", {}).get("OnDemand", {})
 
     grouped: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}
-    for sku_id, region, arch_raw, group_raw, unit, usd in con.execute(_SQL).fetchall():
-        arch = _ARCH_MAP.get(arch_raw)
-        dim = _GROUP_MAP.get(group_raw)
+    for sku_id, product in products.items():
+        if product.get("productFamily") != "Serverless":
+            continue
+        attrs = product.get("attributes", {})
+        region = attrs.get("regionCode", "")
+        arch = _ARCH_MAP.get(attrs.get("archSupport", ""))
+        dim = _GROUP_MAP.get(attrs.get("group", ""))
         if arch is None or dim is None:
             continue
         if normalizer.try_normalize(_PROVIDER, region) is None:
-            continue  # skip regions outside our coverage map
-        key = (arch, region)
-        grouped.setdefault(key, {})[dim] = {"sku": sku_id, "usd": usd, "unit": unit}
+            continue
+        pd = _first_pd(terms_od.get(sku_id) or {})
+        if pd is None:
+            continue
+        usd = float(pd.get("pricePerUnit", {}).get("USD", "0"))
+        unit = pd.get("unit", "")
+        grouped.setdefault((arch, region), {})[dim] = {"sku": sku_id, "usd": usd, "unit": unit}
 
     for (arch, region), dims in sorted(grouped.items()):
         if {"requests", "duration"} - dims.keys():

--- a/pipeline/ingest/aws_lambda.py
+++ b/pipeline/ingest/aws_lambda.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_lambda.py
+++ b/pipeline/ingest/aws_lambda.py
@@ -32,38 +32,33 @@ _GROUP_MAP: dict[str, str] = {
 }
 
 _SQL = """
-WITH prod_keys AS (
-  SELECT unnest(json_keys(products)) AS sku_id, products, terms FROM offer
-),
-products_flat AS (
+WITH products_flat AS (
   SELECT
-    sku_id,
-    json_extract_string(products, '$."' || sku_id || '".productFamily') AS family,
-    json_extract_string(products, '$."' || sku_id || '".attributes.regionCode') AS region,
-    json_extract_string(products, '$."' || sku_id || '".attributes.archSupport') AS arch_raw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.group') AS group_raw,
-    terms
-  FROM prod_keys
+    p.key AS sku_id,
+    json_extract_string(p.value, '$.productFamily') AS family,
+    json_extract_string(p.value, '$.attributes.regionCode') AS region,
+    json_extract_string(p.value, '$.attributes.archSupport') AS arch_raw,
+    json_extract_string(p.value, '$.attributes.group') AS group_raw
+  FROM offer, json_each(offer.products) AS p(key, value)
+  WHERE json_extract_string(p.value, '$.productFamily') = 'Serverless'
 ),
-term_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms, '$.OnDemand."' || sku_id || '"'))[1] AS term_key
-  FROM products_flat
+terms_flat AS (
+  SELECT
+    t.key AS sku_id,
+    (json_keys(t.value))[1] AS term_key,
+    t.value AS term_obj
+  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
 ),
 pd_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms,
-      '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions'))[1] AS pd_key
-  FROM term_keys
+  SELECT tf.sku_id, tf.term_key, tf.term_obj,
+    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
+  FROM terms_flat tf
 )
-SELECT sku_id, region, arch_raw, group_raw,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".unit') AS unit,
-  CAST(json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".pricePerUnit.USD')
-    AS DOUBLE) AS usd
-FROM pd_keys
-WHERE family = 'Serverless'
+SELECT pf.sku_id, pf.region, pf.arch_raw, pf.group_raw,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
+  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
+FROM products_flat pf
+JOIN pd_keys pk ON pf.sku_id = pk.sku_id
 """
 
 

--- a/pipeline/ingest/aws_lambda.py
+++ b/pipeline/ingest/aws_lambda.py
@@ -77,7 +77,8 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
         dim = _GROUP_MAP.get(group_raw)
         if arch is None or dim is None:
             continue
-        normalizer.normalize(_PROVIDER, region)  # early reject on unknown region
+        if normalizer.try_normalize(_PROVIDER, region) is None:
+            continue  # skip regions outside our coverage map
         key = (arch, region)
         grouped.setdefault(key, {})[dim] = {"sku": sku_id, "usd": usd, "unit": unit}
 

--- a/pipeline/ingest/aws_rds.py
+++ b/pipeline/ingest/aws_rds.py
@@ -74,7 +74,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=536870912)"
     )
     for sku_id, instance_type, region, engine_raw, depl_raw, license_model, vcpu_raw, memory_raw, unit, usd in (
         con.execute(_SQL).fetchall()

--- a/pipeline/ingest/aws_rds.py
+++ b/pipeline/ingest/aws_rds.py
@@ -1,4 +1,4 @@
-"""Normalize AWS RDS offer JSON into sku row dicts via DuckDB.
+"""Normalize AWS RDS offer JSON into sku row dicts.
 
 Spec §5 db.relational kind. Engine and deployment-option ride the
 terms.tenancy and terms.os slots — see enums.yaml comment for rationale.
@@ -7,6 +7,7 @@ terms.tenancy and terms.os slots — see enums.yaml comment for rationale.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -15,7 +16,7 @@ from typing import Any
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
 
-from ._duckdb import dumps, open_conn
+from ._duckdb import dumps
 from .aws_common import load_region_normalizer
 
 _PROVIDER = "aws"
@@ -25,56 +26,37 @@ _KIND = "db.relational"
 _ENGINE_MAP = {"PostgreSQL": "postgres", "MySQL": "mysql", "MariaDB": "mariadb"}
 _DEPL_MAP = {"Single-AZ": "single-az", "Multi-AZ": "multi-az"}
 
-_SQL = """
-WITH products_flat AS (
-  SELECT
-    p.key AS sku_id,
-    json_extract_string(p.value, '$.productFamily') AS family,
-    json_extract_string(p.value, '$.attributes.instanceType') AS instance_type,
-    json_extract_string(p.value, '$.attributes.regionCode') AS region,
-    json_extract_string(p.value, '$.attributes.databaseEngine') AS engine_raw,
-    json_extract_string(p.value, '$.attributes.deploymentOption') AS depl_raw,
-    json_extract_string(p.value, '$.attributes.licenseModel') AS license_model,
-    json_extract_string(p.value, '$.attributes.vcpu') AS vcpu,
-    json_extract_string(p.value, '$.attributes.memory') AS memory
-  FROM offer, json_each(offer.products) AS p(key, value)
-  WHERE json_extract_string(p.value, '$.productFamily') = 'Database Instance'
-),
-terms_flat AS (
-  SELECT
-    t.key AS sku_id,
-    (json_keys(t.value))[1] AS term_key,
-    t.value AS term_obj
-  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
-),
-pd_keys AS (
-  SELECT tf.sku_id, tf.term_key, tf.term_obj,
-    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
-  FROM terms_flat tf
-)
-SELECT pf.sku_id, pf.instance_type, pf.region, pf.engine_raw, pf.depl_raw, pf.license_model, pf.vcpu, pf.memory,
-  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
-  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
-FROM products_flat pf
-JOIN pd_keys pk ON pf.sku_id = pk.sku_id
-"""
-
 
 def _parse_memory(raw: str) -> float:
     return float(raw.split()[0])
 
 
+def _first_pd(term_data: dict) -> dict | None:
+    term = next(iter(term_data.values()), None)
+    if not term:
+        return None
+    return next(iter(term.get("priceDimensions", {}).values()), None)
+
+
 def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     normalizer = load_region_normalizer()
-    con = open_conn()
-    path_literal = str(offer_path).replace("'", "''")
-    con.execute(
-        f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=536870912)"
-    )
-    for sku_id, instance_type, region, engine_raw, depl_raw, license_model, vcpu_raw, memory_raw, unit, usd in (
-        con.execute(_SQL).fetchall()
-    ):
+    with offer_path.open() as f:
+        offer = json.load(f)
+    products = offer.get("products", {})
+    terms_od = offer.get("terms", {}).get("OnDemand", {})
+
+    for sku_id, product in products.items():
+        if product.get("productFamily") != "Database Instance":
+            continue
+        attrs = product.get("attributes", {})
+        instance_type = attrs.get("instanceType", "")
+        region = attrs.get("regionCode", "")
+        engine_raw = attrs.get("databaseEngine", "")
+        depl_raw = attrs.get("deploymentOption", "")
+        license_model = attrs.get("licenseModel", "")
+        vcpu_raw = attrs.get("vcpu", "")
+        memory_raw = attrs.get("memory", "")
+
         if license_model and license_model != "No license required":
             continue
         if engine_raw not in _ENGINE_MAP or depl_raw not in _DEPL_MAP:
@@ -82,6 +64,12 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
         region_normalized = normalizer.try_normalize(_PROVIDER, region)
         if region_normalized is None:
             continue
+        pd = _first_pd(terms_od.get(sku_id) or {})
+        if pd is None:
+            continue
+        usd = float(pd.get("pricePerUnit", {}).get("USD", "0"))
+        unit = pd.get("unit", "")
+
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": _ENGINE_MAP[engine_raw],

--- a/pipeline/ingest/aws_rds.py
+++ b/pipeline/ingest/aws_rds.py
@@ -74,7 +74,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'})"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
     )
     for sku_id, instance_type, region, engine_raw, depl_raw, license_model, vcpu_raw, memory_raw, unit, usd in (
         con.execute(_SQL).fetchall()

--- a/pipeline/ingest/aws_rds.py
+++ b/pipeline/ingest/aws_rds.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_rds.py
+++ b/pipeline/ingest/aws_rds.py
@@ -78,7 +78,9 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
             continue
         if engine_raw not in _ENGINE_MAP or depl_raw not in _DEPL_MAP:
             continue
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": _ENGINE_MAP[engine_raw],

--- a/pipeline/ingest/aws_rds.py
+++ b/pipeline/ingest/aws_rds.py
@@ -25,42 +25,37 @@ _ENGINE_MAP = {"PostgreSQL": "postgres", "MySQL": "mysql", "MariaDB": "mariadb"}
 _DEPL_MAP = {"Single-AZ": "single-az", "Multi-AZ": "multi-az"}
 
 _SQL = """
-WITH prod_keys AS (
-  SELECT unnest(json_keys(products)) AS sku_id, products, terms FROM offer
-),
-products_flat AS (
+WITH products_flat AS (
   SELECT
-    sku_id,
-    json_extract_string(products, '$."' || sku_id || '".productFamily') AS family,
-    json_extract_string(products, '$."' || sku_id || '".attributes.instanceType') AS instance_type,
-    json_extract_string(products, '$."' || sku_id || '".attributes.regionCode') AS region,
-    json_extract_string(products, '$."' || sku_id || '".attributes.databaseEngine') AS engine_raw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.deploymentOption') AS depl_raw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.licenseModel') AS license_model,
-    json_extract_string(products, '$."' || sku_id || '".attributes.vcpu') AS vcpu,
-    json_extract_string(products, '$."' || sku_id || '".attributes.memory') AS memory,
-    terms
-  FROM prod_keys
+    p.key AS sku_id,
+    json_extract_string(p.value, '$.productFamily') AS family,
+    json_extract_string(p.value, '$.attributes.instanceType') AS instance_type,
+    json_extract_string(p.value, '$.attributes.regionCode') AS region,
+    json_extract_string(p.value, '$.attributes.databaseEngine') AS engine_raw,
+    json_extract_string(p.value, '$.attributes.deploymentOption') AS depl_raw,
+    json_extract_string(p.value, '$.attributes.licenseModel') AS license_model,
+    json_extract_string(p.value, '$.attributes.vcpu') AS vcpu,
+    json_extract_string(p.value, '$.attributes.memory') AS memory
+  FROM offer, json_each(offer.products) AS p(key, value)
+  WHERE json_extract_string(p.value, '$.productFamily') = 'Database Instance'
 ),
-term_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms, '$.OnDemand."' || sku_id || '"'))[1] AS term_key
-  FROM products_flat
+terms_flat AS (
+  SELECT
+    t.key AS sku_id,
+    (json_keys(t.value))[1] AS term_key,
+    t.value AS term_obj
+  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
 ),
 pd_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms,
-      '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions'))[1] AS pd_key
-  FROM term_keys
+  SELECT tf.sku_id, tf.term_key, tf.term_obj,
+    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
+  FROM terms_flat tf
 )
-SELECT sku_id, instance_type, region, engine_raw, depl_raw, license_model, vcpu, memory,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".unit') AS unit,
-  CAST(json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".pricePerUnit.USD')
-    AS DOUBLE) AS usd
-FROM pd_keys
-WHERE family = 'Database Instance'
+SELECT pf.sku_id, pf.instance_type, pf.region, pf.engine_raw, pf.depl_raw, pf.license_model, pf.vcpu, pf.memory,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
+  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
+FROM products_flat pf
+JOIN pd_keys pk ON pf.sku_id = pk.sku_id
 """
 
 

--- a/pipeline/ingest/aws_s3.py
+++ b/pipeline/ingest/aws_s3.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_s3.py
+++ b/pipeline/ingest/aws_s3.py
@@ -120,7 +120,8 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
                 continue
         else:
             continue
-        normalizer.normalize(_PROVIDER, region)  # early reject on unknown region
+        if normalizer.try_normalize(_PROVIDER, region) is None:
+            continue  # skip regions outside our coverage map
         key = (klass, region)
         grouped.setdefault(key, {})[dim] = {
             "sku": sku_id, "usd": usd, "unit": unit, "volume_type": volume_type,

--- a/pipeline/ingest/aws_s3.py
+++ b/pipeline/ingest/aws_s3.py
@@ -60,40 +60,34 @@ _REQUEST_GROUP_MAP: dict[str, str] = {
 # on-demand term has one non-tiered priceDimension per SKU for the m3a.2
 # scope (first tier only for storage); we take the first pd_key.
 _SQL = """
-WITH prod_keys AS (
-  SELECT unnest(json_keys(products)) AS sku_id, products, terms FROM offer
-),
-products_flat AS (
+WITH products_flat AS (
   SELECT
-    sku_id,
-    json_extract_string(products, '$."' || sku_id || '".productFamily') AS family,
-    json_extract_string(products, '$."' || sku_id || '".attributes.regionCode') AS region,
-    json_extract_string(products, '$."' || sku_id || '".attributes.volumeType') AS volume_type,
-    json_extract_string(products, '$."' || sku_id || '".attributes.group') AS group_raw,
-    terms
-  FROM prod_keys
+    p.key AS sku_id,
+    json_extract_string(p.value, '$.productFamily') AS family,
+    json_extract_string(p.value, '$.attributes.regionCode') AS region,
+    json_extract_string(p.value, '$.attributes.volumeType') AS volume_type,
+    json_extract_string(p.value, '$.attributes.group') AS group_raw
+  FROM offer, json_each(offer.products) AS p(key, value)
+  WHERE json_extract_string(p.value, '$.productFamily') IN ('Storage', 'API Request')
 ),
-term_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms, '$.OnDemand."' || sku_id || '"'))[1] AS term_key
-  FROM products_flat
+terms_flat AS (
+  SELECT
+    t.key AS sku_id,
+    (json_keys(t.value))[1] AS term_key,
+    t.value AS term_obj
+  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
 ),
 pd_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms,
-      '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions'))[1] AS pd_key
-  FROM term_keys
+  SELECT tf.sku_id, tf.term_key, tf.term_obj,
+    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
+  FROM terms_flat tf
 )
-SELECT sku_id, family, region, volume_type, group_raw,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".unit') AS unit,
-  CAST(json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".pricePerUnit.USD')
-    AS DOUBLE) AS usd,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".beginRange') AS begin_range
-FROM pd_keys
-WHERE family IN ('Storage', 'API Request')
+SELECT pf.sku_id, pf.family, pf.region, pf.volume_type, pf.group_raw,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
+  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".beginRange') AS begin_range
+FROM products_flat pf
+JOIN pd_keys pk ON pf.sku_id = pk.sku_id
 """
 
 

--- a/pipeline/ingest/aws_s3.py
+++ b/pipeline/ingest/aws_s3.py
@@ -103,7 +103,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'})"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
     )
 
     # Collect: (storage_class, region) -> {"storage": {sku,usd,unit,volume_type}, ...}

--- a/pipeline/ingest/azure_blob.py
+++ b/pipeline/ingest/azure_blob.py
@@ -93,7 +93,8 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
         dim = _dim_for(meter_name)
         if dim is None:
             continue
-        normalizer.normalize(_PROVIDER, region)  # early reject on unknown region
+        if normalizer.try_normalize(_PROVIDER, region) is None:
+            continue  # skip regions outside our coverage map
         if dim == "storage":
             divisor, unit = parse_storage_uom(uom)
         else:

--- a/pipeline/ingest/azure_blob.py
+++ b/pipeline/ingest/azure_blob.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/azure_common.py
+++ b/pipeline/ingest/azure_common.py
@@ -117,6 +117,15 @@ def fetch_prices(filter_str: str, target: Path, *, session=None, retries: int = 
             for attempt in range(retries):
                 try:
                     resp = sess.get(url, headers=headers, timeout=15.0)
+                    if resp.status_code == 429:
+                        retry_after = resp.headers.get("Retry-After")
+                        delay = float(retry_after) if retry_after else (0.5 * 2**attempt * 10)
+                        if attempt < retries - 1:
+                            time.sleep(delay)
+                            continue
+                        raise RuntimeError(
+                            f"GET {url} failed with status 429 after {retries} attempts"
+                        )
                     if resp.status_code in _RETRY_STATUSES:
                         if attempt < retries - 1:
                             time.sleep(0.5 * 2**attempt)

--- a/pipeline/ingest/azure_common.py
+++ b/pipeline/ingest/azure_common.py
@@ -60,3 +60,110 @@ def parse_request_uom(uom: str) -> tuple[float, str]:
         return _REQUEST_DIVISORS[uom]
     except KeyError as exc:
         raise ValueError(f"unsupported request unitOfMeasure: {uom}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Live Azure retail-prices fetcher (m3a.4.1)
+# ---------------------------------------------------------------------------
+
+import hashlib  # noqa: E402
+import json  # noqa: E402
+import os  # noqa: E402
+import time  # noqa: E402
+from pathlib import Path  # noqa: E402
+from urllib.parse import urlencode  # noqa: E402
+
+import requests  # noqa: E402
+
+_AZURE_RETAIL_BASE = "https://prices.azure.com/api/retail/prices"
+_MAX_PAGES = 10_000
+_UA = "sku-pipeline/0.0 (+https://github.com/sofq/sku)"
+
+
+def fetch_prices(filter_str: str, target: Path, *, session=None, retries: int = 3) -> str:
+    """Page through Azure retail-prices with $filter=<filter_str> and write
+    the concatenated items to `target` as ``{"Items": [...]}`` with items sorted
+    by skuId.  Returns SHA256 hex digest of the sorted normalised item list.
+
+    First request: ``{_AZURE_RETAIL_BASE}?$filter=<filter_str>&api-version=2023-01-01-preview``.
+    Subsequent requests follow ``NextPageLink`` verbatim (Azure returns full URLs).
+    Caps at ``_MAX_PAGES`` pages → ``RuntimeError("page_cap_exceeded")``.
+    Retries 500/502/503/504 per-page with ``time.sleep(0.5 * 2**attempt)``; 4xx no retry.
+    Atomic write via .part + os.replace.
+    User-Agent: ``sku-pipeline/<anything> (+https://github.com/sofq/sku)``.
+    """
+    _RETRY_STATUSES = frozenset({500, 502, 503, 504})
+    headers = {"User-Agent": _UA}
+
+    own_session = session is None
+    sess = requests.Session() if own_session else session
+
+    try:
+        items: list[dict] = []
+        first_url = (
+            _AZURE_RETAIL_BASE
+            + "?"
+            + urlencode({"$filter": filter_str, "api-version": "2023-01-01-preview"})
+        )
+        next_url: str | None = first_url
+
+        for _ in range(_MAX_PAGES):
+            if next_url is None:
+                break
+
+            url = next_url
+            last_exc: Exception | None = None
+
+            for attempt in range(retries):
+                try:
+                    resp = sess.get(url, headers=headers, timeout=15.0)
+                    if resp.status_code in _RETRY_STATUSES:
+                        if attempt < retries - 1:
+                            time.sleep(0.5 * 2**attempt)
+                            continue
+                        raise RuntimeError(
+                            f"GET {url} failed with status {resp.status_code}"
+                            f" after {retries} attempts"
+                        )
+                    if resp.status_code >= 400:
+                        raise RuntimeError(
+                            f"GET {url} failed with status {resp.status_code} (no retry)"
+                        )
+                    resp.raise_for_status()
+                    data = resp.json()
+                    items.extend(data.get("Items") or [])
+                    next_url = data.get("NextPageLink") or None
+                    last_exc = None
+                    break
+                except RuntimeError:
+                    raise
+                except requests.RequestException as exc:
+                    last_exc = exc
+                    if attempt < retries - 1:
+                        time.sleep(0.5 * 2**attempt)
+            else:
+                if last_exc is not None:
+                    raise RuntimeError(f"GET {url} failed after {retries} attempts: {last_exc}")
+
+            if next_url is None:
+                break
+        else:
+            raise RuntimeError("page_cap_exceeded")
+
+        # Sort items by skuId for determinism.
+        sorted_items = sorted(items, key=lambda x: x.get("skuId", ""))
+        serialised = json.dumps(sorted_items, separators=(",", ":"), sort_keys=True).encode()
+        digest = hashlib.sha256(serialised).hexdigest()
+
+        # Atomic write.
+        target = Path(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        part = target.with_suffix(target.suffix + ".part")
+        body = json.dumps({"Items": sorted_items}, sort_keys=True)
+        part.write_text(body, encoding="utf-8")
+        os.replace(part, target)
+
+        return digest
+    finally:
+        if own_session:
+            sess.close()

--- a/pipeline/ingest/azure_disks.py
+++ b/pipeline/ingest/azure_disks.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/azure_disks.py
+++ b/pipeline/ingest/azure_disks.py
@@ -65,7 +65,9 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
         if disk_type is None:
             continue  # Ultra + reserved + others skipped
         divisor, unit = parse_storage_uom(uom)
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": "",

--- a/pipeline/ingest/azure_functions.py
+++ b/pipeline/ingest/azure_functions.py
@@ -70,7 +70,8 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
         dim = _DIM_MAP.get(meter_name)
         if dim is None:
             continue
-        normalizer.normalize(_PROVIDER, region)
+        if normalizer.try_normalize(_PROVIDER, region) is None:
+            continue  # skip regions outside our coverage map
         if dim == "executions":
             divisor, unit = parse_request_uom(uom)
             amount = price / divisor

--- a/pipeline/ingest/azure_functions.py
+++ b/pipeline/ingest/azure_functions.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/azure_sql.py
+++ b/pipeline/ingest/azure_sql.py
@@ -61,6 +61,7 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
     con = open_conn()
     path_literal = str(prices_path).replace("'", "''")
     sql = _SQL.replace("{path}", path_literal)
+    seen: set[str] = set()
     for (
         sku_id, sku_name, region, product, price, uom, currency, row_type, service_name,
     ) in con.execute(sql).fetchall():
@@ -80,6 +81,9 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
             divisor, unit = parse_unit_of_measure(uom)
         except ValueError:
             continue  # skip non-hourly meters (monthly, per-request, etc.)
+        if sku_id in seen:
+            continue
+        seen.add(sku_id)
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": "azure-sql",

--- a/pipeline/ingest/azure_sql.py
+++ b/pipeline/ingest/azure_sql.py
@@ -76,7 +76,10 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
         region_normalized = normalizer.try_normalize(_PROVIDER, region)
         if region_normalized is None:
             continue
-        divisor, unit = parse_unit_of_measure(uom)
+        try:
+            divisor, unit = parse_unit_of_measure(uom)
+        except ValueError:
+            continue  # skip non-hourly meters (monthly, per-request, etc.)
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": "azure-sql",

--- a/pipeline/ingest/azure_sql.py
+++ b/pipeline/ingest/azure_sql.py
@@ -35,7 +35,7 @@ WITH items AS (
   FROM read_json_auto('{path}', maximum_object_size=33554432)
 )
 SELECT
-  meterId       AS sku_id,
+  CAST(meterId AS VARCHAR) AS sku_id,
   skuName       AS resource_name,
   armRegionName AS region,
   productName   AS product_name,

--- a/pipeline/ingest/azure_sql.py
+++ b/pipeline/ingest/azure_sql.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/azure_sql.py
+++ b/pipeline/ingest/azure_sql.py
@@ -72,7 +72,9 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
         deployment = _classify_deployment(product)
         if deployment is None:
             continue
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_unit_of_measure(uom)
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",

--- a/pipeline/ingest/azure_vm.py
+++ b/pipeline/ingest/azure_vm.py
@@ -29,7 +29,7 @@ WITH items AS (
   FROM read_json_auto('{path}', maximum_object_size=536870912)
 )
 SELECT
-  meterId       AS sku_id,
+  CAST(meterId AS VARCHAR) AS sku_id,
   armSkuName    AS resource_name,
   armRegionName AS region,
   productName   AS product_name,
@@ -66,7 +66,9 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
         # OS detection: productName contains "Windows" for Windows VMs;
         # everything else is Linux (the only two surfaces we ship in m3b.1).
         os_value = "windows" if "Windows" in product else "linux"
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_unit_of_measure(uom)
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",

--- a/pipeline/ingest/azure_vm.py
+++ b/pipeline/ingest/azure_vm.py
@@ -53,6 +53,7 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
     con = open_conn()
     path_literal = str(prices_path).replace("'", "''")
     sql = _SQL.replace("{path}", path_literal)
+    seen: set[str] = set()
     for (
         sku_id, arm_sku, region, product, price, uom, currency, row_type, service_name,
     ) in con.execute(sql).fetchall():
@@ -64,8 +65,9 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
             continue
         if any(hint in product for hint in _SPOT_HINTS):
             continue
-        # OS detection: productName contains "Windows" for Windows VMs;
-        # everything else is Linux (the only two surfaces we ship in m3b.1).
+        if sku_id in seen:
+            continue
+        seen.add(sku_id)
         os_value = "windows" if "Windows" in product else "linux"
         region_normalized = normalizer.try_normalize(_PROVIDER, region)
         if region_normalized is None:

--- a/pipeline/ingest/azure_vm.py
+++ b/pipeline/ingest/azure_vm.py
@@ -26,7 +26,7 @@ _KIND = "compute.vm"
 _SQL = """
 WITH items AS (
   SELECT UNNEST(Items, recursive := true)
-  FROM read_json_auto('{path}', maximum_object_size=134217728)
+  FROM read_json_auto('{path}', maximum_object_size=536870912)
 )
 SELECT
   meterId       AS sku_id,

--- a/pipeline/ingest/azure_vm.py
+++ b/pipeline/ingest/azure_vm.py
@@ -26,7 +26,7 @@ _KIND = "compute.vm"
 _SQL = """
 WITH items AS (
   SELECT UNNEST(Items, recursive := true)
-  FROM read_json_auto('{path}', maximum_object_size=33554432)
+  FROM read_json_auto('{path}', maximum_object_size=134217728)
 )
 SELECT
   meterId       AS sku_id,

--- a/pipeline/ingest/azure_vm.py
+++ b/pipeline/ingest/azure_vm.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/gcp_cloud_sql.py
+++ b/pipeline/ingest/gcp_cloud_sql.py
@@ -92,7 +92,9 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         if not service_regions:
             continue
         region = service_regions[0]
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_usage_unit(usage_unit)
         amount = parse_unit_price(units=price_units, nanos=int(price_nanos)) / divisor
         terms = apply_kind_defaults(_KIND, {

--- a/pipeline/ingest/gcp_cloud_sql.py
+++ b/pipeline/ingest/gcp_cloud_sql.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/gcp_common.py
+++ b/pipeline/ingest/gcp_common.py
@@ -8,22 +8,41 @@ Usage units are ratios like `h`, `GiBy.h`, `GiBy.mo`; we canonicalize to the
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+
+import requests
+
 from .aws_common import load_region_normalizer  # re-export — same shared YAML loader
 
 __all__ = [
     "load_region_normalizer",
     "parse_unit_price",
     "parse_usage_unit",
+    "fetch_skus",
 ]
 
+_GCP_BILLING_BASE = "https://cloudbilling.googleapis.com/v1"
+
+_GCP_SERVICE_IDS: dict[str, str] = {
+    "gcp_gce": "6F81-5844-456A",  # Compute Engine
+    "gcp_cloud_sql": "9662-B51E-5089",  # Cloud SQL
+    "gcp_gcs": "95FF-2EF5-5EA1",  # Cloud Storage
+    "gcp_run": "152E-C115-5142",  # Cloud Run
+    "gcp_functions": "29E7-DA93-CA13",  # Cloud Functions
+}
+
 _USAGE_UNITS: dict[str, tuple[float, str]] = {
-    "h":        (1.0, "hrs"),
-    "GiBy.h":   (1.0, "gb-hr"),
-    "GiBy.mo":  (1.0, "gb-mo"),
-    "By.mo":    (1.0 / (1024 ** 3), "gb-mo"),   # byte-month → gb-month
-    "count":    (1.0, "requests"),
-    "s":        (1.0, "s"),                     # serverless CPU/request duration
-    "GiBy.s":   (1.0, "gb-s"),                  # serverless memory allocation time
+    "h": (1.0, "hrs"),
+    "GiBy.h": (1.0, "gb-hr"),
+    "GiBy.mo": (1.0, "gb-mo"),
+    "By.mo": (1.0 / (1024**3), "gb-mo"),  # byte-month → gb-month
+    "count": (1.0, "requests"),
+    "s": (1.0, "s"),  # serverless CPU/request duration
+    "GiBy.s": (1.0, "gb-s"),  # serverless memory allocation time
 }
 
 
@@ -38,3 +57,98 @@ def parse_usage_unit(unit: str) -> tuple[float, str]:
         return _USAGE_UNITS[unit]
     except KeyError as exc:
         raise ValueError(f"unsupported usageUnit: {unit}") from exc
+
+
+def fetch_skus(
+    shard: str,
+    target: Path,
+    *,
+    api_key: str,
+    session: requests.Session | None = None,
+    retries: int = 3,
+) -> str:
+    """Page through `/services/{service_id}/skus?pageSize=5000&key={api_key}` and
+    write `{"skus": [...]}` (sorted by skuId) to target. Returns SHA256 hex
+    digest over the sorted skus (same serialization used for the file body's
+    items).
+
+    Pagination via response `nextPageToken`; append `&pageToken=<token>` to
+    each subsequent GET. Terminates when the response omits `nextPageToken`
+    or it's empty.
+    403 → RuntimeError("gcp_forbidden: <shard>/<service_id>") — no retry.
+    Other 4xx → RuntimeError(url-contains) — no retry.
+    500/502/503/504 retried with `time.sleep(0.5 * 2**attempt)` per page.
+    Unknown `shard` → KeyError from the dict lookup — let it propagate.
+    User-Agent header: `sku-pipeline/...` matching pipeline/ingest/http.py LiveClient.
+    Atomic write via .part + os.replace.
+    """
+    # KeyError propagates naturally for unknown shards — this must happen before
+    # any network setup so no requests are made.
+    service_id = _GCP_SERVICE_IDS[shard]
+
+    if session is None:
+        session = requests.Session()
+
+    session.headers.update(
+        {
+            "User-Agent": "sku-pipeline/0.0 (+https://github.com/sofq/sku)",
+            "Accept": "application/json",
+        }
+    )
+
+    base_url = f"{_GCP_BILLING_BASE}/services/{service_id}/skus"
+    all_skus: list[dict] = []
+    page_token: str | None = None
+
+    while True:
+        params: dict[str, str] = {"pageSize": "5000", "key": api_key}
+        if page_token:
+            params["pageToken"] = page_token
+
+        # Per-page retry loop — resets between pages.
+        last_exc: Exception | None = None
+        resp = None
+        for attempt in range(retries):
+            try:
+                resp = session.get(base_url, params=params, timeout=30.0)
+                if resp.status_code == 403:
+                    raise RuntimeError(f"gcp_forbidden: {shard}/{service_id}")
+                if 400 <= resp.status_code < 500:
+                    raise RuntimeError(f"gcp fetch failed {resp.status_code}: {resp.url}")
+                if resp.status_code in (500, 502, 503, 504):
+                    last_exc = RuntimeError(
+                        f"gcp fetch server error {resp.status_code}: {resp.url}"
+                    )
+                    time.sleep(0.5 * (2**attempt))
+                    continue
+                resp.raise_for_status()
+                break
+            except RuntimeError:
+                raise
+            except requests.RequestException as exc:
+                last_exc = exc
+                time.sleep(0.5 * (2**attempt))
+        else:
+            raise RuntimeError(f"gcp fetch failed after {retries} attempts: {last_exc}")
+
+        data = resp.json()
+        all_skus.extend(data.get("skus", []))
+
+        page_token = data.get("nextPageToken") or None
+        if not page_token:
+            break
+
+    sorted_skus = sorted(all_skus, key=lambda x: x.get("skuId", ""))
+
+    # Compute SHA256 over the compact sorted serialization.
+    serialized_bytes = json.dumps(sorted_skus, separators=(",", ":"), sort_keys=True).encode()
+    digest = hashlib.sha256(serialized_bytes).hexdigest()
+
+    # Atomic write.
+    target = Path(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    part_path = Path(str(target) + ".part")
+    part_path.write_text(json.dumps({"skus": sorted_skus}, sort_keys=True))
+    os.replace(part_path, target)
+
+    return digest

--- a/pipeline/ingest/gcp_functions.py
+++ b/pipeline/ingest/gcp_functions.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
@@ -69,7 +70,7 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
 
     grouped: dict[str, dict[str, Any]] = {}
     for (
-        sku_id, description, svc_name, resource_family, resource_group, usage_type,
+        sku_id, description, svc_name, _resource_family, resource_group, usage_type,
         service_regions, usage_unit, currency, price_units, price_nanos,
     ) in con.execute(sql).fetchall():
         if svc_name != _SERVICE_DISPLAY:

--- a/pipeline/ingest/gcp_functions.py
+++ b/pipeline/ingest/gcp_functions.py
@@ -86,7 +86,9 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         if not service_regions:
             continue
         region = service_regions[0]
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_usage_unit(usage_unit)
         amount = parse_unit_price(units=price_units, nanos=int(price_nanos or 0)) / divisor
         bucket = grouped.setdefault(region, {

--- a/pipeline/ingest/gcp_gce.py
+++ b/pipeline/ingest/gcp_gce.py
@@ -76,7 +76,9 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         if not service_regions:
             continue
         region = service_regions[0]
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_usage_unit(usage_unit)
         amount = parse_unit_price(units=price_units, nanos=int(price_nanos)) / divisor
         terms = apply_kind_defaults(_KIND, {

--- a/pipeline/ingest/gcp_gce.py
+++ b/pipeline/ingest/gcp_gce.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/gcp_gcs.py
+++ b/pipeline/ingest/gcp_gcs.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
@@ -89,7 +90,7 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
     # (class, region) -> {sku_id for storage meter, description, resource_group, region_normalized, prices:{dim: {...}}}
     grouped: dict[tuple[str, str], dict[str, Any]] = {}
     for (
-        sku_id, description, svc_name, resource_family, resource_group, usage_type,
+        sku_id, description, svc_name, _resource_family, resource_group, usage_type,
         service_regions, usage_unit, currency, price_units, price_nanos,
     ) in con.execute(sql).fetchall():
         if svc_name != "Cloud Storage":

--- a/pipeline/ingest/gcp_gcs.py
+++ b/pipeline/ingest/gcp_gcs.py
@@ -104,7 +104,9 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         if not service_regions:
             continue
         region = service_regions[0]
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_usage_unit(usage_unit)
         amount = parse_unit_price(units=price_units, nanos=int(price_nanos or 0)) / divisor
         dim = _dimension(description)

--- a/pipeline/ingest/gcp_run.py
+++ b/pipeline/ingest/gcp_run.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
@@ -73,7 +74,7 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
 
     grouped: dict[str, dict[str, Any]] = {}
     for (
-        sku_id, description, svc_name, resource_family, resource_group, usage_type,
+        sku_id, description, svc_name, _resource_family, resource_group, usage_type,
         service_regions, usage_unit, currency, price_units, price_nanos,
     ) in con.execute(sql).fetchall():
         if svc_name != _SERVICE_DISPLAY:

--- a/pipeline/ingest/gcp_run.py
+++ b/pipeline/ingest/gcp_run.py
@@ -90,7 +90,9 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         if not service_regions:
             continue
         region = service_regions[0]
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_usage_unit(usage_unit)
         amount = parse_unit_price(units=price_units, nanos=int(price_nanos or 0)) / divisor
         bucket = grouped.setdefault(region, {

--- a/pipeline/ingest/openrouter.py
+++ b/pipeline/ingest/openrouter.py
@@ -7,12 +7,14 @@ pair plus one synthetic aggregated row per model with provider='openrouter'.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
 import time
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults, load_enums
 from normalize.terms import terms_hash
@@ -22,8 +24,6 @@ from .http import FixtureClient, LiveClient
 
 class NonUSDError(RuntimeError):
     """Raised when an upstream endpoint declares a non-USD currency."""
-
-
 
 
 def _kind_for_modality(modality: str | None, input_modalities: list[str] | None) -> str:
@@ -261,6 +261,49 @@ def _write_rows(rows: Iterable[dict[str, Any]], out: Path | None) -> None:
         with out.open("w") as fh:
             for r in rows:
                 fh.write(encode(r) + "\n")
+
+
+def fetch(target_dir: Path, *, client: LiveClient | None = None) -> str:
+    """Materialise a full OpenRouter fixture tree under `target_dir`:
+
+        target_dir/models.json
+        target_dir/endpoints/{author}__{slug}.json
+
+    Returns SHA256 hex digest over the sorted list of ``id`` strings from
+    ``models.json.data[*].id`` — the version indicator for the OpenRouter shard.
+    Atomic per-file write: write to ``<name>.part``, os.replace onto final name.
+    Creates parent directories as needed.
+    """
+    client = client or LiveClient()
+
+    models_payload = client.get("/api/v1/models")
+
+    # Write models.json atomically.
+    target_dir = Path(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    models_content = json.dumps(models_payload, sort_keys=True, separators=(",", ":"))
+    models_final = target_dir / "models.json"
+    models_part = target_dir / "models.json.part"
+    models_part.write_text(models_content, encoding="utf-8")
+    os.replace(models_part, models_final)
+
+    # Write one endpoint file per model, atomically.
+    endpoints_dir = target_dir / "endpoints"
+    for model in models_payload.get("data", []):
+        model_id: str = model["id"]
+        ep_payload = client.get(f"/api/v1/models/{model_id}/endpoints")
+        ep_content = json.dumps(ep_payload, sort_keys=True, separators=(",", ":"))
+        flat = model_id.replace("/", "__")
+        endpoints_dir.mkdir(parents=True, exist_ok=True)
+        ep_final = endpoints_dir / f"{flat}.json"
+        ep_part = endpoints_dir / f"{flat}.json.part"
+        ep_part.write_text(ep_content, encoding="utf-8")
+        os.replace(ep_part, ep_final)
+
+    # Compute version digest over sorted model id list.
+    sorted_ids = sorted(m["id"] for m in models_payload.get("data", []))
+    digest = hashlib.sha256(json.dumps(sorted_ids).encode()).hexdigest()
+    return digest
 
 
 def main() -> int:

--- a/pipeline/normalize/enums.py
+++ b/pipeline/normalize/enums.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
-from typing import Mapping
 
 import yaml
 

--- a/pipeline/normalize/regions.yaml
+++ b/pipeline/normalize/regions.yaml
@@ -6,6 +6,7 @@ groups:
     - {provider: aws,   region: us-east-2}
     - {provider: azure, region: eastus}
     - {provider: azure, region: eastus2}
+    - {provider: azure, region: southcentralus}
     - {provider: gcp,   region: us-east1}
     - {provider: gcp,   region: us-east4}
   us-west:

--- a/pipeline/normalize/terms.py
+++ b/pipeline/normalize/terms.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Mapping
+from collections.abc import Mapping
 
 # Fixed field order — MUST NOT CHANGE without a schema_version bump.
 _FIELD_ORDER: tuple[str, ...] = (

--- a/pipeline/package/build_delta.py
+++ b/pipeline/package/build_delta.py
@@ -86,7 +86,6 @@ def _compute_statements(prev_db: Path, new_db: Path) -> list[str]:
         curr_sku_ids = {r[0] for r in curr.execute("SELECT sku_id FROM skus")}
 
         deleted = sorted(prev_sku_ids - curr_sku_ids)
-        common = prev_sku_ids & curr_sku_ids
         added = sorted(curr_sku_ids - prev_sku_ids)
 
         # Gather per-table column lists once.
@@ -211,9 +210,11 @@ def _part_path(out_sql_gz: Path, index: int, total: int) -> Path:
 
 def _write_gzip(path: Path, payload: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "wb") as raw:
-        with gzip.GzipFile(fileobj=raw, mode="wb", compresslevel=9, mtime=0) as fh:
-            fh.write(payload)
+    with (
+        open(path, "wb") as raw,
+        gzip.GzipFile(fileobj=raw, mode="wb", compresslevel=9, mtime=0) as fh,
+    ):
+        fh.write(payload)
 
 
 def _format_payload(statements: Iterable[str], *, header: str | None = None) -> bytes:

--- a/pipeline/package/build_delta.py
+++ b/pipeline/package/build_delta.py
@@ -1,0 +1,306 @@
+"""Emit a gzipped SQL delta that transforms one shard SQLite into another.
+
+Spec §3 (daily update flow): each data release publishes a set of delta SQL
+files alongside baselines. Clients walk the delta chain between their current
+baseline and `head_version`, applying each file in order.
+
+This module is the *server-side* half of that flow. Run in the workflow's
+`diff-package` job against (previous_release's shard, today's shard) — writes
+one or more gzipped `.sql.gz` files that, when applied to the previous shard,
+reproduce today's shard bytes (modulo the `metadata` table, which is replayed
+in full every time).
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import sqlite3
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+# All non-metadata tables owned by the shard schema (pipeline/package/schema.sql).
+# `skus` is parent; the rest FK to skus.sku_id with ON DELETE CASCADE.
+_SKU_CHILD_TABLES: tuple[str, ...] = ("resource_attrs", "terms", "prices", "health")
+_SKU_TABLES: tuple[str, ...] = ("skus",) + _SKU_CHILD_TABLES
+
+
+def _sql_literal(value: object) -> str:
+    """Render a Python scalar as a SQLite literal."""
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if isinstance(value, (bytes, bytearray)):
+        return "X'" + bytes(value).hex() + "'"
+    text = str(value).replace("'", "''")
+    return f"'{text}'"
+
+
+def _columns(con: sqlite3.Connection, table: str) -> list[str]:
+    return [r[1] for r in con.execute(f"PRAGMA table_info({table})").fetchall()]
+
+
+def _row_payloads(
+    con: sqlite3.Connection, table: str, columns: Sequence[str]
+) -> dict[tuple, tuple]:
+    """Map PK tuple → full row tuple, ordered by PK columns."""
+    pk_cols = [r[1] for r in con.execute(f"PRAGMA table_info({table})").fetchall() if r[5]]
+    if not pk_cols:
+        pk_cols = list(columns)
+    col_list = ", ".join(columns)
+    rows: dict[tuple, tuple] = {}
+    for row in con.execute(f"SELECT {col_list} FROM {table}"):
+        pk = tuple(row[columns.index(c)] for c in pk_cols)
+        rows[pk] = tuple(row)
+    return rows
+
+
+def _insert_stmt(table: str, columns: Sequence[str], row: Sequence[object]) -> str:
+    cols = ", ".join(columns)
+    vals = ", ".join(_sql_literal(v) for v in row)
+    return f"INSERT OR REPLACE INTO {table}({cols}) VALUES({vals});"
+
+
+def _delete_by_sku_id_stmt(table: str, sku_id: str) -> str:
+    return f"DELETE FROM {table} WHERE sku_id = {_sql_literal(sku_id)};"
+
+
+def _delete_prices_by_pk_stmt(sku_id: str, dimension: str, tier: str) -> str:
+    return (
+        f"DELETE FROM prices WHERE sku_id = {_sql_literal(sku_id)}"
+        f" AND dimension = {_sql_literal(dimension)}"
+        f" AND tier = {_sql_literal(tier)};"
+    )
+
+
+def _compute_statements(prev_db: Path, new_db: Path) -> list[str]:
+    """Assemble the ordered statement list."""
+    prev = sqlite3.connect(f"file:{prev_db}?mode=ro", uri=True)
+    curr = sqlite3.connect(f"file:{new_db}?mode=ro", uri=True)
+    try:
+        prev_sku_ids = {r[0] for r in prev.execute("SELECT sku_id FROM skus")}
+        curr_sku_ids = {r[0] for r in curr.execute("SELECT sku_id FROM skus")}
+
+        deleted = sorted(prev_sku_ids - curr_sku_ids)
+        common = prev_sku_ids & curr_sku_ids
+        added = sorted(curr_sku_ids - prev_sku_ids)
+
+        # Gather per-table column lists once.
+        cols_by_table = {t: _columns(curr, t) for t in _SKU_TABLES}
+
+        # For every changed/new sku_id, determine which rows differ per child table.
+        changed_sku_ids: set[str] = set()
+
+        # Table-level diffs we'll emit.
+        # Each element is (apply_order_sort_key, sql_statement).
+        stmts: list[tuple[int, str]] = []
+
+        # 1) DELETE rows for removed skus (cascades handle child tables, but
+        #    we emit explicit DELETEs per table so the SQL is explicit and
+        #    independent of PRAGMA foreign_keys state on the client side).
+        for sku_id in deleted:
+            for table in reversed(_SKU_TABLES):  # children first, skus last
+                stmts.append((0, _delete_by_sku_id_stmt(table, sku_id)))
+
+        # 2) For skus still present, diff each child table + skus itself.
+        #    When anything changed for a sku_id, mark it changed so we can
+        #    rewrite the skus row (terms_hash may have bumped).
+        for table in _SKU_TABLES:
+            cols = cols_by_table[table]
+            prev_rows = _row_payloads(prev, table, cols)
+            curr_rows = _row_payloads(curr, table, cols)
+
+            # Rows whose PK exists in both but contents differ.
+            common_pks = prev_rows.keys() & curr_rows.keys()
+            for pk in common_pks:
+                if prev_rows[pk] != curr_rows[pk]:
+                    # sku_id is always the first element of the PK in our schema.
+                    changed_sku_ids.add(str(pk[0]))
+
+            # Rows in curr but not prev: these are additions.
+            new_pks = curr_rows.keys() - prev_rows.keys()
+            for pk in new_pks:
+                changed_sku_ids.add(str(pk[0]))
+
+            # Rows in prev but not curr (same sku_id, but PK like
+            # (sku_id, dimension, tier) removed on `prices`).
+            # Only `prices` has a compound PK; for other tables this set is
+            # empty when the sku_id is still present because those tables are
+            # 1:1 with skus.
+            orphan_pks = prev_rows.keys() - curr_rows.keys()
+            for pk in orphan_pks:
+                sku_id = str(pk[0])
+                if sku_id in curr_sku_ids:
+                    if table == "prices":
+                        stmts.append(
+                            (
+                                1,
+                                _delete_prices_by_pk_stmt(
+                                    sku_id=str(pk[0]),
+                                    dimension=str(pk[1]),
+                                    tier=str(pk[2]),
+                                ),
+                            )
+                        )
+                    else:
+                        # Should not happen for 1:1 tables unless the new shard
+                        # dropped the child row entirely. Emit a by-sku delete
+                        # and let the INSERT re-add it.
+                        changed_sku_ids.add(sku_id)
+
+        # 3) Add newly-introduced sku_ids unconditionally.
+        for sku_id in added:
+            changed_sku_ids.add(sku_id)
+
+        # 4) For each changed sku_id, emit INSERT OR REPLACE for its rows in
+        #    skus + every child table (order: skus first so FK on children
+        #    resolves).
+        for sku_id in sorted(changed_sku_ids):
+            for table in _SKU_TABLES:
+                cols = cols_by_table[table]
+                rows = curr.execute(
+                    f"SELECT {', '.join(cols)} FROM {table} WHERE sku_id = ?",
+                    (sku_id,),
+                ).fetchall()
+                for row in rows:
+                    stmts.append((2, _insert_stmt(table, cols, row)))
+
+        # 5) Metadata: always rewritten in full (small table, changes every
+        #    release — catalog_version, generated_at, row_count).
+        meta_cols = _columns(curr, "metadata")
+        stmts.append((3, "DELETE FROM metadata;"))
+        meta_rows = curr.execute(
+            f"SELECT {', '.join(meta_cols)} FROM metadata ORDER BY key"
+        ).fetchall()
+        for row in meta_rows:
+            stmts.append((3, _insert_stmt("metadata", meta_cols, row)))
+    finally:
+        prev.close()
+        curr.close()
+
+    # Stable apply order: group 0 (deletes) → 1 (prices PK deletes) → 2 (upserts) → 3 (metadata).
+    stmts.sort(key=lambda pair: pair[0])
+    return [s for _, s in stmts]
+
+
+def _is_noop(statements: Sequence[str]) -> bool:
+    """Return True when the only statements are the metadata replay."""
+    for stmt in statements:
+        if not stmt.startswith("DELETE FROM metadata") and not stmt.startswith(
+            "INSERT OR REPLACE INTO metadata"
+        ):
+            return False
+    return True
+
+
+def _part_path(out_sql_gz: Path, index: int, total: int) -> Path:
+    """Insert `-partN` before the `.sql.gz` suffix when splitting."""
+    if total <= 1:
+        return out_sql_gz
+    name = out_sql_gz.name
+    if name.endswith(".sql.gz"):
+        base = name[: -len(".sql.gz")]
+        return out_sql_gz.with_name(f"{base}-part{index}.sql.gz")
+    # Fallback: append before the last suffix.
+    return out_sql_gz.with_name(f"{out_sql_gz.stem}-part{index}{out_sql_gz.suffix}")
+
+
+def _write_gzip(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as raw:
+        with gzip.GzipFile(fileobj=raw, mode="wb", compresslevel=9, mtime=0) as fh:
+            fh.write(payload)
+
+
+def _format_payload(statements: Iterable[str], *, header: str | None = None) -> bytes:
+    lines: list[str] = []
+    if header:
+        lines.append(f"-- {header}")
+    lines.extend(statements)
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def build_delta(
+    prev_db: Path,
+    new_db: Path,
+    out_sql_gz: Path,
+    *,
+    max_bytes: int = 8 * 1024 * 1024,
+) -> list[Path]:
+    """Emit a gzipped SQL delta from `prev_db` → `new_db`.
+
+    When the single gzipped artifact would exceed `max_bytes`, the delta is
+    split row-by-row into apply-order `-part{N}.sql.gz` files, each ≤ roughly
+    `max_bytes` gzipped. Returns the list of part files written (in apply
+    order). Always returns at least one path; empty diffs produce a single
+    `-- noop` file containing only the metadata replay.
+    """
+    prev_db = Path(prev_db)
+    new_db = Path(new_db)
+    out_sql_gz = Path(out_sql_gz)
+
+    statements = _compute_statements(prev_db, new_db)
+
+    if _is_noop(statements):
+        payload = _format_payload(statements, header="noop")
+        path = _part_path(out_sql_gz, 1, 1)
+        _write_gzip(path, payload)
+        return [path]
+
+    # First attempt: dump all statements in a single file.
+    single_payload = _format_payload(statements)
+    if len(gzip.compress(single_payload)) <= max_bytes:
+        path = _part_path(out_sql_gz, 1, 1)
+        _write_gzip(path, single_payload)
+        return [path]
+
+    # Split: walk statements and close a part whenever gzip output would exceed
+    # max_bytes. Each part is a self-contained SQL snippet (apply-order
+    # preserved; the client concatenates + applies them sequentially).
+    parts_payloads: list[bytes] = []
+    current: list[str] = []
+    for stmt in statements:
+        candidate = current + [stmt]
+        candidate_bytes = _format_payload(candidate)
+        if current and len(gzip.compress(candidate_bytes)) > max_bytes:
+            parts_payloads.append(_format_payload(current))
+            current = [stmt]
+        else:
+            current = candidate
+    if current:
+        parts_payloads.append(_format_payload(current))
+
+    total = len(parts_payloads)
+    written: list[Path] = []
+    for idx, payload in enumerate(parts_payloads, start=1):
+        path = _part_path(out_sql_gz, idx, total)
+        _write_gzip(path, payload)
+        written.append(path)
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="package.build_delta")
+    ap.add_argument("--prev", type=Path, required=True, help="previous release shard .db")
+    ap.add_argument("--new", type=Path, required=True, help="today's shard .db")
+    ap.add_argument("--out", type=Path, required=True, help="output .sql.gz path")
+    ap.add_argument(
+        "--max-bytes",
+        type=int,
+        default=8 * 1024 * 1024,
+        help="split into -partN.sql.gz when a single gzipped file would exceed this",
+    )
+    args = ap.parse_args(argv)
+
+    paths = build_delta(args.prev, args.new, args.out, max_bytes=args.max_bytes)
+    for p in paths:
+        print(p)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/package/build_manifest.py
+++ b/pipeline/package/build_manifest.py
@@ -1,0 +1,239 @@
+"""Assemble the manifest.json asset for a data release.
+
+Spec §3 (manifest structure): clients hit this file to discover where to
+download baselines + deltas for each shard, how to verify them (sha256), and
+what minimum binary version they require. This module walks the set of
+artifacts built by the `diff-package` matrix job and emits the manifest per
+that shape.
+
+Artifact layout in `artifacts_dir` (produced by `scripts/ci/diff_package_shard.sh`):
+
+    <shard>.db.zst             # present only on baseline-rebuild
+    <shard>.db.zst.sha256      # matching sha256 file (sidecar, same basename)
+    <shard>-<from>-to-<to>.sql.gz
+    <shard>-<from>-to-<to>-part<N>.sql.gz   # when split
+    <shard>.meta.json          # {"shard": "...", "row_count": N, "has_baseline": bool,
+                                #  "delta_from": "...", "delta_to": "..."}
+
+Every shard touched by today's run contributes a `<shard>.meta.json` sidecar;
+that is the authoritative source of row_count + what file-types to expect.
+Shards absent from today's run are carried forward from `previous_manifest`
+unmodified so clients keep working against yesterday's baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_SCHEMA_VERSION = 1
+
+
+def _sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _file_entry(path: Path, release_base_url: str) -> dict[str, Any]:
+    return {
+        "url": f"{release_base_url.rstrip('/')}/{path.name}",
+        "sha256": _sha256_of(path),
+        "size": path.stat().st_size,
+    }
+
+
+def _delta_parts_for(shard: str, delta_from: str, delta_to: str, artifacts_dir: Path) -> list[Path]:
+    """Find every part of a single delta in apply-order."""
+    prefix = f"{shard}-{delta_from}-to-{delta_to}"
+    single = artifacts_dir / f"{prefix}.sql.gz"
+    if single.is_file():
+        return [single]
+    parts: list[Path] = []
+    for candidate in sorted(artifacts_dir.glob(f"{prefix}-part*.sql.gz")):
+        parts.append(candidate)
+    return parts
+
+
+def _delta_entry(
+    *,
+    shard: str,
+    delta_from: str,
+    delta_to: str,
+    artifacts_dir: Path,
+    release_base_url: str,
+) -> dict[str, Any]:
+    parts = _delta_parts_for(shard, delta_from, delta_to, artifacts_dir)
+    if not parts:
+        raise FileNotFoundError(
+            f"expected delta file(s) for {shard} {delta_from} → {delta_to} under {artifacts_dir}"
+        )
+    entry: dict[str, Any] = {"from": delta_from, "to": delta_to}
+    if len(parts) == 1:
+        entry.update(_file_entry(parts[0], release_base_url))
+    else:
+        entry["parts"] = [_file_entry(p, release_base_url) for p in parts]
+        # Convenience: total size of all parts.
+        entry["size"] = sum(p["size"] for p in entry["parts"])
+    return entry
+
+
+def _read_sidecar(path: Path) -> dict[str, Any]:
+    doc = json.loads(path.read_text())
+    for key in ("shard", "row_count", "has_baseline", "delta_to"):
+        if key not in doc:
+            raise KeyError(f"{path}: missing key {key!r}")
+    return doc
+
+
+def _load_previous(previous_manifest: Path | None) -> dict[str, Any]:
+    if previous_manifest is None or not Path(previous_manifest).is_file():
+        return {"shards": {}}
+    return json.loads(Path(previous_manifest).read_text())
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def build_manifest(
+    *,
+    artifacts_dir: Path,
+    out: Path,
+    catalog_version: str,
+    release_base_url: str,
+    previous_manifest: Path | None,
+    min_binary_version: str,
+    shard_schema_version: int = 1,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Write manifest.json to `out` and return the document.
+
+    Only shards with a `<shard>.meta.json` sidecar in `artifacts_dir` are
+    considered "touched" today. Every other shard listed in
+    `previous_manifest` is carried forward unchanged.
+    """
+    artifacts_dir = Path(artifacts_dir)
+    out = Path(out)
+
+    previous = _load_previous(previous_manifest)
+    prev_shards: dict[str, Any] = previous.get("shards", {})
+
+    # Discover sidecars → shard entries for today.
+    sidecars = {
+        s.stem[: -len(".meta")] if s.name.endswith(".meta.json") else s.stem: _read_sidecar(s)
+        for s in artifacts_dir.glob("*.meta.json")
+    }
+
+    shards_out: dict[str, Any] = {}
+
+    # Every shard that showed up today.
+    for shard, meta in sidecars.items():
+        prev_entry: dict[str, Any] = prev_shards.get(shard, {})
+        has_baseline = bool(meta["has_baseline"])
+        delta_to = meta["delta_to"]
+        delta_from = meta.get("delta_from")
+
+        if has_baseline:
+            baseline_path = artifacts_dir / f"{shard}.db.zst"
+            if not baseline_path.is_file():
+                raise FileNotFoundError(
+                    f"{shard} sidecar says has_baseline=true but {baseline_path} missing"
+                )
+            baseline_entry = _file_entry(baseline_path, release_base_url)
+            entry: dict[str, Any] = {
+                "baseline_version": delta_to,
+                "baseline_url": baseline_entry["url"],
+                "baseline_sha256": baseline_entry["sha256"],
+                "baseline_size": baseline_entry["size"],
+                "head_version": delta_to,
+                "min_binary_version": min_binary_version,
+                "shard_schema_version": shard_schema_version,
+                "deltas": [],
+                "row_count": int(meta["row_count"]),
+                "last_updated": delta_to,
+            }
+        else:
+            if not prev_entry:
+                raise ValueError(
+                    f"{shard}: no baseline this run and no previous manifest entry — "
+                    "cannot assemble a delta-only entry without a baseline to chain from"
+                )
+            if not delta_from:
+                raise ValueError(f"{shard}: sidecar missing delta_from for delta-only run")
+
+            new_delta = _delta_entry(
+                shard=shard,
+                delta_from=delta_from,
+                delta_to=delta_to,
+                artifacts_dir=artifacts_dir,
+                release_base_url=release_base_url,
+            )
+
+            entry = dict(prev_entry)
+            entry["head_version"] = delta_to
+            entry["last_updated"] = delta_to
+            entry["min_binary_version"] = min_binary_version
+            entry["shard_schema_version"] = shard_schema_version
+            entry["row_count"] = int(meta["row_count"])
+            entry["deltas"] = list(prev_entry.get("deltas", [])) + [new_delta]
+
+        shards_out[shard] = entry
+
+    # Carry-forward untouched shards from the previous manifest.
+    for shard, prev_entry in prev_shards.items():
+        if shard not in shards_out:
+            shards_out[shard] = dict(prev_entry)
+
+    # Alphabetise for diff-friendly output.
+    sorted_shards = {k: shards_out[k] for k in sorted(shards_out.keys())}
+
+    doc: dict[str, Any] = {
+        "schema_version": _SCHEMA_VERSION,
+        "generated_at": now or _now_iso(),
+        "catalog_version": catalog_version,
+        "min_binary_version": min_binary_version,
+        "shards": sorted_shards,
+    }
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out.with_suffix(out.suffix + ".part")
+    with tmp.open("w") as fh:
+        json.dump(doc, fh, indent=2, sort_keys=False)
+        fh.write("\n")
+    tmp.replace(out)
+    return doc
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="package.build_manifest")
+    ap.add_argument("--artifacts-dir", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--catalog-version", required=True)
+    ap.add_argument("--release-base-url", required=True)
+    ap.add_argument("--previous-manifest", type=Path, default=None)
+    ap.add_argument("--min-binary-version", default="1.0.0")
+    ap.add_argument("--shard-schema-version", type=int, default=1)
+    args = ap.parse_args(argv)
+
+    build_manifest(
+        artifacts_dir=args.artifacts_dir,
+        out=args.out,
+        catalog_version=args.catalog_version,
+        release_base_url=args.release_base_url,
+        previous_manifest=args.previous_manifest,
+        min_binary_version=args.min_binary_version,
+        shard_schema_version=args.shard_schema_version,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/package/build_shard.py
+++ b/pipeline/package/build_shard.py
@@ -6,8 +6,9 @@ import argparse
 import json
 import sqlite3
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 _HERE = Path(__file__).resolve().parent
 _SCHEMA_SQL = (_HERE / "schema.sql").read_text()

--- a/pipeline/package/sanity_check.py
+++ b/pipeline/package/sanity_check.py
@@ -65,9 +65,7 @@ def sanity_check(
 
         generated_at = _metadata_value(con, "generated_at")
         if not generated_at:
-            raise SanityError(
-                shard, "missing_generated_at", "metadata.generated_at is NULL/empty"
-            )
+            raise SanityError(shard, "missing_generated_at", "metadata.generated_at is NULL/empty")
 
         # FK integrity: every price row must reference a live sku row.
         orphan_prices = con.execute(
@@ -101,7 +99,8 @@ def sanity_check(
             added = sorted(curr_schema.keys() - prev_schema.keys())
             removed = sorted(prev_schema.keys() - curr_schema.keys())
             changed = sorted(
-                k for k in curr_schema.keys() & prev_schema.keys()
+                k
+                for k in curr_schema.keys() & prev_schema.keys()
                 if curr_schema[k] != prev_schema[k]
             )
             raise SanityError(

--- a/pipeline/package/sanity_check.py
+++ b/pipeline/package/sanity_check.py
@@ -1,0 +1,148 @@
+"""Lightweight sanity guard for the daily release chain (spec §3 line 198).
+
+Runs per-shard in the `diff-package` job against today's freshly-built SQLite
+shard vs. yesterday's decompressed baseline. Catches the common failure modes
+before we publish — row-count cliff from a broken fetcher, upstream schema
+drift, orphaned foreign keys, or a forgotten `generated_at` in metadata. Every
+miss here would poison the client caches until the next manual intervention.
+
+Does *not* attempt a full upstream cross-check — that is `data-validate.yml`'s
+job (m3a.4.3).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+
+class SanityError(Exception):
+    """Raised when a sanity check fails. Carries the shard name in `shard`."""
+
+    def __init__(self, shard: str, reason: str, detail: str = "") -> None:
+        super().__init__(f"[{shard}] {reason}: {detail}" if detail else f"[{shard}] {reason}")
+        self.shard = shard
+        self.reason = reason
+        self.detail = detail
+
+
+def _count_rows(con: sqlite3.Connection, table: str) -> int:
+    return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+
+
+def _schema_ddl(con: sqlite3.Connection) -> dict[str, str]:
+    rows = con.execute(
+        "SELECT name, sql FROM sqlite_master "
+        "WHERE type='table' AND name NOT LIKE 'sqlite_%' "
+        "ORDER BY name"
+    ).fetchall()
+    return {name: (sql or "").strip() for name, sql in rows}
+
+
+def _metadata_value(con: sqlite3.Connection, key: str) -> str | None:
+    row = con.execute("SELECT value FROM metadata WHERE key = ?", (key,)).fetchone()
+    return row[0] if row else None
+
+
+def sanity_check(
+    *,
+    shard: str,
+    shard_db: Path,
+    previous_db: Path | None,
+    tolerance_pct: float = 5.0,
+) -> None:
+    """Raise :class:`SanityError` when any guard trips.
+
+    When `previous_db` is `None` (first release) only the intra-shard checks
+    run: schema validity, FK integrity, `metadata.generated_at` populated.
+    """
+    shard_db = Path(shard_db)
+    con = sqlite3.connect(f"file:{shard_db}?mode=ro", uri=True)
+    try:
+        con.execute("PRAGMA foreign_keys = ON")
+
+        generated_at = _metadata_value(con, "generated_at")
+        if not generated_at:
+            raise SanityError(
+                shard, "missing_generated_at", "metadata.generated_at is NULL/empty"
+            )
+
+        # FK integrity: every price row must reference a live sku row.
+        orphan_prices = con.execute(
+            "SELECT COUNT(*) FROM prices p "
+            "LEFT JOIN skus s ON s.sku_id = p.sku_id "
+            "WHERE s.sku_id IS NULL"
+        ).fetchone()[0]
+        if orphan_prices:
+            raise SanityError(
+                shard, "fk_orphan_prices", f"{orphan_prices} price rows without matching sku"
+            )
+
+        curr_skus = _count_rows(con, "skus")
+        curr_schema = _schema_ddl(con)
+
+        if previous_db is None:
+            # Fresh release — nothing to compare against.
+            if curr_skus == 0:
+                raise SanityError(shard, "empty_shard", "skus table is empty on first release")
+            return
+
+        prev_path = Path(previous_db)
+        prev = sqlite3.connect(f"file:{prev_path}?mode=ro", uri=True)
+        try:
+            prev_skus = _count_rows(prev, "skus")
+            prev_schema = _schema_ddl(prev)
+        finally:
+            prev.close()
+
+        if curr_schema != prev_schema:
+            added = sorted(curr_schema.keys() - prev_schema.keys())
+            removed = sorted(prev_schema.keys() - curr_schema.keys())
+            changed = sorted(
+                k for k in curr_schema.keys() & prev_schema.keys()
+                if curr_schema[k] != prev_schema[k]
+            )
+            raise SanityError(
+                shard,
+                "schema_drift",
+                f"added={added} removed={removed} changed={changed}",
+            )
+
+        if prev_skus > 0:
+            drift_pct = 100.0 * abs(curr_skus - prev_skus) / prev_skus
+            if drift_pct > tolerance_pct:
+                raise SanityError(
+                    shard,
+                    "row_count_drift",
+                    f"prev={prev_skus} curr={curr_skus} drift={drift_pct:.2f}% "
+                    f"exceeds tolerance {tolerance_pct:.2f}%",
+                )
+    finally:
+        con.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="package.sanity_check")
+    ap.add_argument("--shard", required=True)
+    ap.add_argument("--shard-db", type=Path, required=True)
+    ap.add_argument("--previous-db", type=Path, default=None)
+    ap.add_argument("--tolerance-pct", type=float, default=5.0)
+    args = ap.parse_args(argv)
+
+    try:
+        sanity_check(
+            shard=args.shard,
+            shard_db=args.shard_db,
+            previous_db=args.previous_db,
+            tolerance_pct=args.tolerance_pct,
+        )
+    except SanityError as exc:
+        print(f"sanity check failed: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -27,3 +27,9 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.ruff.lint.per-file-ignores]
+# Ingest modules embed long json_extract_string() SQL inside triple-quoted
+# strings; ruff counts the string content as source lines. Splitting the SQL
+# to stay under 100 cols hurts readability more than it helps.
+"ingest/*.py" = ["E501"]

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 dev = [
   "pytest>=8.0",
   "ruff>=0.5",
+  "requests-mock>=1.12",
 ]
 
 [tool.setuptools]

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
 ]
 
 [tool.setuptools]
-packages = ["ingest", "normalize", "package"]
+packages = ["ingest", "normalize", "package", "discover"]
 
 [tool.ruff]
 line-length = 100

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "zstandard>=0.22",
   "duckdb>=0.10,<2",
   "numpy>=1.26",
+  "ijson>=3.2",
 ]
 
 [project.optional-dependencies]

--- a/pipeline/tests/test_aws_cloudfront_ingest.py
+++ b/pipeline/tests/test_aws_cloudfront_ingest.py
@@ -5,10 +5,11 @@ from pathlib import Path
 
 import pytest
 
-from ingest.aws_cloudfront import ingest, LOCATION_MAP
+from ingest.aws_cloudfront import LOCATION_MAP, ingest
 
-FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "aws_cloudfront" / "offer.json"
-GOLDEN = Path(__file__).resolve().parent.parent / "testdata" / "golden" / "aws_cloudfront_rows.jsonl"
+_DATA = Path(__file__).resolve().parent.parent / "testdata"
+FIXTURE = _DATA / "aws_cloudfront" / "offer.json"
+GOLDEN = _DATA / "golden" / "aws_cloudfront_rows.jsonl"
 
 
 def _canonical(rows):

--- a/pipeline/tests/test_aws_dynamodb_ingest.py
+++ b/pipeline/tests/test_aws_dynamodb_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.aws_dynamodb import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "aws_dynamodb" / "offer.json"

--- a/pipeline/tests/test_aws_dynamodb_ingest.py
+++ b/pipeline/tests/test_aws_dynamodb_ingest.py
@@ -52,11 +52,11 @@ def test_standard_ia_storage_cheaper_than_standard_same_region():
             f"standard-ia storage {ia_storage} should be < standard {std_storage} in {region}"
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     first_sku = next(iter(bad["products"]))
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="ap-south-9"):
-        list(ingest(offer_path=p))
+    rows = list(ingest(offer_path=p))
+    assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_ebs_ingest.py
+++ b/pipeline/tests/test_aws_ebs_ingest.py
@@ -38,11 +38,11 @@ def test_each_row_has_only_storage_dim():
         assert [p["dimension"] for p in r["prices"]] == ["storage"]
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     first_sku = next(iter(bad["products"]))
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="ap-south-9"):
-        list(ingest(offer_path=p))
+    rows = list(ingest(offer_path=p))
+    assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_ebs_ingest.py
+++ b/pipeline/tests/test_aws_ebs_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.aws_ebs import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "aws_ebs" / "offer.json"

--- a/pipeline/tests/test_aws_ebs_ingest.py
+++ b/pipeline/tests/test_aws_ebs_ingest.py
@@ -14,24 +14,24 @@ def _canonical(rows):
 
 
 def test_fixture_matches_golden():
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     expected = [json.loads(line) for line in GOLDEN.read_text().splitlines() if line.strip()]
     assert _canonical(rows) == _canonical(expected)
 
 
 def test_all_rows_are_storage_block_kind():
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     assert rows
     assert {r["kind"] for r in rows} == {"storage.block"}
 
 
 def test_every_volume_type_present():
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     assert {r["resource_name"] for r in rows} == {"gp3", "gp2", "io2", "st1", "sc1"}
 
 
 def test_each_row_has_only_storage_dim():
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     for r in rows:
         assert [p["dimension"] for p in r["prices"]] == ["storage"]
 
@@ -42,5 +42,5 @@ def test_unknown_region_skipped(tmp_path):
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    rows = list(ingest(offer_path=p))
+    rows = list(ingest(offer_paths=[p]))
     assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_ec2_ingest.py
+++ b/pipeline/tests/test_aws_ec2_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.aws_ec2 import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "aws_ec2" / "offer.json"

--- a/pipeline/tests/test_aws_ec2_ingest.py
+++ b/pipeline/tests/test_aws_ec2_ingest.py
@@ -14,13 +14,13 @@ def _canonical(rows):
 
 
 def test_fixture_matches_golden():
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     expected = [json.loads(line) for line in GOLDEN.read_text().splitlines() if line.strip()]
     assert _canonical(rows) == _canonical(expected)
 
 
 def test_all_rows_are_compute_vm_kind():
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     assert rows, "fixture produced zero rows"
     assert {r["kind"] for r in rows} == {"compute.vm"}
 
@@ -28,7 +28,7 @@ def test_all_rows_are_compute_vm_kind():
 def test_terms_hash_matches_terms_content():
     """For every row, recompute terms_hash from the row's terms and assert equality."""
     from normalize.terms import terms_hash
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     for r in rows:
         assert r["terms_hash"] == terms_hash(r["terms"])
 
@@ -40,5 +40,5 @@ def test_unknown_region_skipped(tmp_path):
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    rows = list(ingest(offer_path=p))
+    rows = list(ingest(offer_paths=[p]))
     assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_ec2_ingest.py
+++ b/pipeline/tests/test_aws_ec2_ingest.py
@@ -35,12 +35,12 @@ def test_terms_hash_matches_terms_content():
         assert r["terms_hash"] == terms_hash(r["terms"])
 
 
-def test_unknown_region_rejected(tmp_path):
-    """A product in a region not in regions.yaml must fail the ingest."""
+def test_unknown_region_skipped(tmp_path):
+    """A product in a region outside regions.yaml is silently dropped."""
     bad = json.loads(FIXTURE.read_text())
     first_sku = next(iter(bad["products"]))
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="ap-south-9"):
-        list(ingest(offer_path=p))
+    rows = list(ingest(offer_path=p))
+    assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_fetch.py
+++ b/pipeline/tests/test_aws_fetch.py
@@ -1,0 +1,153 @@
+"""Tests for fetch_offer() in ingest.aws_common."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import requests_mock as req_mock
+
+from ingest.aws_common import fetch_offer
+
+_EC2_URL = "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/index.json"
+_BODY = json.dumps(
+    {
+        "publicationDate": "2026-04-18T00:00:00Z",
+        "offers": {"AmazonEC2": {}},
+    }
+).encode()
+
+
+@pytest.fixture()
+def _patch_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("ingest.aws_common.time.sleep", lambda _x: None)
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path(tmp_path: Path) -> None:
+    target = tmp_path / "offer.json"
+    with req_mock.Mocker() as m:
+        m.get(
+            _EC2_URL,
+            content=_BODY,
+            headers={"Content-Length": str(len(_BODY))},
+        )
+        pub_date = fetch_offer("aws_ec2", target)
+
+    assert pub_date == "2026-04-18T00:00:00Z"
+    assert target.exists()
+    assert target.read_bytes() == _BODY
+
+
+# ---------------------------------------------------------------------------
+# 2. EBS shares EC2 offer URL
+# ---------------------------------------------------------------------------
+
+
+def test_ebs_shares_ec2_url(tmp_path: Path) -> None:
+    target = tmp_path / "offer.json"
+    with req_mock.Mocker() as m:
+        m.get(
+            _EC2_URL,
+            content=_BODY,
+            headers={"Content-Length": str(len(_BODY))},
+        )
+        fetch_offer("aws_ebs", target)
+        assert m.last_request.url == _EC2_URL
+
+
+# ---------------------------------------------------------------------------
+# 3. 404 — no retry on 4xx
+# ---------------------------------------------------------------------------
+
+
+def test_404_raises_no_retry(tmp_path: Path) -> None:
+    target = tmp_path / "offer.json"
+    with req_mock.Mocker() as m:
+        m.get(_EC2_URL, status_code=404)
+        with pytest.raises(RuntimeError, match=r"https://"):
+            fetch_offer("aws_ec2", target)
+        assert m.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. 500 → 500 → 200 (two retries then success)
+# ---------------------------------------------------------------------------
+
+
+def test_500_then_success(tmp_path: Path, _patch_sleep: None) -> None:
+    target = tmp_path / "offer.json"
+    responses = [
+        {"status_code": 500},
+        {"status_code": 500},
+        {
+            "status_code": 200,
+            "content": _BODY,
+            "headers": {"Content-Length": str(len(_BODY))},
+        },
+    ]
+    with req_mock.Mocker() as m:
+        m.get(_EC2_URL, response_list=responses)
+        pub_date = fetch_offer("aws_ec2", target)
+        assert pub_date == "2026-04-18T00:00:00Z"
+        assert m.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# 5. 500 all 3 → RuntimeError; call_count == retries (3)
+# ---------------------------------------------------------------------------
+
+
+def test_500_exhausted(tmp_path: Path, _patch_sleep: None) -> None:
+    target = tmp_path / "offer.json"
+    with req_mock.Mocker() as m:
+        m.get(_EC2_URL, status_code=500)
+        with pytest.raises(RuntimeError):
+            fetch_offer("aws_ec2", target, retries=3)
+        assert m.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# 6. Truncated body — .part and target must not exist after failure
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_body(tmp_path: Path) -> None:
+    target = tmp_path / "offer.json"
+    short_body = _BODY[:50]
+    with req_mock.Mocker() as m:
+        m.get(
+            _EC2_URL,
+            content=short_body,
+            headers={"Content-Length": "1000"},
+        )
+        with pytest.raises(RuntimeError, match="truncated"):
+            fetch_offer("aws_ec2", target)
+
+    assert not target.exists()
+    assert not target.with_suffix(target.suffix + ".part").exists()
+
+
+# ---------------------------------------------------------------------------
+# 7. User-Agent header
+# ---------------------------------------------------------------------------
+
+
+def test_user_agent(tmp_path: Path) -> None:
+    target = tmp_path / "offer.json"
+    with req_mock.Mocker() as m:
+        m.get(
+            _EC2_URL,
+            content=_BODY,
+            headers={"Content-Length": str(len(_BODY))},
+        )
+        fetch_offer("aws_ec2", target)
+        ua = m.last_request.headers.get("User-Agent", "")
+
+    assert ua.startswith("sku-pipeline/")
+    assert "https://github.com/sofq/sku" in ua

--- a/pipeline/tests/test_aws_fetch.py
+++ b/pipeline/tests/test_aws_fetch.py
@@ -37,9 +37,9 @@ def test_happy_path(tmp_path: Path) -> None:
             content=_BODY,
             headers={"Content-Length": str(len(_BODY))},
         )
-        pub_date = fetch_offer("aws_ec2", target)
+        result = fetch_offer("aws_ec2", target)
 
-    assert pub_date == "2026-04-18T00:00:00Z"
+    assert result is None
     assert target.exists()
     assert target.read_bytes() == _BODY
 
@@ -93,8 +93,8 @@ def test_500_then_success(tmp_path: Path, _patch_sleep: None) -> None:
     ]
     with req_mock.Mocker() as m:
         m.get(_EC2_URL, response_list=responses)
-        pub_date = fetch_offer("aws_ec2", target)
-        assert pub_date == "2026-04-18T00:00:00Z"
+        fetch_offer("aws_ec2", target)
+        assert target.read_bytes() == _BODY
         assert m.call_count == 3
 
 

--- a/pipeline/tests/test_aws_lambda_ingest.py
+++ b/pipeline/tests/test_aws_lambda_ingest.py
@@ -45,11 +45,11 @@ def test_arm64_price_lower_than_x86_64_same_region():
             assert arm_dur < x86_dur, f"arm64 duration {arm_dur} should be < x86_64 {x86_dur}"
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     first_sku = next(iter(bad["products"]))
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="ap-south-9"):
-        list(ingest(offer_path=p))
+    rows = list(ingest(offer_path=p))
+    assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_lambda_ingest.py
+++ b/pipeline/tests/test_aws_lambda_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.aws_lambda import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "aws_lambda" / "offer.json"

--- a/pipeline/tests/test_aws_s3_ingest.py
+++ b/pipeline/tests/test_aws_s3_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.aws_s3 import ingest
 from normalize.terms import terms_hash
 

--- a/pipeline/tests/test_aws_s3_ingest.py
+++ b/pipeline/tests/test_aws_s3_ingest.py
@@ -45,11 +45,11 @@ def test_terms_hash_uses_empty_tenancy_os():
         assert r["terms_hash"] == terms_hash(r["terms"])
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     first_sku = next(iter(bad["products"]))
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="ap-south-9"):
-        list(ingest(offer_path=p))
+    rows = list(ingest(offer_path=p))
+    assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_strip.py
+++ b/pipeline/tests/test_aws_strip.py
@@ -1,0 +1,214 @@
+"""Tests for the streaming-strip + per-region fetch helpers in aws_common."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import requests_mock as req_mock
+
+from ingest.aws_common import (
+    _strip_ec2_offer,
+    aws_regions_from_yaml,
+    fetch_offer_regions_stripped,
+)
+
+
+def _write(path: Path, obj: dict) -> None:
+    path.write_text(json.dumps(obj))
+
+
+def test_strip_keeps_only_whitelisted_fields(tmp_path: Path) -> None:
+    """Strip drops Reserved terms, offerTermCode, description, non-EC2 attrs."""
+    raw = {
+        "formatVersion": "v1.0",
+        "offerCode": "AmazonEC2",
+        "publicationDate": "2026-04-18T00:00:00Z",
+        "version": "20260418000000",
+        "products": {
+            "sku-compute": {
+                "productFamily": "Compute Instance",
+                "sku": "sku-compute",
+                "attributes": {
+                    "instanceType": "m5.large",
+                    "regionCode": "us-east-1",
+                    "operatingSystem": "Linux",
+                    "tenancy": "Shared",
+                    "preInstalledSw": "NA",
+                    "capacitystatus": "Used",
+                    "vcpu": "2",
+                    "memory": "8 GiB",
+                    "physicalProcessor": "Intel",
+                    "networkPerformance": "10 Gig",
+                    "servicecode": "AmazonEC2",  # dropped
+                    "location": "US East",  # dropped
+                },
+            },
+            "sku-storage": {
+                "productFamily": "Storage",
+                "attributes": {
+                    "volumeApiName": "gp3",
+                    "regionCode": "us-east-1",
+                    "servicecode": "AmazonEC2",  # dropped
+                },
+            },
+            "sku-ignored": {
+                "productFamily": "Data Transfer",  # whole product dropped
+                "attributes": {"regionCode": "us-east-1"},
+            },
+        },
+        "terms": {
+            "OnDemand": {
+                "sku-compute": {
+                    "sku-compute.TERM": {
+                        "offerTermCode": "JRTC",  # dropped
+                        "effectiveDate": "2020-01-01",  # dropped
+                        "termAttributes": {},  # dropped
+                        "priceDimensions": {
+                            "sku-compute.TERM.RATE": {
+                                "rateCode": "abc",  # dropped
+                                "description": "$0.096 per hour",  # dropped
+                                "beginRange": "0",  # dropped
+                                "endRange": "Inf",  # dropped
+                                "unit": "Hrs",
+                                "pricePerUnit": {"USD": "0.0960000000"},
+                            }
+                        },
+                    }
+                },
+                "sku-ignored": {  # referenced but product dropped
+                    "sku-ignored.TERM": {
+                        "priceDimensions": {"x.y.z": {"unit": "GB", "pricePerUnit": {"USD": "1"}}}
+                    }
+                },
+            },
+            "Reserved": {  # entire Reserved block dropped
+                "sku-compute": {"a.b": {"priceDimensions": {}}}
+            },
+        },
+    }
+    raw_path = tmp_path / "raw.json"
+    out_path = tmp_path / "stripped.json"
+    _write(raw_path, raw)
+
+    _strip_ec2_offer(raw_path, out_path)
+    stripped = json.loads(out_path.read_text())
+
+    # Products: kept two, dropped one.
+    assert set(stripped["products"]) == {"sku-compute", "sku-storage"}
+    compute_attrs = stripped["products"]["sku-compute"]["attributes"]
+    assert "servicecode" not in compute_attrs
+    assert "location" not in compute_attrs
+    assert compute_attrs["instanceType"] == "m5.large"
+    assert compute_attrs["vcpu"] == "2"
+    assert stripped["products"]["sku-storage"]["attributes"]["volumeApiName"] == "gp3"
+
+    # Terms: Reserved gone; OnDemand for dropped products pruned.
+    assert set(stripped["terms"]) == {"OnDemand"}
+    assert set(stripped["terms"]["OnDemand"]) == {"sku-compute"}
+    term = next(iter(stripped["terms"]["OnDemand"]["sku-compute"].values()))
+    assert set(term) == {"priceDimensions"}  # offerTermCode, termAttributes gone
+    pd = next(iter(term["priceDimensions"].values()))
+    assert set(pd) == {"unit", "pricePerUnit"}
+    assert pd["unit"] == "Hrs"
+    assert pd["pricePerUnit"]["USD"] == "0.0960000000"
+
+
+def test_strip_reduces_file_size(tmp_path: Path) -> None:
+    """Sanity check: stripping the existing fixture produces a smaller file.
+
+    The fixture is already hand-trimmed (no Reserved, short descriptions), so
+    this mostly catches regressions where we accidentally stop trimming. Real
+    per-region AWS offers see ~95%+ reduction.
+    """
+    fixture = Path(__file__).resolve().parent.parent / "testdata" / "aws_ec2" / "offer.json"
+    out_path = tmp_path / "stripped.json"
+    _strip_ec2_offer(fixture, out_path)
+    assert out_path.stat().st_size < fixture.stat().st_size
+
+
+def test_aws_regions_from_yaml_matches_regions_yaml() -> None:
+    """Hardcoded regions list matches current regions.yaml coverage."""
+    assert aws_regions_from_yaml() == [
+        "ap-northeast-1",
+        "eu-west-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-2",
+    ]
+
+
+def test_fetch_offer_regions_stripped(tmp_path: Path) -> None:
+    """End-to-end: mock region_index + per-region fetches, verify strip produces output."""
+    region_index_url = (
+        "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/region_index.json"
+    )
+    region_a_url = (
+        "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/20260418/us-east-1/index.json"
+    )
+    region_b_url = (
+        "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/20260418/eu-west-1/index.json"
+    )
+    region_index = {
+        "regions": {
+            "us-east-1": {
+                "regionCode": "us-east-1",
+                "currentVersionUrl": "/offers/v1.0/aws/AmazonEC2/20260418/us-east-1/index.json",
+            },
+            "eu-west-1": {
+                "regionCode": "eu-west-1",
+                "currentVersionUrl": "/offers/v1.0/aws/AmazonEC2/20260418/eu-west-1/index.json",
+            },
+        }
+    }
+    tiny_offer = {
+        "products": {
+            "sku-x": {
+                "productFamily": "Compute Instance",
+                "attributes": {"instanceType": "m5.large", "regionCode": "us-east-1"},
+            }
+        },
+        "terms": {
+            "OnDemand": {
+                "sku-x": {
+                    "sku-x.T": {
+                        "priceDimensions": {
+                            "sku-x.T.R": {"unit": "Hrs", "pricePerUnit": {"USD": "0.1"}}
+                        }
+                    }
+                }
+            }
+        },
+    }
+    body_index = json.dumps(region_index).encode()
+    body_offer = json.dumps(tiny_offer).encode()
+
+    idx_hdr = {"Content-Length": str(len(body_index))}
+    offer_hdr = {"Content-Length": str(len(body_offer))}
+    with req_mock.Mocker() as m:
+        m.get(region_index_url, content=body_index, headers=idx_hdr)
+        m.get(region_a_url, content=body_offer, headers=offer_hdr)
+        m.get(region_b_url, content=body_offer, headers=offer_hdr)
+        out_dir = tmp_path / "stripped"
+        paths = fetch_offer_regions_stripped(
+            "aws_ec2", out_dir, regions=["us-east-1", "eu-west-1", "ap-south-99"]
+        )
+
+    # Only two regions existed upstream; the missing one is silently skipped.
+    assert sorted(p.name for p in paths) == [
+        "aws_ec2-eu-west-1.json",
+        "aws_ec2-us-east-1.json",
+    ]
+    # Raw files removed; stripped files remain.
+    assert not any(out_dir.glob("*.raw.json"))
+    # Each stripped file is valid JSON with our trimmed shape.
+    for p in paths:
+        doc = json.loads(p.read_text())
+        assert list(doc["products"]) == ["sku-x"]
+        assert list(doc["terms"]["OnDemand"]) == ["sku-x"]
+
+
+def test_fetch_unsupported_shard_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="per-region offer not supported"):
+        fetch_offer_regions_stripped("aws_s3", tmp_path, regions=["us-east-1"])

--- a/pipeline/tests/test_azure_blob_ingest.py
+++ b/pipeline/tests/test_azure_blob_ingest.py
@@ -54,7 +54,7 @@ def test_non_usd_rows_filtered():
         assert eur_ids.isdisjoint(parts)
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     for it in bad["Items"]:
         if it["type"] == "Consumption" and it["currencyCode"] == "USD":
@@ -62,5 +62,5 @@ def test_unknown_region_rejected(tmp_path):
             break
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="centralus"):
-        list(ingest(prices_path=p))
+    rows = list(ingest(prices_path=p))
+    assert all(r["region"] != "centralus" for r in rows)

--- a/pipeline/tests/test_azure_blob_ingest.py
+++ b/pipeline/tests/test_azure_blob_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.azure_blob import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "azure_blob" / "prices.json"
@@ -31,7 +29,8 @@ def test_each_row_carries_three_dims():
     rows = list(ingest(prices_path=FIXTURE))
     for r in rows:
         dims = {p["dimension"] for p in r["prices"]}
-        assert dims == {"storage", "read-ops", "write-ops"}, f"row {r['sku_id']} missing dims: {dims}"
+        assert dims == {"storage", "read-ops", "write-ops"}, \
+            f"row {r['sku_id']} missing dims: {dims}"
 
 
 def test_reservation_rows_filtered():

--- a/pipeline/tests/test_azure_fetch.py
+++ b/pipeline/tests/test_azure_fetch.py
@@ -1,0 +1,203 @@
+"""Tests for fetch_prices() in ingest.azure_common (TDD, Task 3 m3a.4.1)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+import requests_mock as req_mock
+
+import ingest.azure_common as azure_common
+from ingest.azure_common import _AZURE_RETAIL_BASE, fetch_prices
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PAGE2_URL = "https://mocked/page2"
+
+_ITEM1 = {"skuId": "sku-A", "retailPrice": 0.01}
+_ITEM2 = {"skuId": "sku-B", "retailPrice": 0.02}
+_ITEM3 = {"skuId": "sku-C", "retailPrice": 0.03}
+_ITEM4 = {"skuId": "sku-D", "retailPrice": 0.04}
+_ITEM5 = {"skuId": "sku-E", "retailPrice": 0.05}
+
+_PAGE1_RESP = {"Items": [_ITEM3, _ITEM1, _ITEM2], "NextPageLink": _PAGE2_URL}
+_PAGE2_RESP = {"Items": [_ITEM5, _ITEM4], "NextPageLink": None}
+
+
+def _sorted_items(items: list[dict]) -> list[dict]:
+    return sorted(items, key=lambda x: x.get("skuId", ""))
+
+
+def _hash_items(items: list[dict]) -> str:
+    sorted_items = _sorted_items(items)
+    data = json.dumps(sorted_items, separators=(",", ":"), sort_keys=True).encode()
+    return hashlib.sha256(data).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Two-page pagination + stable hash
+# ---------------------------------------------------------------------------
+
+
+def test_two_page_pagination(tmp_path):
+    target = tmp_path / "out.json"
+    with req_mock.Mocker() as m:
+        m.get(_AZURE_RETAIL_BASE, json=_PAGE1_RESP)
+        m.get(_PAGE2_URL, json=_PAGE2_RESP)
+
+        digest = fetch_prices("serviceName eq 'Virtual Machines'", target)
+
+    body = json.loads(target.read_text())
+    assert list(body.keys()) == ["Items"]
+    assert len(body["Items"]) == 5
+
+    expected_order = _sorted_items([_ITEM1, _ITEM2, _ITEM3, _ITEM4, _ITEM5])
+    assert body["Items"] == expected_order
+
+    expected_digest = _hash_items([_ITEM1, _ITEM2, _ITEM3, _ITEM4, _ITEM5])
+    assert digest == expected_digest
+
+
+def test_two_page_pagination_hash_stable(tmp_path):
+    """Hash is deterministic: two calls with identical data produce same digest."""
+    target1 = tmp_path / "out1.json"
+    target2 = tmp_path / "out2.json"
+
+    with req_mock.Mocker() as m:
+        m.get(_AZURE_RETAIL_BASE, json=_PAGE1_RESP)
+        m.get(_PAGE2_URL, json=_PAGE2_RESP)
+        digest1 = fetch_prices("serviceName eq 'Virtual Machines'", target1)
+
+    with req_mock.Mocker() as m:
+        m.get(_AZURE_RETAIL_BASE, json=_PAGE1_RESP)
+        m.get(_PAGE2_URL, json=_PAGE2_RESP)
+        digest2 = fetch_prices("serviceName eq 'Virtual Machines'", target2)
+
+    assert digest1 == digest2
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Empty result
+# ---------------------------------------------------------------------------
+
+
+def test_empty_result(tmp_path):
+    target = tmp_path / "empty.json"
+    with req_mock.Mocker() as m:
+        m.get(_AZURE_RETAIL_BASE, json={"Items": [], "NextPageLink": None})
+
+        digest = fetch_prices("serviceName eq 'Nope'", target)
+
+    body = json.loads(target.read_text())
+    assert body == {"Items": []}
+
+    expected_digest = hashlib.sha256(
+        json.dumps([], separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+    assert digest == expected_digest
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Filter URL-encoding
+# ---------------------------------------------------------------------------
+
+
+def test_filter_url_encoding(tmp_path):
+    filter_str = "serviceName eq 'Virtual Machines' and armRegionName eq 'eastus'"
+    target = tmp_path / "filter.json"
+
+    with req_mock.Mocker() as m:
+        m.get(_AZURE_RETAIL_BASE, json={"Items": [], "NextPageLink": None})
+
+        fetch_prices(filter_str, target)
+
+        first_req = m.request_history[0]
+        # .qs normalizes casing; check the raw URL for the encoded filter value.
+        raw_url = first_req.url
+        assert "$filter" in raw_url or "%24filter" in raw_url
+        # URL must contain URL-encoded apostrophes (%27) confirming encoding.
+        assert "%27" in raw_url
+        # And the key names must appear (case-sensitive) in the encoded URL.
+        assert "serviceName" in raw_url
+        assert "armRegionName" in raw_url
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Page cap exceeded
+# ---------------------------------------------------------------------------
+
+
+def test_page_cap_exceeded(tmp_path, monkeypatch):
+    """After _MAX_PAGES pages, raises RuntimeError('page_cap_exceeded')."""
+    monkeypatch.setattr(azure_common, "_MAX_PAGES", 3)
+
+    target = tmp_path / "cap.json"
+
+    with req_mock.Mocker() as m:
+        # Each page links to the next with a unique URL.
+        for i in range(10):
+            url = _AZURE_RETAIL_BASE if i == 0 else f"https://mocked/page{i}"
+            next_url = f"https://mocked/page{i + 1}"
+            m.get(url, json={"Items": [{"skuId": f"sku-{i}"}], "NextPageLink": next_url})
+
+        with pytest.raises(RuntimeError, match="page_cap_exceeded"):
+            fetch_prices("serviceName eq 'Anything'", target)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Retry on 5xx mid-pagination
+# ---------------------------------------------------------------------------
+
+
+def test_retry_on_5xx(tmp_path, monkeypatch):
+    """Second page: 500 twice, then 200. Final data is correct; retries are counted."""
+    monkeypatch.setattr("ingest.azure_common.time.sleep", lambda *_: None)
+
+    target = tmp_path / "retry.json"
+    call_counts: dict[str, int] = {"page2": 0}
+
+    def page2_callback(request, context):
+        call_counts["page2"] += 1
+        if call_counts["page2"] <= 2:
+            context.status_code = 500
+            return {"error": "internal"}
+        context.status_code = 200
+        return _PAGE2_RESP
+
+    with req_mock.Mocker() as m:
+        m.get(_AZURE_RETAIL_BASE, json=_PAGE1_RESP)
+        m.get(_PAGE2_URL, json=page2_callback)
+
+        digest = fetch_prices("serviceName eq 'Virtual Machines'", target, retries=3)
+
+    assert call_counts["page2"] == 3  # 2 failures + 1 success
+
+    body = json.loads(target.read_text())
+    assert len(body["Items"]) == 5
+
+    expected_digest = _hash_items([_ITEM1, _ITEM2, _ITEM3, _ITEM4, _ITEM5])
+    assert digest == expected_digest
+
+
+# ---------------------------------------------------------------------------
+# Test 6: User-Agent header
+# ---------------------------------------------------------------------------
+
+
+def test_user_agent_header(tmp_path):
+    """Every request (first page + subsequent pages) carries the sku-pipeline User-Agent."""
+    target = tmp_path / "ua.json"
+
+    with req_mock.Mocker() as m:
+        m.get(_AZURE_RETAIL_BASE, json=_PAGE1_RESP)
+        m.get(_PAGE2_URL, json=_PAGE2_RESP)
+
+        fetch_prices("serviceName eq 'VMs'", target)
+
+        for req in m.request_history:
+            ua = req.headers.get("User-Agent", "")
+            assert "sku-pipeline" in ua, f"Missing sku-pipeline in User-Agent: {ua!r}"
+            assert "github.com/sofq/sku" in ua, f"Missing repo URL in User-Agent: {ua!r}"

--- a/pipeline/tests/test_azure_functions_ingest.py
+++ b/pipeline/tests/test_azure_functions_ingest.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 from ingest.azure_functions import ingest
 
-FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "azure_functions" / "prices.json"
-GOLDEN = Path(__file__).resolve().parent.parent / "testdata" / "golden" / "azure_functions_rows.jsonl"
+_DATA = Path(__file__).resolve().parent.parent / "testdata"
+FIXTURE = _DATA / "azure_functions" / "prices.json"
+GOLDEN = _DATA / "golden" / "azure_functions_rows.jsonl"
 
 
 def _canonical(rows):

--- a/pipeline/tests/test_azure_sql_ingest.py
+++ b/pipeline/tests/test_azure_sql_ingest.py
@@ -43,7 +43,7 @@ def test_business_critical_more_expensive_than_general_purpose():
 
 
 def test_unit_of_measure_divisor_applied():
-    """The one '100 Hours' row in the fixture must come out at the same per-hour rate as its '1 Hour' twin."""
+    """The one '100 Hours' row must match the per-hour rate of its '1 Hour' twin."""
     rows = list(ingest(prices_path=FIXTURE))
     # Group by (sku, region, deployment); we expect equal-or-very-close per-hour amounts
     # for the row priced as '100 Hours' and any sibling priced as '1 Hour'. Since the

--- a/pipeline/tests/test_azure_sql_ingest.py
+++ b/pipeline/tests/test_azure_sql_ingest.py
@@ -3,7 +3,7 @@
 import json
 from pathlib import Path
 
-import pytest
+import pytest  # used by test_unit_of_measure_divisor_applied
 
 from ingest.azure_sql import ingest
 
@@ -57,8 +57,8 @@ def test_unit_of_measure_divisor_applied():
         assert west == pytest.approx(east * 1.05, rel=1e-9)
 
 
-def test_unknown_uom_rejected(tmp_path):
-    """A row with a non-time unitOfMeasure must fail the build."""
+def test_unknown_uom_skipped(tmp_path):
+    """A row with an unrecognised unitOfMeasure (monthly, per-million, etc.) is silently dropped."""
     bad = json.loads(FIXTURE.read_text())
     for it in bad["Items"]:
         if it["serviceName"] == "SQL Database" and it["currencyCode"] == "USD":
@@ -66,5 +66,5 @@ def test_unknown_uom_rejected(tmp_path):
             break
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(ValueError, match="GB/Month"):
-        list(ingest(prices_path=p))
+    rows = list(ingest(prices_path=p))
+    assert all(r["prices"][0]["unit"] != "gb-mo" for r in rows)

--- a/pipeline/tests/test_azure_vm_ingest.py
+++ b/pipeline/tests/test_azure_vm_ingest.py
@@ -51,8 +51,8 @@ def test_non_usd_rows_rejected():
         assert r["prices"][0]["amount"] > 0  # smoke
 
 
-def test_unknown_region_rejected(tmp_path):
-    """An item in a region not in regions.yaml must fail the ingest."""
+def test_unknown_region_skipped(tmp_path):
+    """An item in a region outside regions.yaml is silently dropped."""
     bad = json.loads(FIXTURE.read_text())
     # Mutate the first Consumption USD item to an unseen region.
     for it in bad["Items"]:
@@ -61,5 +61,5 @@ def test_unknown_region_rejected(tmp_path):
             break
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="centralus"):
-        list(ingest(prices_path=p))
+    rows = list(ingest(prices_path=p))
+    assert all(r["region"] != "centralus" for r in rows)

--- a/pipeline/tests/test_azure_vm_ingest.py
+++ b/pipeline/tests/test_azure_vm_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.azure_vm import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "azure_vm" / "prices.json"

--- a/pipeline/tests/test_build_delta.py
+++ b/pipeline/tests/test_build_delta.py
@@ -1,0 +1,176 @@
+"""Unit tests for pipeline.package.build_delta."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import sqlite3
+from pathlib import Path
+
+from package.build_delta import build_delta
+from package.build_shard import build_shard
+
+
+def _base_row(sku_id: str, amount: float) -> dict:
+    return {
+        "sku_id": sku_id,
+        "provider": "anthropic",
+        "service": "llm",
+        "kind": "llm.text",
+        "resource_name": sku_id.split("::")[0],
+        "region": "",
+        "region_normalized": "",
+        "terms": {"commitment": "on_demand", "tenancy": "", "os": ""},
+        "terms_hash": f"h-{sku_id}",
+        "resource_attrs": {"context_length": 200_000},
+        "prices": [
+            {"dimension": "prompt", "tier": "", "amount": amount, "unit": "token"},
+            {"dimension": "completion", "tier": "", "amount": amount * 5, "unit": "token"},
+        ],
+    }
+
+
+def _write_shard(tmp_path: Path, name: str, rows: list[dict], version: str) -> Path:
+    rows_path = tmp_path / f"{name}.rows.jsonl"
+    rows_path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    out = tmp_path / f"{name}.db"
+    build_shard(
+        rows_path=rows_path,
+        shard=name,
+        out_path=out,
+        catalog_version=version,
+        generated_at=f"2026-04-18T00:00:00Z",
+        source_url="https://example.com",
+    )
+    return out
+
+
+def _decompress(paths: list[Path]) -> str:
+    parts = [gzip.decompress(p.read_bytes()).decode() for p in paths]
+    return "\n".join(parts)
+
+
+def _apply_and_snapshot(prev_db: Path, sql: str, tmp_path: Path) -> Path:
+    target = tmp_path / "applied.db"
+    target.write_bytes(prev_db.read_bytes())
+    con = sqlite3.connect(target)
+    try:
+        con.execute("PRAGMA foreign_keys = OFF")
+        con.executescript(sql)
+        con.commit()
+    finally:
+        con.close()
+    return target
+
+
+def _table_snapshot(db: Path, table: str) -> list[tuple]:
+    con = sqlite3.connect(db)
+    try:
+        cols = [r[1] for r in con.execute(f"PRAGMA table_info({table})").fetchall()]
+        rows = list(con.execute(f"SELECT {', '.join(cols)} FROM {table}"))
+        return sorted(rows)
+    finally:
+        con.close()
+
+
+def test_round_trip_inserts_and_updates(tmp_path: Path):
+    """prev has 10 rows, new has 12 (2 inserted, 1 updated). Applying the
+    delta to prev should reproduce new (excluding metadata)."""
+    prev_rows = [_base_row(f"sku-{i}::anthropic::default", 0.001 * (i + 1)) for i in range(10)]
+    new_rows = [_base_row(f"sku-{i}::anthropic::default", 0.001 * (i + 1)) for i in range(12)]
+    # Update row #3's price
+    new_rows[3]["prices"][0]["amount"] = 0.999
+
+    prev_db = _write_shard(tmp_path, "prev", prev_rows, "2026.04.17")
+    new_db = _write_shard(tmp_path, "new", new_rows, "2026.04.18")
+
+    parts = build_delta(prev_db, new_db, tmp_path / "delta.sql.gz")
+    assert len(parts) == 1
+    assert parts[0] == tmp_path / "delta.sql.gz"
+
+    sql = _decompress(parts)
+    applied = _apply_and_snapshot(prev_db, sql, tmp_path)
+
+    for table in ("skus", "resource_attrs", "terms", "prices", "health"):
+        assert _table_snapshot(applied, table) == _table_snapshot(new_db, table), (
+            f"table {table} mismatch after applying delta"
+        )
+
+
+def test_round_trip_deletions(tmp_path: Path):
+    """prev has 10 rows, new has 7 (3 deleted). Delta contains DELETEs."""
+    prev_rows = [_base_row(f"sku-{i}::anthropic::default", 0.001) for i in range(10)]
+    new_rows = prev_rows[:7]
+
+    prev_db = _write_shard(tmp_path, "prev", prev_rows, "2026.04.17")
+    new_db = _write_shard(tmp_path, "new", new_rows, "2026.04.18")
+
+    parts = build_delta(prev_db, new_db, tmp_path / "delta.sql.gz")
+    sql = _decompress(parts)
+    applied = _apply_and_snapshot(prev_db, sql, tmp_path)
+
+    assert _table_snapshot(applied, "skus") == _table_snapshot(new_db, "skus")
+    # Confirm we actually emitted DELETE statements for the 3 removed skus.
+    assert sql.count("DELETE FROM skus WHERE sku_id =") == 3
+    # No bulk upsert of unchanged rows.
+    assert "sku-0::anthropic::default" not in sql or "INSERT OR REPLACE INTO skus" not in sql.split(
+        "DELETE FROM metadata"
+    )[0].split("sku-0::anthropic::default")[0]
+
+
+def test_split_when_gzipped_exceeds_max_bytes(tmp_path: Path):
+    """A max_bytes cap forces the delta to split into multiple parts, and the
+    concatenation still reproduces the target."""
+    prev_rows = [_base_row(f"sku-{i}::anthropic::default", 0.001) for i in range(5)]
+    new_rows = [_base_row(f"sku-{i}::anthropic::default", 0.001 * (i + 1)) for i in range(25)]
+
+    prev_db = _write_shard(tmp_path, "prev", prev_rows, "2026.04.17")
+    new_db = _write_shard(tmp_path, "new", new_rows, "2026.04.18")
+
+    parts = build_delta(prev_db, new_db, tmp_path / "delta.sql.gz", max_bytes=256)
+    assert len(parts) >= 2, f"expected split; got {parts}"
+    for p in parts:
+        assert p.stat().st_size <= 512  # generous headroom over the 256-byte target
+        assert "-part" in p.name
+
+    sql = _decompress(parts)
+    applied = _apply_and_snapshot(prev_db, sql, tmp_path)
+    assert _table_snapshot(applied, "skus") == _table_snapshot(new_db, "skus")
+    assert _table_snapshot(applied, "prices") == _table_snapshot(new_db, "prices")
+
+
+def test_noop_when_shards_identical(tmp_path: Path):
+    """Identical shards produce a single gzipped file containing only the
+    metadata replay + a `-- noop` header."""
+    rows = [_base_row(f"sku-{i}::anthropic::default", 0.001) for i in range(3)]
+    prev_db = _write_shard(tmp_path, "prev", rows, "2026.04.18")
+    new_db = _write_shard(tmp_path, "new", rows, "2026.04.18")
+
+    parts = build_delta(prev_db, new_db, tmp_path / "delta.sql.gz")
+    assert len(parts) == 1
+    sql = _decompress(parts)
+    assert sql.startswith("-- noop")
+    assert "DELETE FROM metadata" in sql
+    # No data-table mutations when no skus changed.
+    assert "DELETE FROM skus" not in sql
+    assert "INSERT OR REPLACE INTO skus" not in sql
+    assert "INSERT OR REPLACE INTO prices" not in sql
+
+
+def test_prices_row_deletion_within_same_sku(tmp_path: Path):
+    """When a sku_id remains but one of its price rows is dropped, the delta
+    emits a DELETE for just that (sku_id, dimension, tier)."""
+    prev_rows = [_base_row("sku-0::anthropic::default", 0.001)]
+    new_rows = [_base_row("sku-0::anthropic::default", 0.001)]
+    new_rows[0]["prices"] = [new_rows[0]["prices"][0]]  # drop the completion row
+
+    prev_db = _write_shard(tmp_path, "prev", prev_rows, "2026.04.17")
+    new_db = _write_shard(tmp_path, "new", new_rows, "2026.04.18")
+
+    parts = build_delta(prev_db, new_db, tmp_path / "delta.sql.gz")
+    sql = _decompress(parts)
+    assert "DELETE FROM prices WHERE sku_id = 'sku-0::anthropic::default'" in sql
+    assert "dimension = 'completion'" in sql
+
+    applied = _apply_and_snapshot(prev_db, sql, tmp_path)
+    assert _table_snapshot(applied, "prices") == _table_snapshot(new_db, "prices")

--- a/pipeline/tests/test_build_delta.py
+++ b/pipeline/tests/test_build_delta.py
@@ -39,7 +39,7 @@ def _write_shard(tmp_path: Path, name: str, rows: list[dict], version: str) -> P
         shard=name,
         out_path=out,
         catalog_version=version,
-        generated_at=f"2026-04-18T00:00:00Z",
+        generated_at="2026-04-18T00:00:00Z",
         source_url="https://example.com",
     )
     return out
@@ -113,9 +113,11 @@ def test_round_trip_deletions(tmp_path: Path):
     # Confirm we actually emitted DELETE statements for the 3 removed skus.
     assert sql.count("DELETE FROM skus WHERE sku_id =") == 3
     # No bulk upsert of unchanged rows.
-    assert "sku-0::anthropic::default" not in sql or "INSERT OR REPLACE INTO skus" not in sql.split(
-        "DELETE FROM metadata"
-    )[0].split("sku-0::anthropic::default")[0]
+    assert (
+        "sku-0::anthropic::default" not in sql
+        or "INSERT OR REPLACE INTO skus"
+        not in sql.split("DELETE FROM metadata")[0].split("sku-0::anthropic::default")[0]
+    )
 
 
 def test_split_when_gzipped_exceeds_max_bytes(tmp_path: Path):

--- a/pipeline/tests/test_build_manifest.py
+++ b/pipeline/tests/test_build_manifest.py
@@ -1,0 +1,354 @@
+"""Unit tests for pipeline.package.build_manifest."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from package.build_manifest import build_manifest
+
+NOW = "2026-04-18T00:00:00Z"
+BASE_URL = "https://github.com/sofq/sku/releases/download/data-2026.04.18"
+
+
+def _write(path: Path, contents: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(contents)
+
+
+def _sha(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+
+def _sidecar(path: Path, **fields) -> None:
+    path.write_text(json.dumps(fields))
+
+
+def test_fresh_first_release_every_shard_has_baseline_empty_deltas(tmp_path: Path):
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+
+    shard_bytes = b"fake sqlite zstd bytes"
+    for shard in ("aws-ec2", "openrouter"):
+        _write(artifacts / f"{shard}.db.zst", shard_bytes)
+        _sidecar(
+            artifacts / f"{shard}.meta.json",
+            shard=shard,
+            row_count=42,
+            has_baseline=True,
+            delta_from=None,
+            delta_to="2026.04.18",
+        )
+
+    out = tmp_path / "manifest.json"
+    doc = build_manifest(
+        artifacts_dir=artifacts,
+        out=out,
+        catalog_version="2026.04.18",
+        release_base_url=BASE_URL,
+        previous_manifest=None,
+        min_binary_version="1.0.0",
+        now=NOW,
+    )
+
+    assert doc["schema_version"] == 1
+    assert doc["catalog_version"] == "2026.04.18"
+    assert doc["generated_at"] == NOW
+    assert doc["min_binary_version"] == "1.0.0"
+    assert list(doc["shards"].keys()) == ["aws-ec2", "openrouter"]  # sorted
+
+    for shard in ("aws-ec2", "openrouter"):
+        entry = doc["shards"][shard]
+        assert entry["baseline_version"] == "2026.04.18"
+        assert entry["head_version"] == "2026.04.18"
+        assert entry["baseline_url"] == f"{BASE_URL}/{shard}.db.zst"
+        assert entry["baseline_sha256"] == _sha(shard_bytes)
+        assert entry["baseline_size"] == len(shard_bytes)
+        assert entry["deltas"] == []
+        assert entry["row_count"] == 42
+        assert entry["shard_schema_version"] == 1
+        assert entry["min_binary_version"] == "1.0.0"
+        assert entry["last_updated"] == "2026.04.18"
+
+    # File on disk matches returned doc (pretty-printed + trailing newline).
+    assert json.loads(out.read_text()) == doc
+
+
+def test_normal_day_extends_deltas_and_preserves_baseline(tmp_path: Path):
+    # Previous manifest says baseline was 2026.04.17 for aws-ec2.
+    prev_manifest = tmp_path / "prev-manifest.json"
+    prev_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "generated_at": "2026-04-17T03:00:00Z",
+                "catalog_version": "2026.04.17",
+                "min_binary_version": "1.0.0",
+                "shards": {
+                    "aws-ec2": {
+                        "baseline_version": "2026.04.15",
+                        "baseline_url": f"{BASE_URL}/../data-2026.04.15/aws-ec2.db.zst",
+                        "baseline_sha256": "a" * 64,
+                        "baseline_size": 1024,
+                        "head_version": "2026.04.17",
+                        "min_binary_version": "1.0.0",
+                        "shard_schema_version": 1,
+                        "deltas": [
+                            {
+                                "from": "2026.04.15",
+                                "to": "2026.04.16",
+                                "url": "https://example/d1.sql.gz",
+                                "sha256": "b" * 64,
+                                "size": 10,
+                            },
+                            {
+                                "from": "2026.04.16",
+                                "to": "2026.04.17",
+                                "url": "https://example/d2.sql.gz",
+                                "sha256": "c" * 64,
+                                "size": 12,
+                            },
+                        ],
+                        "row_count": 50,
+                        "last_updated": "2026.04.17",
+                    }
+                },
+            }
+        )
+    )
+
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    delta_bytes = b"-- today delta\n"
+    _write(artifacts / "aws-ec2-2026.04.17-to-2026.04.18.sql.gz", delta_bytes)
+    _sidecar(
+        artifacts / "aws-ec2.meta.json",
+        shard="aws-ec2",
+        row_count=55,
+        has_baseline=False,
+        delta_from="2026.04.17",
+        delta_to="2026.04.18",
+    )
+
+    doc = build_manifest(
+        artifacts_dir=artifacts,
+        out=tmp_path / "manifest.json",
+        catalog_version="2026.04.18",
+        release_base_url=BASE_URL,
+        previous_manifest=prev_manifest,
+        min_binary_version="1.0.0",
+        now=NOW,
+    )
+
+    entry = doc["shards"]["aws-ec2"]
+    assert entry["baseline_version"] == "2026.04.15"  # preserved
+    assert entry["head_version"] == "2026.04.18"
+    assert entry["last_updated"] == "2026.04.18"
+    assert entry["row_count"] == 55
+
+    # Deltas: old two + today's one.
+    assert len(entry["deltas"]) == 3
+    today_delta = entry["deltas"][-1]
+    assert today_delta["from"] == "2026.04.17"
+    assert today_delta["to"] == "2026.04.18"
+    assert today_delta["url"] == f"{BASE_URL}/aws-ec2-2026.04.17-to-2026.04.18.sql.gz"
+    assert today_delta["sha256"] == _sha(delta_bytes)
+    assert today_delta["size"] == len(delta_bytes)
+
+
+def test_baseline_rebuild_resets_deltas(tmp_path: Path):
+    prev_manifest = tmp_path / "prev-manifest.json"
+    prev_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "shards": {
+                    "aws-ec2": {
+                        "baseline_version": "2026.04.01",
+                        "baseline_url": "https://stale/baseline.db.zst",
+                        "baseline_sha256": "x" * 64,
+                        "baseline_size": 1,
+                        "head_version": "2026.04.17",
+                        "deltas": [{"from": "x", "to": "y", "url": "z", "sha256": "q", "size": 1}],
+                        "row_count": 50,
+                        "last_updated": "2026.04.17",
+                    }
+                },
+            }
+        )
+    )
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    new_baseline = b"new baseline bytes"
+    _write(artifacts / "aws-ec2.db.zst", new_baseline)
+    _sidecar(
+        artifacts / "aws-ec2.meta.json",
+        shard="aws-ec2",
+        row_count=60,
+        has_baseline=True,
+        delta_from=None,
+        delta_to="2026.04.18",
+    )
+
+    doc = build_manifest(
+        artifacts_dir=artifacts,
+        out=tmp_path / "manifest.json",
+        catalog_version="2026.04.18",
+        release_base_url=BASE_URL,
+        previous_manifest=prev_manifest,
+        min_binary_version="1.0.0",
+        now=NOW,
+    )
+
+    entry = doc["shards"]["aws-ec2"]
+    assert entry["baseline_version"] == "2026.04.18"
+    assert entry["head_version"] == "2026.04.18"
+    assert entry["baseline_url"] == f"{BASE_URL}/aws-ec2.db.zst"
+    assert entry["baseline_sha256"] == _sha(new_baseline)
+    assert entry["deltas"] == []
+    assert entry["row_count"] == 60
+
+
+def test_shard_not_in_today_artifacts_is_carried_forward(tmp_path: Path):
+    prev_manifest = tmp_path / "prev-manifest.json"
+    prev_entry = {
+        "baseline_version": "2026.04.10",
+        "baseline_url": "https://prev/baseline.db.zst",
+        "baseline_sha256": "z" * 64,
+        "baseline_size": 100,
+        "head_version": "2026.04.17",
+        "deltas": [],
+        "row_count": 99,
+        "last_updated": "2026.04.17",
+    }
+    prev_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "shards": {
+                    "aws-ec2": prev_entry,
+                    "azure-vm": {
+                        "baseline_version": "x",
+                        "baseline_url": "u",
+                        "baseline_sha256": "s",
+                        "baseline_size": 1,
+                        "head_version": "x",
+                        "deltas": [],
+                        "row_count": 1,
+                    },
+                },
+            }
+        )
+    )
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    # Only aws-ec2 was touched today.
+    _write(artifacts / "aws-ec2.db.zst", b"new")
+    _sidecar(
+        artifacts / "aws-ec2.meta.json",
+        shard="aws-ec2",
+        row_count=1,
+        has_baseline=True,
+        delta_from=None,
+        delta_to="2026.04.18",
+    )
+
+    doc = build_manifest(
+        artifacts_dir=artifacts,
+        out=tmp_path / "manifest.json",
+        catalog_version="2026.04.18",
+        release_base_url=BASE_URL,
+        previous_manifest=prev_manifest,
+        min_binary_version="1.0.0",
+        now=NOW,
+    )
+
+    # aws-ec2 rebuilt, azure-vm carried forward unchanged.
+    assert list(doc["shards"].keys()) == ["aws-ec2", "azure-vm"]
+    assert doc["shards"]["azure-vm"]["baseline_version"] == "x"
+    assert doc["shards"]["azure-vm"]["baseline_url"] == "u"
+
+
+def test_multi_part_delta_recorded_with_parts(tmp_path: Path):
+    prev_manifest = tmp_path / "prev-manifest.json"
+    prev_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "shards": {
+                    "aws-ec2": {
+                        "baseline_version": "2026.04.10",
+                        "baseline_url": "u",
+                        "baseline_sha256": "a" * 64,
+                        "baseline_size": 1,
+                        "head_version": "2026.04.17",
+                        "deltas": [],
+                        "row_count": 5,
+                        "last_updated": "2026.04.17",
+                    }
+                },
+            }
+        )
+    )
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    p1 = b"aaa"
+    p2 = b"bbbb"
+    _write(artifacts / "aws-ec2-2026.04.17-to-2026.04.18-part1.sql.gz", p1)
+    _write(artifacts / "aws-ec2-2026.04.17-to-2026.04.18-part2.sql.gz", p2)
+    _sidecar(
+        artifacts / "aws-ec2.meta.json",
+        shard="aws-ec2",
+        row_count=7,
+        has_baseline=False,
+        delta_from="2026.04.17",
+        delta_to="2026.04.18",
+    )
+
+    doc = build_manifest(
+        artifacts_dir=artifacts,
+        out=tmp_path / "manifest.json",
+        catalog_version="2026.04.18",
+        release_base_url=BASE_URL,
+        previous_manifest=prev_manifest,
+        min_binary_version="1.0.0",
+        now=NOW,
+    )
+
+    delta = doc["shards"]["aws-ec2"]["deltas"][0]
+    assert delta["from"] == "2026.04.17"
+    assert delta["to"] == "2026.04.18"
+    assert "parts" in delta
+    assert [p["url"] for p in delta["parts"]] == [
+        f"{BASE_URL}/aws-ec2-2026.04.17-to-2026.04.18-part1.sql.gz",
+        f"{BASE_URL}/aws-ec2-2026.04.17-to-2026.04.18-part2.sql.gz",
+    ]
+    assert delta["size"] == len(p1) + len(p2)
+
+
+def test_delta_only_without_previous_manifest_raises(tmp_path: Path):
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    _write(artifacts / "aws-ec2-2026.04.17-to-2026.04.18.sql.gz", b"d")
+    _sidecar(
+        artifacts / "aws-ec2.meta.json",
+        shard="aws-ec2",
+        row_count=1,
+        has_baseline=False,
+        delta_from="2026.04.17",
+        delta_to="2026.04.18",
+    )
+
+    with pytest.raises(ValueError, match="no baseline"):
+        build_manifest(
+            artifacts_dir=artifacts,
+            out=tmp_path / "manifest.json",
+            catalog_version="2026.04.18",
+            release_base_url=BASE_URL,
+            previous_manifest=None,
+            min_binary_version="1.0.0",
+            now=NOW,
+        )

--- a/pipeline/tests/test_discover_driver.py
+++ b/pipeline/tests/test_discover_driver.py
@@ -20,7 +20,7 @@ def _mock_all_providers(m: requests_mock.Mocker, *, aws_pub: str = "2026-04-18T0
 
     for service_code in set(_AWS_SERVICE_CODES.values()):
         m.get(
-            f"{_AWS_OFFER_BASE}/{service_code}/current/index.json",
+            f"{_AWS_OFFER_BASE}/{service_code}/index.json",
             json={"publicationDate": aws_pub},
         )
     m.get(_AZURE_RETAIL_BASE, json={"Items": []})
@@ -183,7 +183,7 @@ def test_one_shard_errors_others_still_succeed(tmp_path: Path) -> None:
         # Set up AWS discover to FAIL (the AWS group all errors as a unit),
         # but openrouter succeeds.
         for service_code in set(_AWS_SERVICE_CODES.values()):
-            m.get(f"{_AWS_OFFER_BASE}/{service_code}/current/index.json", status_code=500)
+            m.get(f"{_AWS_OFFER_BASE}/{service_code}/index.json", status_code=500)
         m.get("https://openrouter.ai/api/v1/models", json={"data": []})
         rc = run(
             state_path=state,
@@ -205,7 +205,7 @@ def test_all_shards_error_exits_2(tmp_path: Path) -> None:
 
     with requests_mock.Mocker() as m:
         for service_code in set(_AWS_SERVICE_CODES.values()):
-            m.get(f"{_AWS_OFFER_BASE}/{service_code}/current/index.json", status_code=500)
+            m.get(f"{_AWS_OFFER_BASE}/{service_code}/index.json", status_code=500)
         rc = run(
             state_path=state,
             out_path=out,

--- a/pipeline/tests/test_discover_driver.py
+++ b/pipeline/tests/test_discover_driver.py
@@ -1,0 +1,273 @@
+"""Tests for discover.driver.run (and __main__ entrypoint smoke)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import requests_mock
+
+from discover.driver import ALL_SHARDS, run
+from ingest.aws_common import _AWS_OFFER_BASE
+from ingest.azure_common import _AZURE_RETAIL_BASE
+from ingest.gcp_common import _GCP_BILLING_BASE, _GCP_SERVICE_IDS
+
+
+def _mock_all_providers(m: requests_mock.Mocker, *, aws_pub: str = "2026-04-18T00:00:00Z") -> None:
+    """Register mocks for every shard so a full ALL_SHARDS discover passes."""
+    from ingest.aws_common import _AWS_SERVICE_CODES
+
+    for service_code in set(_AWS_SERVICE_CODES.values()):
+        m.get(
+            f"{_AWS_OFFER_BASE}/{service_code}/current/index.json",
+            json={"publicationDate": aws_pub},
+        )
+    m.get(_AZURE_RETAIL_BASE, json={"Items": []})
+    for service_id in _GCP_SERVICE_IDS.values():
+        m.get(
+            f"{_GCP_BILLING_BASE}/services/{service_id}",
+            json={"displayName": "svc", "updateTime": "t"},
+        )
+    m.get("https://openrouter.ai/api/v1/models", json={"data": []})
+
+
+def test_dry_run_empty_state_baseline_rebuild_true(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    rc = run(state_path=state, out_path=out, live=False)
+    assert rc == 0
+    doc = json.loads(out.read_text())
+    assert doc["baseline_rebuild"] is True
+    assert doc["shards"] == []
+    assert doc["errors"] == []
+
+
+def test_dry_run_populated_state_baseline_rebuild_false(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    # Pre-populate state.
+    state.write_text(json.dumps({"schema_version": 1, "indicators": {"aws_ec2": "v1"}}))
+    out = tmp_path / "changed.json"
+    rc = run(state_path=state, out_path=out, live=False)
+    assert rc == 0
+    doc = json.loads(out.read_text())
+    assert doc["baseline_rebuild"] is False
+    assert doc["shards"] == []
+
+
+def test_first_live_run_all_shards_appear(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    with requests_mock.Mocker() as m:
+        _mock_all_providers(m)
+        rc = run(
+            state_path=state,
+            out_path=out,
+            live=True,
+            gcp_api_key="test-key",
+        )
+    assert rc == 0
+    doc = json.loads(out.read_text())
+    assert doc["baseline_rebuild"] is True
+    assert set(doc["shards"]) == set(ALL_SHARDS)
+    assert doc["errors"] == []
+    # State was persisted.
+    saved = json.loads(state.read_text())
+    assert set(saved["indicators"].keys()) == set(ALL_SHARDS)
+
+
+def test_second_live_run_unchanged_upstream_empty_shards(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    with requests_mock.Mocker() as m:
+        _mock_all_providers(m)
+        run(state_path=state, out_path=out, live=True, gcp_api_key="k")
+    # Second run with identical upstream → no changes.
+    with requests_mock.Mocker() as m:
+        _mock_all_providers(m)
+        rc = run(state_path=state, out_path=out, live=True, gcp_api_key="k")
+    assert rc == 0
+    doc = json.loads(out.read_text())
+    assert doc["baseline_rebuild"] is False
+    assert doc["shards"] == []
+    assert set(doc["unchanged"]) == set(ALL_SHARDS)
+
+
+def test_one_shard_changed(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    with requests_mock.Mocker() as m:
+        _mock_all_providers(m, aws_pub="2026-04-18T00:00:00Z")
+        run(state_path=state, out_path=out, live=True, gcp_api_key="k")
+    # Second run: AWS publicationDate changes.
+    with requests_mock.Mocker() as m:
+        _mock_all_providers(m, aws_pub="2026-04-19T00:00:00Z")
+        rc = run(state_path=state, out_path=out, live=True, gcp_api_key="k")
+    assert rc == 0
+    doc = json.loads(out.read_text())
+    aws_shards = [s for s in ALL_SHARDS if s.startswith("aws_")]
+    assert set(doc["shards"]) == set(aws_shards)
+
+
+def test_baseline_rebuild_flag_forces_all(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    # Seed a live state so the "!prev_map" branch wouldn't already force all shards.
+    with requests_mock.Mocker() as m:
+        _mock_all_providers(m)
+        run(state_path=state, out_path=out, live=True, gcp_api_key="k")
+    # Now rerun with --baseline-rebuild even though upstream is identical.
+    with requests_mock.Mocker() as m:
+        _mock_all_providers(m)
+        rc = run(state_path=state, out_path=out, live=True, baseline_rebuild=True, gcp_api_key="k")
+    assert rc == 0
+    doc = json.loads(out.read_text())
+    assert doc["baseline_rebuild"] is True
+    assert set(doc["shards"]) == set(ALL_SHARDS)
+
+
+def test_shards_allowlist_restricts_and_validates(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    with requests_mock.Mocker() as m:
+        _mock_all_providers(m)
+        rc = run(
+            state_path=state,
+            out_path=out,
+            live=True,
+            shards=["aws_ec2", "aws_rds"],
+            gcp_api_key="k",
+        )
+    assert rc == 0
+    doc = json.loads(out.read_text())
+    # only those two possible
+    assert set(doc["shards"]) <= {"aws_ec2", "aws_rds"}
+
+
+def test_dashed_shard_alias_accepted(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    with requests_mock.Mocker() as m:
+        _mock_all_providers(m)
+        rc = run(
+            state_path=state,
+            out_path=out,
+            live=True,
+            shards=["aws-ec2"],
+            gcp_api_key="k",
+        )
+    assert rc == 0
+
+
+def test_unknown_shard_exits_4(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    rc = run(
+        state_path=state,
+        out_path=out,
+        live=True,
+        shards=["made_up_shard"],
+        gcp_api_key="k",
+    )
+    assert rc == 4
+    doc = json.loads(out.read_text())
+    assert any(e["reason"] == "unknown_shard" for e in doc["errors"])
+
+
+def test_one_shard_errors_others_still_succeed(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    from ingest.aws_common import _AWS_SERVICE_CODES
+
+    with requests_mock.Mocker() as m:
+        # Set up AWS discover to FAIL (the AWS group all errors as a unit),
+        # but openrouter succeeds.
+        for service_code in set(_AWS_SERVICE_CODES.values()):
+            m.get(f"{_AWS_OFFER_BASE}/{service_code}/current/index.json", status_code=500)
+        m.get("https://openrouter.ai/api/v1/models", json={"data": []})
+        rc = run(
+            state_path=state,
+            out_path=out,
+            live=True,
+            shards=["aws_ec2", "openrouter"],
+            gcp_api_key="k",
+        )
+    assert rc == 0
+    doc = json.loads(out.read_text())
+    assert any(e["shard"] == "aws_ec2" for e in doc["errors"])
+    assert "openrouter" in doc["shards"] or "openrouter" in doc["unchanged"]
+
+
+def test_all_shards_error_exits_2(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    from ingest.aws_common import _AWS_SERVICE_CODES
+
+    with requests_mock.Mocker() as m:
+        for service_code in set(_AWS_SERVICE_CODES.values()):
+            m.get(f"{_AWS_OFFER_BASE}/{service_code}/current/index.json", status_code=500)
+        rc = run(
+            state_path=state,
+            out_path=out,
+            live=True,
+            shards=["aws_ec2", "aws_rds"],
+            gcp_api_key="k",
+        )
+    assert rc == 2
+    doc = json.loads(out.read_text())
+    assert len(doc["errors"]) >= 2
+    assert doc["shards"] == []
+
+
+def test_main_entrypoint_smoke(tmp_path: Path) -> None:
+    """python -m discover parses args and returns exit code."""
+    from discover.__main__ import main
+
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    rc = main(["--state", str(state), "--out", str(out)])
+    assert rc == 0
+    assert out.exists()
+    doc = json.loads(out.read_text())
+    assert doc["baseline_rebuild"] is True
+
+
+def test_main_entrypoint_invalid_shard(tmp_path: Path) -> None:
+    from discover.__main__ import main
+
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    rc = main(["--state", str(state), "--out", str(out), "--shards", "bogus"])
+    assert rc == 4
+
+
+def test_dry_run_output_is_indented_and_sorted(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    run(state_path=state, out_path=out, live=False)
+    raw = out.read_text()
+    assert "\n" in raw and "  " in raw  # indented
+    doc = json.loads(raw)
+    assert list(doc.keys()) == sorted(doc.keys())
+
+
+def test_gcp_live_without_api_key_records_error(tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    out = tmp_path / "changed.json"
+    with requests_mock.Mocker() as m:
+        _mock_all_providers(m)
+        rc = run(
+            state_path=state,
+            out_path=out,
+            live=True,
+            shards=["gcp_gce"],
+            gcp_api_key=None,
+        )
+    # Single-shard all-errored → exit 2.
+    assert rc == 2
+    doc = json.loads(out.read_text())
+    assert any(e["reason"] == "gcp_missing_api_key" for e in doc["errors"])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/pipeline/tests/test_discover_providers.py
+++ b/pipeline/tests/test_discover_providers.py
@@ -1,0 +1,228 @@
+"""Unit tests for pipeline.discover.{aws,azure,gcp,openrouter}."""
+
+from __future__ import annotations
+
+import pytest
+import requests_mock
+
+from discover import aws as aws_disc
+from discover import azure as azure_disc
+from discover import gcp as gcp_disc
+from discover import openrouter as or_disc
+from ingest.aws_common import _AWS_OFFER_BASE
+from ingest.azure_common import _AZURE_RETAIL_BASE
+from ingest.gcp_common import _GCP_BILLING_BASE, _GCP_SERVICE_IDS
+
+# -----------------------------------------------------------------------------
+# AWS discover
+# -----------------------------------------------------------------------------
+
+
+def test_aws_discover_returns_publicationDate():
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json",
+            json={"publicationDate": "2026-04-18T00:00:00Z"},
+        )
+        m.get(
+            f"{_AWS_OFFER_BASE}/AmazonRDS/current/index.json",
+            json={"publicationDate": "2026-04-17T00:00:00Z"},
+        )
+        result = aws_disc.discover(["aws_ec2", "aws_rds"])
+    assert result == {
+        "aws_ec2": "2026-04-18T00:00:00Z",
+        "aws_rds": "2026-04-17T00:00:00Z",
+    }
+
+
+def test_aws_discover_ebs_maps_to_ec2_endpoint():
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json",
+            json={"publicationDate": "2026-04-18T00:00:00Z"},
+        )
+        result = aws_disc.discover(["aws_ebs"])
+    assert result == {"aws_ebs": "2026-04-18T00:00:00Z"}
+
+
+def test_aws_discover_http_failure_raises_runtimeerror():
+    with requests_mock.Mocker() as m:
+        m.get(f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json", status_code=500)
+        with pytest.raises(RuntimeError, match="aws_discover_http_500"):
+            aws_disc.discover(["aws_ec2"])
+
+
+def test_aws_discover_indicator_changes_when_upstream_changes():
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json",
+            json={"publicationDate": "2026-04-18T00:00:00Z"},
+        )
+        a = aws_disc.discover(["aws_ec2"])
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json",
+            json={"publicationDate": "2026-04-19T00:00:00Z"},
+        )
+        b = aws_disc.discover(["aws_ec2"])
+    assert a["aws_ec2"] != b["aws_ec2"]
+
+
+def test_aws_discover_unknown_shard_raises_keyerror():
+    with pytest.raises(KeyError):
+        aws_disc.discover(["aws_nope"])
+
+
+# -----------------------------------------------------------------------------
+# Azure discover
+# -----------------------------------------------------------------------------
+
+
+def test_azure_discover_hashes_top_one_page():
+    with requests_mock.Mocker() as m:
+        m.get(_AZURE_RETAIL_BASE, json={"Items": [{"skuId": "abc", "retailPrice": 0.1}]})
+        result = azure_disc.discover(["azure_vm"])
+    assert set(result) == {"azure_vm"}
+    assert len(result["azure_vm"]) == 64  # sha256 hex length
+
+
+def test_azure_discover_indicator_changes_when_upstream_changes():
+    with requests_mock.Mocker() as m:
+        m.get(_AZURE_RETAIL_BASE, json={"Items": [{"skuId": "a"}]})
+        a = azure_disc.discover(["azure_vm"])
+    with requests_mock.Mocker() as m:
+        m.get(_AZURE_RETAIL_BASE, json={"Items": [{"skuId": "b"}]})
+        b = azure_disc.discover(["azure_vm"])
+    assert a["azure_vm"] != b["azure_vm"]
+
+
+def test_azure_discover_http_failure_raises():
+    with requests_mock.Mocker() as m:
+        m.get(_AZURE_RETAIL_BASE, status_code=503)
+        with pytest.raises(RuntimeError, match="azure_discover_http_503"):
+            azure_disc.discover(["azure_vm"])
+
+
+def test_azure_discover_unknown_shard_raises_keyerror():
+    with pytest.raises(KeyError):
+        azure_disc.discover(["azure_nope"])
+
+
+def test_azure_discover_uses_top_one_param():
+    with requests_mock.Mocker() as m:
+        m.get(_AZURE_RETAIL_BASE, json={"Items": []})
+        azure_disc.discover(["azure_vm"])
+        qs = m.request_history[0].qs
+    assert qs.get("$top") == ["1"]
+
+
+# -----------------------------------------------------------------------------
+# GCP discover
+# -----------------------------------------------------------------------------
+
+
+def test_gcp_discover_uses_parent_service_updateTime():
+    service_id = _GCP_SERVICE_IDS["gcp_gce"]
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{_GCP_BILLING_BASE}/services/{service_id}",
+            json={"displayName": "Compute Engine", "updateTime": "2026-04-18T00:00:00Z"},
+        )
+        result = gcp_disc.discover(["gcp_gce"], api_key="test-key")
+    assert result == {"gcp_gce": "Compute Engine|2026-04-18T00:00:00Z"}
+
+
+def test_gcp_discover_api_key_in_query():
+    service_id = _GCP_SERVICE_IDS["gcp_gce"]
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{_GCP_BILLING_BASE}/services/{service_id}",
+            json={"displayName": "GCE", "updateTime": "t"},
+        )
+        gcp_disc.discover(["gcp_gce"], api_key="secret-key")
+        qs = m.request_history[0].qs
+    assert qs.get("key") == ["secret-key"]
+
+
+def test_gcp_discover_falls_back_to_sku_hash_when_no_updateTime():
+    service_id = _GCP_SERVICE_IDS["gcp_gce"]
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{_GCP_BILLING_BASE}/services/{service_id}",
+            json={"displayName": "GCE"},  # no updateTime
+        )
+        m.get(
+            f"{_GCP_BILLING_BASE}/services/{service_id}/skus",
+            json={"skus": [{"skuId": "one"}]},
+        )
+        result = gcp_disc.discover(["gcp_gce"], api_key="k")
+    assert result["gcp_gce"].startswith("sha256:")
+    assert len(result["gcp_gce"]) == len("sha256:") + 64
+
+
+def test_gcp_discover_http_failure_raises():
+    service_id = _GCP_SERVICE_IDS["gcp_gce"]
+    with requests_mock.Mocker() as m:
+        m.get(f"{_GCP_BILLING_BASE}/services/{service_id}", status_code=403)
+        with pytest.raises(RuntimeError, match="gcp_discover_http_403"):
+            gcp_disc.discover(["gcp_gce"], api_key="k")
+
+
+def test_gcp_discover_unknown_shard_raises_keyerror():
+    with pytest.raises(KeyError):
+        gcp_disc.discover(["gcp_nope"], api_key="k")
+
+
+# -----------------------------------------------------------------------------
+# OpenRouter discover
+# -----------------------------------------------------------------------------
+
+
+def test_openrouter_discover_hashes_sorted_model_ids():
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://openrouter.ai/api/v1/models",
+            json={"data": [{"id": "b/two"}, {"id": "a/one"}, {"id": "c/three"}]},
+        )
+        result = or_disc.discover(["openrouter"])
+    assert set(result) == {"openrouter"}
+    assert len(result["openrouter"]) == 64
+
+
+def test_openrouter_discover_stable_and_order_independent():
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://openrouter.ai/api/v1/models",
+            json={"data": [{"id": "a"}, {"id": "b"}]},
+        )
+        a = or_disc.discover(["openrouter"])
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://openrouter.ai/api/v1/models",
+            json={"data": [{"id": "b"}, {"id": "a"}]},
+        )
+        b = or_disc.discover(["openrouter"])
+    assert a == b
+
+
+def test_openrouter_discover_indicator_changes_when_models_change():
+    with requests_mock.Mocker() as m:
+        m.get("https://openrouter.ai/api/v1/models", json={"data": [{"id": "a"}]})
+        a = or_disc.discover(["openrouter"])
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://openrouter.ai/api/v1/models",
+            json={"data": [{"id": "a"}, {"id": "b"}]},
+        )
+        b = or_disc.discover(["openrouter"])
+    assert a["openrouter"] != b["openrouter"]
+
+
+def test_openrouter_discover_unknown_shard_raises_keyerror():
+    with pytest.raises(KeyError):
+        or_disc.discover(["not-openrouter"])
+
+
+def test_openrouter_discover_empty_shards_returns_empty():
+    result = or_disc.discover([])
+    assert result == {}

--- a/pipeline/tests/test_discover_providers.py
+++ b/pipeline/tests/test_discover_providers.py
@@ -21,11 +21,11 @@ from ingest.gcp_common import _GCP_BILLING_BASE, _GCP_SERVICE_IDS
 def test_aws_discover_returns_publicationDate():
     with requests_mock.Mocker() as m:
         m.get(
-            f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json",
+            f"{_AWS_OFFER_BASE}/AmazonEC2/index.json",
             json={"publicationDate": "2026-04-18T00:00:00Z"},
         )
         m.get(
-            f"{_AWS_OFFER_BASE}/AmazonRDS/current/index.json",
+            f"{_AWS_OFFER_BASE}/AmazonRDS/index.json",
             json={"publicationDate": "2026-04-17T00:00:00Z"},
         )
         result = aws_disc.discover(["aws_ec2", "aws_rds"])
@@ -38,7 +38,7 @@ def test_aws_discover_returns_publicationDate():
 def test_aws_discover_ebs_maps_to_ec2_endpoint():
     with requests_mock.Mocker() as m:
         m.get(
-            f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json",
+            f"{_AWS_OFFER_BASE}/AmazonEC2/index.json",
             json={"publicationDate": "2026-04-18T00:00:00Z"},
         )
         result = aws_disc.discover(["aws_ebs"])
@@ -47,7 +47,7 @@ def test_aws_discover_ebs_maps_to_ec2_endpoint():
 
 def test_aws_discover_http_failure_raises_runtimeerror():
     with requests_mock.Mocker() as m:
-        m.get(f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json", status_code=500)
+        m.get(f"{_AWS_OFFER_BASE}/AmazonEC2/index.json", status_code=500)
         with pytest.raises(RuntimeError, match="aws_discover_http_500"):
             aws_disc.discover(["aws_ec2"])
 
@@ -55,13 +55,13 @@ def test_aws_discover_http_failure_raises_runtimeerror():
 def test_aws_discover_indicator_changes_when_upstream_changes():
     with requests_mock.Mocker() as m:
         m.get(
-            f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json",
+            f"{_AWS_OFFER_BASE}/AmazonEC2/index.json",
             json={"publicationDate": "2026-04-18T00:00:00Z"},
         )
         a = aws_disc.discover(["aws_ec2"])
     with requests_mock.Mocker() as m:
         m.get(
-            f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json",
+            f"{_AWS_OFFER_BASE}/AmazonEC2/index.json",
             json={"publicationDate": "2026-04-19T00:00:00Z"},
         )
         b = aws_disc.discover(["aws_ec2"])

--- a/pipeline/tests/test_discover_state.py
+++ b/pipeline/tests/test_discover_state.py
@@ -1,0 +1,71 @@
+"""Tests for pipeline.discover.state."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from discover import state as state_mod
+from discover.state import State, load, save
+
+
+def test_missing_file_returns_empty_state(tmp_path: Path) -> None:
+    s = load(tmp_path / "state.json")
+    assert s.schema_version == state_mod._STATE_SCHEMA_VERSION
+    assert dict(s.indicators) == {}
+
+
+def test_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    original = State(schema_version=1, indicators={"aws-ec2": "abc", "gcp-gce": "xyz"})
+    save(path, original)
+    assert path.exists()
+    loaded = load(path)
+    assert loaded.schema_version == original.schema_version
+    assert dict(loaded.indicators) == dict(original.indicators)
+
+
+def test_save_produces_sorted_indented_json(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    save(path, State(schema_version=1, indicators={"z": "1", "a": "2", "m": "3"}))
+    raw = path.read_text()
+    doc = json.loads(raw)
+    assert list(doc["indicators"].keys()) == ["a", "m", "z"]
+    assert "\n" in raw and "  " in raw  # indented
+
+
+def test_schema_version_mismatch_raises(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps({"schema_version": 99, "indicators": {}}))
+    with pytest.raises(RuntimeError, match="state_schema_version_mismatch"):
+        load(path)
+
+
+def test_missing_schema_version_raises(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps({"indicators": {}}))
+    with pytest.raises(RuntimeError, match="state_schema_version_mismatch"):
+        load(path)
+
+
+def test_atomic_write_no_partial_on_crash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "state.json"
+    save(path, State(schema_version=1, indicators={"original": "ok"}))
+    original_body = path.read_text()
+
+    def boom(src, dst):
+        raise RuntimeError("crash_mid_write")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(RuntimeError, match="crash_mid_write"):
+        save(path, State(schema_version=1, indicators={"new": "changed"}))
+
+    # Original file unchanged.
+    assert path.read_text() == original_body
+    # A .part may be left behind since os.replace never ran, but it must not
+    # have clobbered the original file — that's the atomic-write invariant.
+    part = path.with_suffix(path.suffix + ".part")
+    assert not (part.exists() and part.stat().st_size == 0)

--- a/pipeline/tests/test_gcp_cloud_sql_ingest.py
+++ b/pipeline/tests/test_gcp_cloud_sql_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.gcp_cloud_sql import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "gcp_cloud_sql" / "skus.json"

--- a/pipeline/tests/test_gcp_fetch.py
+++ b/pipeline/tests/test_gcp_fetch.py
@@ -1,0 +1,151 @@
+"""Tests for fetch_skus() in ingest.gcp_common.
+
+Uses requests_mock to simulate GCP Cloud Billing Catalog API responses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from ingest.gcp_common import fetch_skus
+
+_GCE_SERVICE_ID = "6F81-5844-456A"
+_GCE_BASE_URL = f"https://cloudbilling.googleapis.com/v1/services/{_GCE_SERVICE_ID}/skus"
+_API_KEY = "test-api-key-abc123"
+
+_SKU_A = {"skuId": "AAA-111", "description": "sku-a"}
+_SKU_B = {"skuId": "BBB-222", "description": "sku-b"}
+_SKU_C = {"skuId": "CCC-333", "description": "sku-c"}
+
+
+def _build_sorted_skus(items: list[dict]) -> list[dict]:
+    return sorted(items, key=lambda x: x.get("skuId", ""))
+
+
+def _compute_hash(sorted_skus: list[dict]) -> str:
+    serialized = json.dumps(sorted_skus, separators=(",", ":"), sort_keys=True).encode()
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def test_three_page_pagination(requests_mock, tmp_path):
+    """Three pages via nextPageToken — all 3 skus written, sorted by skuId."""
+    requests_mock.get(
+        _GCE_BASE_URL,
+        [
+            {"json": {"skus": [_SKU_B], "nextPageToken": "tok1"}},
+            {"json": {"skus": [_SKU_A], "nextPageToken": "tok2"}},
+            {"json": {"skus": [_SKU_C]}},
+        ],
+    )
+    target = tmp_path / "gcp_gce_raw.json"
+    fetch_skus("gcp_gce", target, api_key=_API_KEY)
+
+    assert target.exists()
+    data = json.loads(target.read_text())
+    assert list(data.keys()) == ["skus"]
+    assert data["skus"] == _build_sorted_skus([_SKU_B, _SKU_A, _SKU_C])
+    assert requests_mock.call_count == 3
+
+
+def test_api_key_in_every_querystring(requests_mock, tmp_path):
+    """Every request (including paginated ones) carries key=<api_key>."""
+    requests_mock.get(
+        _GCE_BASE_URL,
+        [
+            {"json": {"skus": [_SKU_A], "nextPageToken": "tok1"}},
+            {"json": {"skus": [_SKU_B]}},
+        ],
+    )
+    target = tmp_path / "out.json"
+    fetch_skus("gcp_gce", target, api_key=_API_KEY)
+
+    assert requests_mock.call_count == 2
+    for req in requests_mock.request_history:
+        qs = parse_qs(urlparse(req.url).query)
+        assert "key" in qs, f"'key' missing from querystring: {req.url}"
+        assert qs["key"] == [_API_KEY], f"wrong api_key in {req.url}"
+
+
+def test_gcp_gce_service_id_in_url(requests_mock, tmp_path):
+    """`fetch_skus('gcp_gce', ...)` hits a URL containing the correct service id."""
+    requests_mock.get(_GCE_BASE_URL, json={"skus": [_SKU_A]})
+    target = tmp_path / "out.json"
+    fetch_skus("gcp_gce", target, api_key=_API_KEY)
+
+    assert requests_mock.call_count == 1
+    assert f"/services/{_GCE_SERVICE_ID}/skus" in requests_mock.request_history[0].url
+
+
+def test_403_raises_gcp_forbidden_no_retry(requests_mock, tmp_path):
+    """403 response raises RuntimeError('gcp_forbidden') immediately, no retries."""
+    requests_mock.get(_GCE_BASE_URL, status_code=403)
+    target = tmp_path / "out.json"
+
+    with pytest.raises(RuntimeError) as exc_info:
+        fetch_skus("gcp_gce", target, api_key=_API_KEY)
+
+    err_msg = str(exc_info.value)
+    assert "gcp_forbidden" in err_msg
+    assert _GCE_SERVICE_ID in err_msg
+    assert requests_mock.call_count == 1
+
+
+def test_500_then_200_succeeds_with_retry(requests_mock, tmp_path):
+    """A single 500 on the first page is retried and succeeds on the second attempt."""
+    requests_mock.get(
+        _GCE_BASE_URL,
+        [
+            {"status_code": 500},
+            {"json": {"skus": [_SKU_A]}},
+        ],
+    )
+    target = tmp_path / "out.json"
+    fetch_skus("gcp_gce", target, api_key=_API_KEY, retries=3)
+
+    assert target.exists()
+    data = json.loads(target.read_text())
+    assert data["skus"] == [_SKU_A]
+    # 1 failed attempt + 1 successful attempt = 2 calls
+    assert requests_mock.call_count == 2
+
+
+def test_hash_stability(requests_mock, tmp_path):
+    """Running twice with identical mock data returns the identical digest."""
+    requests_mock.get(_GCE_BASE_URL, json={"skus": [_SKU_B, _SKU_A]})
+    target1 = tmp_path / "out1.json"
+    target2 = tmp_path / "out2.json"
+
+    digest1 = fetch_skus("gcp_gce", target1, api_key=_API_KEY)
+    digest2 = fetch_skus("gcp_gce", target2, api_key=_API_KEY)
+
+    assert digest1 == digest2
+    assert len(digest1) == 64  # SHA256 hex
+
+
+def test_unknown_shard_raises_key_error(tmp_path):
+    """Unknown shard propagates KeyError from the dict lookup (no request made)."""
+    target = tmp_path / "out.json"
+    with pytest.raises(KeyError):
+        fetch_skus("gcp_unknown", target, api_key=_API_KEY)
+
+
+def test_user_agent_on_every_request(requests_mock, tmp_path):
+    """User-Agent header matching sku-pipeline/... is present on every request."""
+    requests_mock.get(
+        _GCE_BASE_URL,
+        [
+            {"json": {"skus": [_SKU_A], "nextPageToken": "tok1"}},
+            {"json": {"skus": [_SKU_B]}},
+        ],
+    )
+    target = tmp_path / "out.json"
+    fetch_skus("gcp_gce", target, api_key=_API_KEY)
+
+    assert requests_mock.call_count == 2
+    for req in requests_mock.request_history:
+        ua = req.headers.get("User-Agent", "")
+        assert ua.startswith("sku-pipeline/"), f"unexpected User-Agent: {ua!r}"

--- a/pipeline/tests/test_gcp_functions_ingest.py
+++ b/pipeline/tests/test_gcp_functions_ingest.py
@@ -57,7 +57,7 @@ def test_architecture_attr():
         assert row["resource_name"] == "x86_64"
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:
         if sku["category"]["resourceGroup"] == "CloudFunctionsV2" and sku["category"]["usageType"] == "OnDemand":
@@ -65,5 +65,5 @@ def test_unknown_region_rejected(tmp_path):
                 sku["serviceRegions"] = ["mars-1"]
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="gcp/mars-1"):
-        list(ingest(skus_path=p))
+    rows = list(ingest(skus_path=p))
+    assert all(r["region"] != "mars-1" for r in rows)

--- a/pipeline/tests/test_gcp_functions_ingest.py
+++ b/pipeline/tests/test_gcp_functions_ingest.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.gcp_functions import ingest
-
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "gcp_functions" / "skus.json"
 GOLDEN = Path(__file__).resolve().parent.parent / "testdata" / "golden" / "gcp_functions_rows.jsonl"
@@ -60,9 +57,14 @@ def test_architecture_attr():
 def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:
-        if sku["category"]["resourceGroup"] == "CloudFunctionsV2" and sku["category"]["usageType"] == "OnDemand":
-            if sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]["unitPrice"]["currencyCode"] == "USD":
-                sku["serviceRegions"] = ["mars-1"]
+        cat = sku["category"]
+        rate = sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]
+        if (
+            cat["resourceGroup"] == "CloudFunctionsV2"
+            and cat["usageType"] == "OnDemand"
+            and rate["unitPrice"]["currencyCode"] == "USD"
+        ):
+            sku["serviceRegions"] = ["mars-1"]
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
     rows = list(ingest(skus_path=p))

--- a/pipeline/tests/test_gcp_gce_ingest.py
+++ b/pipeline/tests/test_gcp_gce_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.gcp_gce import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "gcp_gce" / "skus.json"
@@ -52,9 +50,11 @@ def test_unknown_region_skipped(tmp_path):
     """A SKU in a region outside regions.yaml is silently dropped."""
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:
-        if sku["category"]["usageType"] == "OnDemand" and sku["pricingInfo"][0]["pricingExpression"][
-            "tieredRates"
-        ][0]["unitPrice"]["currencyCode"] == "USD":
+        rate = sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]
+        if (
+            sku["category"]["usageType"] == "OnDemand"
+            and rate["unitPrice"]["currencyCode"] == "USD"
+        ):
             sku["serviceRegions"] = ["us-central1"]
             break
     p = tmp_path / "bad.json"

--- a/pipeline/tests/test_gcp_gce_ingest.py
+++ b/pipeline/tests/test_gcp_gce_ingest.py
@@ -48,8 +48,8 @@ def test_non_usd_filtered():
     assert "SKU-N1S2-EUW1-EUR" not in out_ids
 
 
-def test_unknown_region_rejected(tmp_path):
-    """A SKU in a region not in regions.yaml must fail the ingest."""
+def test_unknown_region_skipped(tmp_path):
+    """A SKU in a region outside regions.yaml is silently dropped."""
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:
         if sku["category"]["usageType"] == "OnDemand" and sku["pricingInfo"][0]["pricingExpression"][
@@ -59,5 +59,5 @@ def test_unknown_region_rejected(tmp_path):
             break
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="gcp/us-central1"):
-        list(ingest(skus_path=p))
+    rows = list(ingest(skus_path=p))
+    assert all(r["region"] != "us-central1" for r in rows)

--- a/pipeline/tests/test_gcp_gcs_ingest.py
+++ b/pipeline/tests/test_gcp_gcs_ingest.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.gcp_gcs import ingest
-
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "gcp_gcs" / "skus.json"
 GOLDEN = Path(__file__).resolve().parent.parent / "testdata" / "golden" / "gcp_gcs_rows.jsonl"
@@ -61,9 +58,14 @@ def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     # Point the standard-storage / read-ops / write-ops meters at an unknown region.
     for sku in bad["skus"]:
-        if sku["category"]["resourceGroup"] == "StandardStorage" and sku["category"]["usageType"] == "OnDemand":
-            if sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]["unitPrice"]["currencyCode"] == "USD":
-                sku["serviceRegions"] = ["mars-1"]
+        cat = sku["category"]
+        rate = sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]
+        if (
+            cat["resourceGroup"] == "StandardStorage"
+            and cat["usageType"] == "OnDemand"
+            and rate["unitPrice"]["currencyCode"] == "USD"
+        ):
+            sku["serviceRegions"] = ["mars-1"]
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
     rows = list(ingest(skus_path=p))

--- a/pipeline/tests/test_gcp_gcs_ingest.py
+++ b/pipeline/tests/test_gcp_gcs_ingest.py
@@ -57,7 +57,7 @@ def test_three_dimensions_per_row():
         assert sorted(p["dimension"] for p in row["prices"]) == expected
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     # Point the standard-storage / read-ops / write-ops meters at an unknown region.
     for sku in bad["skus"]:
@@ -66,5 +66,5 @@ def test_unknown_region_rejected(tmp_path):
                 sku["serviceRegions"] = ["mars-1"]
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="gcp/mars-1"):
-        list(ingest(skus_path=p))
+    rows = list(ingest(skus_path=p))
+    assert all(r["region"] != "mars-1" for r in rows)

--- a/pipeline/tests/test_gcp_run_ingest.py
+++ b/pipeline/tests/test_gcp_run_ingest.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.gcp_run import ingest
-
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "gcp_run" / "skus.json"
 GOLDEN = Path(__file__).resolve().parent.parent / "testdata" / "golden" / "gcp_run_rows.jsonl"
@@ -60,9 +57,14 @@ def test_architecture_attr():
 def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:
-        if sku["category"]["resourceGroup"] == "CloudRunV2" and sku["category"]["usageType"] == "OnDemand":
-            if sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]["unitPrice"]["currencyCode"] == "USD":
-                sku["serviceRegions"] = ["mars-1"]
+        cat = sku["category"]
+        rate = sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]
+        if (
+            cat["resourceGroup"] == "CloudRunV2"
+            and cat["usageType"] == "OnDemand"
+            and rate["unitPrice"]["currencyCode"] == "USD"
+        ):
+            sku["serviceRegions"] = ["mars-1"]
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
     rows = list(ingest(skus_path=p))

--- a/pipeline/tests/test_gcp_run_ingest.py
+++ b/pipeline/tests/test_gcp_run_ingest.py
@@ -57,7 +57,7 @@ def test_architecture_attr():
         assert row["resource_name"] == "x86_64"
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:
         if sku["category"]["resourceGroup"] == "CloudRunV2" and sku["category"]["usageType"] == "OnDemand":
@@ -65,5 +65,5 @@ def test_unknown_region_rejected(tmp_path):
                 sku["serviceRegions"] = ["mars-1"]
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="gcp/mars-1"):
-        list(ingest(skus_path=p))
+    rows = list(ingest(skus_path=p))
+    assert all(r["region"] != "mars-1" for r in rows)

--- a/pipeline/tests/test_openrouter_fetch.py
+++ b/pipeline/tests/test_openrouter_fetch.py
@@ -1,0 +1,173 @@
+"""Tests for pipeline/ingest/openrouter.py::fetch().
+
+Uses requests_mock to intercept calls made by LiveClient underneath fetch().
+"""
+
+from __future__ import annotations
+
+import json
+
+import requests_mock as req_mock_module
+
+from ingest.http import FixtureClient, LiveClient
+from ingest.openrouter import fetch
+
+BASE = LiveClient.BASE
+
+MODELS_PAYLOAD = {
+    "data": [
+        {"id": "a/x"},
+        {"id": "b/y"},
+        {"id": "c/z"},
+    ]
+}
+
+ENDPOINT_PAYLOADS = {
+    "a/x": {"data": {"id": "a/x", "endpoints": []}},
+    "b/y": {"data": {"id": "b/y", "endpoints": []}},
+    "c/z": {"data": {"id": "c/z", "endpoints": []}},
+}
+
+
+def _register_mocks(m: req_mock_module.Mocker, models: dict, endpoints: dict) -> None:
+    m.get(f"{BASE}/api/v1/models", json=models)
+    for model_id, ep_payload in endpoints.items():
+        m.get(f"{BASE}/api/v1/models/{model_id}/endpoints", json=ep_payload)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Happy path round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_round_trip(tmp_path):
+    with req_mock_module.Mocker() as m:
+        _register_mocks(m, MODELS_PAYLOAD, ENDPOINT_PAYLOADS)
+        fetch(tmp_path)
+
+    models_file = tmp_path / "models.json"
+    assert models_file.exists(), "models.json must be written"
+
+    loaded = json.loads(models_file.read_text())
+    assert loaded == MODELS_PAYLOAD, "models.json content must match mocked payload"
+
+    endpoints_dir = tmp_path / "endpoints"
+    assert (endpoints_dir / "a__x.json").exists()
+    assert (endpoints_dir / "b__y.json").exists()
+    assert (endpoints_dir / "c__z.json").exists()
+
+    actual_files = {p.name for p in endpoints_dir.iterdir()}
+    assert actual_files == {"a__x.json", "b__y.json", "c__z.json"}, (
+        "No extra files should exist in endpoints/"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Endpoint file naming uses __ not /
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_file_naming(tmp_path):
+    with req_mock_module.Mocker() as m:
+        _register_mocks(m, MODELS_PAYLOAD, ENDPOINT_PAYLOADS)
+        fetch(tmp_path)
+
+    endpoints_dir = tmp_path / "endpoints"
+    for name in endpoints_dir.iterdir():
+        assert "/" not in name.stem, f"File name must not contain '/': {name.name}"
+        assert "__" in name.stem, f"File name must use '__' separator: {name.name}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Hash stability — two calls with identical mocks yield same digest
+# ---------------------------------------------------------------------------
+
+
+def test_hash_stability(tmp_path):
+    dir_a = tmp_path / "run_a"
+    dir_b = tmp_path / "run_b"
+
+    with req_mock_module.Mocker() as m:
+        _register_mocks(m, MODELS_PAYLOAD, ENDPOINT_PAYLOADS)
+        digest_a = fetch(dir_a)
+
+    with req_mock_module.Mocker() as m:
+        _register_mocks(m, MODELS_PAYLOAD, ENDPOINT_PAYLOADS)
+        digest_b = fetch(dir_b)
+
+    assert digest_a == digest_b, "Identical model sets must produce identical digests"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Hash changes when model set changes
+# ---------------------------------------------------------------------------
+
+
+def test_hash_changes_on_different_model_set(tmp_path):
+    models_v2 = {"data": [{"id": "a/x"}, {"id": "b/y"}]}
+    endpoints_v2 = {
+        "a/x": {"data": {"id": "a/x", "endpoints": []}},
+        "b/y": {"data": {"id": "b/y", "endpoints": []}},
+    }
+
+    dir_a = tmp_path / "v1"
+    dir_b = tmp_path / "v2"
+
+    with req_mock_module.Mocker() as m:
+        _register_mocks(m, MODELS_PAYLOAD, ENDPOINT_PAYLOADS)
+        digest_v1 = fetch(dir_a)
+
+    with req_mock_module.Mocker() as m:
+        _register_mocks(m, models_v2, endpoints_v2)
+        digest_v2 = fetch(dir_b)
+
+    assert digest_v1 != digest_v2, "Different model sets must produce different digests"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: FixtureClient compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_client_compatibility(tmp_path):
+    with req_mock_module.Mocker() as m:
+        _register_mocks(m, MODELS_PAYLOAD, ENDPOINT_PAYLOADS)
+        fetch(tmp_path)
+
+    client = FixtureClient(tmp_path)
+
+    models_result = client.get("/api/v1/models")
+    assert models_result == MODELS_PAYLOAD, (
+        "FixtureClient.get('/api/v1/models') must return the mocked payload"
+    )
+
+    ep_result = client.get("/api/v1/models/a/x/endpoints")
+    assert ep_result == ENDPOINT_PAYLOADS["a/x"], (
+        "FixtureClient.get('/api/v1/models/a/x/endpoints') must return the mocked endpoint"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Empty models list
+# ---------------------------------------------------------------------------
+
+
+def test_empty_models(tmp_path):
+    empty_models = {"data": []}
+
+    with req_mock_module.Mocker() as m:
+        m.get(f"{BASE}/api/v1/models", json=empty_models)
+        digest = fetch(tmp_path)
+
+    assert (tmp_path / "models.json").exists(), "models.json must be written even for empty list"
+
+    endpoints_dir = tmp_path / "endpoints"
+    if endpoints_dir.exists():
+        items = list(endpoints_dir.iterdir())
+        assert items == [], "endpoints/ must be empty for empty model list"
+
+    # Hash of empty sorted list
+    import hashlib
+
+    expected_digest = hashlib.sha256(json.dumps([]).encode()).hexdigest()
+    assert digest == expected_digest, "Digest must be hash of empty JSON array"

--- a/pipeline/tests/test_openrouter_ingest.py
+++ b/pipeline/tests/test_openrouter_ingest.py
@@ -68,7 +68,6 @@ def test_ingest_rejects_non_usd_endpoint():
 
 
 def test_synthetic_aggregated_row_present():
-    monkeypatch = None  # not needed for this test
     client = FixtureClient(FIX)
     models = client.get("/api/v1/models")
     models["data"] = [m for m in models["data"] if m["id"] == "openai/gpt-5"]
@@ -89,13 +88,25 @@ def test_synthetic_aggregated_row_present():
     assert agg[0]["health"] is None
 
 
-def _dup_model(top_pricing: dict[str, str], ep_pricings: list[dict[str, str]], uptimes: list[float]) -> dict:
+def _dup_model(
+    top_pricing: dict[str, str],
+    ep_pricings: list[dict[str, str]],
+    uptimes: list[float],
+) -> dict:
     model = {
         "id": "dup/model",
         "name": "Dup Model",
-        "architecture": {"modality": "text", "input_modalities": ["text"], "output_modalities": ["text"]},
+        "architecture": {
+            "modality": "text",
+            "input_modalities": ["text"],
+            "output_modalities": ["text"],
+        },
         "pricing": top_pricing,
-        "top_provider": {"context_length": 1000, "max_completion_tokens": 100, "is_moderated": False},
+        "top_provider": {
+            "context_length": 1000,
+            "max_completion_tokens": 100,
+            "is_moderated": False,
+        },
         "supported_parameters": [],
     }
     endpoints = []

--- a/pipeline/tests/test_sanity_check.py
+++ b/pipeline/tests/test_sanity_check.py
@@ -1,0 +1,133 @@
+"""Unit tests for pipeline.package.sanity_check."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from package.build_shard import build_shard
+from package.sanity_check import SanityError, sanity_check
+
+
+def _row(sku_id: str, amount: float = 0.001) -> dict:
+    return {
+        "sku_id": sku_id,
+        "provider": "anthropic",
+        "service": "llm",
+        "kind": "llm.text",
+        "resource_name": sku_id.split("::")[0],
+        "region": "",
+        "region_normalized": "",
+        "terms": {"commitment": "on_demand", "tenancy": "", "os": ""},
+        "terms_hash": "h",
+        "resource_attrs": {"context_length": 100_000},
+        "prices": [{"dimension": "prompt", "tier": "", "amount": amount, "unit": "token"}],
+    }
+
+
+def _make_shard(
+    tmp_path: Path,
+    name: str,
+    rows: list[dict],
+    *,
+    version: str = "2026.04.18",
+    generated_at: str = "2026-04-18T00:00:00Z",
+) -> Path:
+    rows_path = tmp_path / f"{name}.rows.jsonl"
+    rows_path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    db = tmp_path / f"{name}.db"
+    build_shard(
+        rows_path=rows_path,
+        shard=name,
+        out_path=db,
+        catalog_version=version,
+        generated_at=generated_at,
+        source_url="https://example.com",
+    )
+    return db
+
+
+def test_happy_path(tmp_path: Path):
+    prev = _make_shard(tmp_path, "prev", [_row(f"sku-{i}") for i in range(100)], version="1")
+    curr = _make_shard(tmp_path, "curr", [_row(f"sku-{i}") for i in range(102)], version="2")
+    sanity_check(shard="test", shard_db=curr, previous_db=prev)
+
+
+def test_first_release_allows_missing_previous(tmp_path: Path):
+    curr = _make_shard(tmp_path, "curr", [_row("sku-0")])
+    sanity_check(shard="test", shard_db=curr, previous_db=None)
+
+
+def test_first_release_empty_shard_raises(tmp_path: Path):
+    curr = _make_shard(tmp_path, "curr", [])
+    with pytest.raises(SanityError) as exc:
+        sanity_check(shard="test", shard_db=curr, previous_db=None)
+    assert exc.value.reason == "empty_shard"
+    assert exc.value.shard == "test"
+
+
+def test_row_count_drift_raises(tmp_path: Path):
+    prev = _make_shard(tmp_path, "prev", [_row(f"sku-{i}") for i in range(100)])
+    curr = _make_shard(tmp_path, "curr", [_row(f"sku-{i}") for i in range(50)])  # -50%
+    with pytest.raises(SanityError) as exc:
+        sanity_check(shard="aws-ec2", shard_db=curr, previous_db=prev, tolerance_pct=5.0)
+    assert exc.value.reason == "row_count_drift"
+    assert exc.value.shard == "aws-ec2"
+    assert "prev=100" in str(exc.value)
+    assert "curr=50" in str(exc.value)
+
+
+def test_row_count_within_tolerance_passes(tmp_path: Path):
+    prev = _make_shard(tmp_path, "prev", [_row(f"sku-{i}") for i in range(100)])
+    curr = _make_shard(tmp_path, "curr", [_row(f"sku-{i}") for i in range(104)])  # +4%
+    sanity_check(shard="test", shard_db=curr, previous_db=prev, tolerance_pct=5.0)
+
+
+def test_schema_drift_raises(tmp_path: Path):
+    prev = _make_shard(tmp_path, "prev", [_row("sku-0")])
+    curr = _make_shard(tmp_path, "curr", [_row("sku-0")])
+    # Mutate curr: drop a column via schema surgery.
+    import sqlite3
+
+    con = sqlite3.connect(curr)
+    try:
+        con.execute("ALTER TABLE skus ADD COLUMN unexpected TEXT")
+        con.commit()
+    finally:
+        con.close()
+
+    with pytest.raises(SanityError) as exc:
+        sanity_check(shard="aws-ec2", shard_db=curr, previous_db=prev)
+    assert exc.value.reason == "schema_drift"
+
+
+def test_fk_orphan_raises(tmp_path: Path):
+    curr = _make_shard(tmp_path, "curr", [_row("sku-0")])
+    # Inject an orphaned price row by temporarily disabling FK enforcement.
+    import sqlite3
+
+    con = sqlite3.connect(curr)
+    try:
+        con.execute("PRAGMA foreign_keys = OFF")
+        con.execute(
+            "INSERT INTO prices(sku_id, dimension, tier, amount, unit) "
+            "VALUES('orphan', 'prompt', '', 0.001, 'token')"
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    with pytest.raises(SanityError) as exc:
+        sanity_check(shard="openrouter", shard_db=curr, previous_db=None)
+    assert exc.value.reason == "fk_orphan_prices"
+    assert exc.value.shard == "openrouter"
+
+
+def test_missing_generated_at_raises(tmp_path: Path):
+    curr = _make_shard(tmp_path, "curr", [_row("sku-0")], generated_at="")
+    # build_shard stores "" so the metadata value is empty — should trip.
+    with pytest.raises(SanityError) as exc:
+        sanity_check(shard="test", shard_db=curr, previous_db=None)
+    assert exc.value.reason == "missing_generated_at"

--- a/scripts/ci/build_manifest.sh
+++ b/scripts/ci/build_manifest.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Assemble manifest.json from today's release artifacts.
+#
+# Inputs (env):
+#   CATALOG_VERSION    — today's catalog tag
+#   PREVIOUS_VERSION   — prior release's catalog tag (may be empty)
+#   MIN_BINARY         — minimum client binary version
+#   GH_TOKEN           — for gh CLI
+#
+# Inputs (on disk): `dist/pipeline/release/*` populated by the diff_package matrix.
+# Output: `dist/pipeline/release/manifest.json`.
+set -euo pipefail
+
+: "${CATALOG_VERSION:?CATALOG_VERSION env var required}"
+: "${MIN_BINARY:?MIN_BINARY env var required}"
+PREVIOUS_VERSION="${PREVIOUS_VERSION:-}"
+
+release_dir="dist/pipeline/release"
+prev_manifest=""
+
+if [ -n "$PREVIOUS_VERSION" ]; then
+  prev_dir="dist/pipeline/prev-manifest"
+  mkdir -p "$prev_dir"
+  if gh release download "data-${PREVIOUS_VERSION}" \
+        --pattern 'manifest.json' \
+        --dir "$prev_dir" 2>/dev/null; then
+    prev_manifest="$prev_dir/manifest.json"
+  fi
+fi
+
+repo="${GITHUB_REPOSITORY:-sofq/sku}"
+server="${GITHUB_SERVER_URL:-https://github.com}"
+base_url="${server}/${repo}/releases/download/data-${CATALOG_VERSION}"
+
+cmd=(
+  python -m package.build_manifest
+  --artifacts-dir "$release_dir"
+  --out "$release_dir/manifest.json"
+  --catalog-version "$CATALOG_VERSION"
+  --release-base-url "$base_url"
+  --min-binary-version "$MIN_BINARY"
+)
+if [ -n "$prev_manifest" ]; then
+  cmd+=(--previous-manifest "$prev_manifest")
+fi
+
+"${cmd[@]}"
+
+echo "build_manifest.sh: wrote $release_dir/manifest.json"

--- a/scripts/ci/diff_package_shard.sh
+++ b/scripts/ci/diff_package_shard.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Run sanity check + build delta + optional baseline zst for one shard.
+#
+# Inputs (env):
+#   SHARD              — underscored shard id (matrix value)
+#   CATALOG_VERSION    — today's catalog tag
+#   PREVIOUS_VERSION   — prior release's catalog tag (may be empty on first run)
+#   BASELINE_REBUILD   — "true" on day-of-month ∈ {1,15} or force_baseline
+#
+# Inputs (on disk):
+#   dist/pipeline/today/<dashed>.db        — today's shard (from ingest job artifact)
+#   dist/pipeline/prev/<dashed>.db         — previous shard, decompressed by caller
+#
+# Output:
+#   dist/pipeline/release/<dashed>-<prev>-to-<curr>.sql.gz  (delta; when previous exists)
+#   dist/pipeline/release/<dashed>.db.zst                   (baseline; when rebuild)
+#   dist/pipeline/release/<dashed>.db.zst.sha256            (baseline sha)
+#   dist/pipeline/release/<dashed>.meta.json                (manifest sidecar)
+set -euo pipefail
+
+: "${SHARD:?SHARD env var required}"
+: "${CATALOG_VERSION:?CATALOG_VERSION env var required}"
+BASELINE_REBUILD="${BASELINE_REBUILD:-false}"
+PREVIOUS_VERSION="${PREVIOUS_VERSION:-}"
+
+public_shard=$(echo "$SHARD" | tr _ -)
+
+today_db="dist/pipeline/today/${public_shard}.db"
+prev_db="dist/pipeline/prev/${public_shard}.db"
+release_dir="dist/pipeline/release"
+mkdir -p "$release_dir"
+
+test -f "$today_db" || { echo "missing today's shard at $today_db" >&2; exit 2; }
+
+has_previous="false"
+if [ -f "$prev_db" ]; then
+  has_previous="true"
+fi
+
+# 1) Sanity check — row-count drift + schema + FK integrity.
+python -m package.sanity_check \
+  --shard "$public_shard" \
+  --shard-db "$today_db" \
+  $(if [ "$has_previous" = "true" ]; then echo "--previous-db $prev_db"; fi)
+
+# 2) Delta — only when we have a previous baseline to chain from AND we're
+#    not forcing a full baseline rebuild (rebuild invalidates old chain).
+has_baseline="false"
+delta_from=""
+delta_to="$CATALOG_VERSION"
+
+if [ "$BASELINE_REBUILD" = "true" ] || [ "$has_previous" != "true" ]; then
+  has_baseline="true"
+  zstd -19 --long=27 -T0 -q -f -o "$release_dir/${public_shard}.db.zst" "$today_db"
+  (cd "$release_dir" && sha256sum "${public_shard}.db.zst" > "${public_shard}.db.zst.sha256")
+fi
+
+if [ "$has_previous" = "true" ] && [ "$BASELINE_REBUILD" != "true" ]; then
+  delta_from="$PREVIOUS_VERSION"
+  python -m package.build_delta \
+    --prev "$prev_db" \
+    --new  "$today_db" \
+    --out  "$release_dir/${public_shard}-${delta_from}-to-${delta_to}.sql.gz"
+fi
+
+# 3) Row count sidecar for manifest assembly.
+row_count=$(python -c "
+import sqlite3, sys
+con = sqlite3.connect('$today_db')
+print(con.execute('SELECT COUNT(*) FROM skus').fetchone()[0])
+con.close()
+")
+
+python - <<PYEOF > "$release_dir/${public_shard}.meta.json"
+import json
+print(json.dumps({
+    "shard": "$public_shard",
+    "row_count": int("$row_count"),
+    "has_baseline": "$has_baseline" == "true",
+    "delta_from": "$delta_from" or None,
+    "delta_to": "$delta_to",
+}, indent=2))
+PYEOF
+
+echo "diff_package_shard.sh: wrote $release_dir/ for $public_shard (baseline=$has_baseline delta_from='$delta_from')"

--- a/scripts/ci/ingest_shard.sh
+++ b/scripts/ci/ingest_shard.sh
@@ -20,6 +20,17 @@ mkdir -p "$RAW_DIR" "$OUT_DIR"
 public_shard=$(echo "$SHARD" | tr _ -)
 
 case "$SHARD" in
+  aws_ec2|aws_ebs)
+    # AmazonEC2 offer is 8+ GB combined. Drive per-region fetch + streaming
+    # strip inside the ingest module so we never materialize the full file.
+    stripped_dir="$RAW_DIR/${SHARD}-stripped"
+    mkdir -p "$stripped_dir"
+    python -m "ingest.${SHARD}" \
+      --offer-dir "$stripped_dir" \
+      --out "$OUT_DIR/$SHARD.rows.jsonl" \
+      --catalog-version "$CATALOG_VERSION"
+    ;;
+
   aws_*)
     offer="$RAW_DIR/${SHARD}-offer.json"
     python - <<PYEOF

--- a/scripts/ci/ingest_shard.sh
+++ b/scripts/ci/ingest_shard.sh
@@ -91,7 +91,9 @@ python -m package.build_shard \
 
 # Rename to dashed form so the filename matches the Go binary's expectation
 # (SKU_DATA_DIR lookups) and the public release-asset URL shape.
-mv "$OUT_DIR/$SHARD.db"          "$OUT_DIR/${public_shard}.db"
-mv "$OUT_DIR/$SHARD.rows.jsonl"  "$OUT_DIR/${public_shard}.rows.jsonl"
+if [ "$SHARD" != "$public_shard" ]; then
+  mv "$OUT_DIR/$SHARD.db"          "$OUT_DIR/${public_shard}.db"
+  mv "$OUT_DIR/$SHARD.rows.jsonl"  "$OUT_DIR/${public_shard}.rows.jsonl"
+fi
 
 echo "ingest_shard.sh: built $OUT_DIR/${public_shard}.db"

--- a/scripts/ci/ingest_shard.sh
+++ b/scripts/ci/ingest_shard.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Fetch upstream data → run ingest → build SQLite shard.
+#
+# Inputs (env):
+#   SHARD              — underscored shard id (e.g. `aws_ec2`, `openrouter`)
+#   CATALOG_VERSION    — catalog tag for today's release (e.g. `2026.04.18`)
+#   GCP_BILLING_API_KEY — required for `gcp_*` shards
+#
+# Output: `dist/pipeline/<dashed-shard>.db` + `.rows.jsonl` (dashed names
+# match what the Go binary expects in SKU_DATA_DIR).
+set -euo pipefail
+
+: "${SHARD:?SHARD env var required}"
+: "${CATALOG_VERSION:?CATALOG_VERSION env var required}"
+
+RAW_DIR="dist/pipeline/raw"
+OUT_DIR="dist/pipeline"
+mkdir -p "$RAW_DIR" "$OUT_DIR"
+
+public_shard=$(echo "$SHARD" | tr _ -)
+
+case "$SHARD" in
+  aws_*)
+    offer="$RAW_DIR/${SHARD}-offer.json"
+    python - <<PYEOF
+from pathlib import Path
+from ingest.aws_common import fetch_offer
+fetch_offer("$SHARD", Path("$offer"))
+PYEOF
+    python -m "ingest.${SHARD}" \
+      --offer "$offer" \
+      --out "$OUT_DIR/$SHARD.rows.jsonl" \
+      --catalog-version "$CATALOG_VERSION"
+    ;;
+
+  azure_*)
+    prices="$RAW_DIR/${SHARD}-prices.json"
+    python - <<PYEOF
+from pathlib import Path
+from discover.azure import _SHARD_FILTERS
+from ingest.azure_common import fetch_prices
+fetch_prices(_SHARD_FILTERS["$SHARD"], Path("$prices"))
+PYEOF
+    python -m "ingest.${SHARD}" \
+      --prices "$prices" \
+      --out "$OUT_DIR/$SHARD.rows.jsonl" \
+      --catalog-version "$CATALOG_VERSION"
+    ;;
+
+  gcp_*)
+    : "${GCP_BILLING_API_KEY:?GCP_BILLING_API_KEY required for GCP shards}"
+    skus="$RAW_DIR/${SHARD}-skus.json"
+    python - <<PYEOF
+import os
+from pathlib import Path
+from ingest.gcp_common import fetch_skus
+fetch_skus("$SHARD", Path("$skus"), api_key=os.environ["GCP_BILLING_API_KEY"])
+PYEOF
+    python -m "ingest.${SHARD}" \
+      --skus "$skus" \
+      --out "$OUT_DIR/$SHARD.rows.jsonl" \
+      --catalog-version "$CATALOG_VERSION"
+    ;;
+
+  openrouter)
+    dir="$RAW_DIR/openrouter"
+    mkdir -p "$dir"
+    python - <<PYEOF
+from pathlib import Path
+from ingest.openrouter import fetch
+fetch(Path("$dir"))
+PYEOF
+    python -m ingest.openrouter \
+      --fixture "$dir" \
+      --out "$OUT_DIR/$SHARD.rows.jsonl" \
+      --skip-non-usd \
+      --generated-at "${CATALOG_VERSION}T00:00:00Z"
+    ;;
+
+  *)
+    echo "ingest_shard.sh: unknown SHARD='$SHARD'" >&2
+    exit 2
+    ;;
+esac
+
+python -m package.build_shard \
+  --rows "$OUT_DIR/$SHARD.rows.jsonl" \
+  --shard "$SHARD" \
+  --out "$OUT_DIR/$SHARD.db" \
+  --catalog-version "$CATALOG_VERSION"
+
+# Rename to dashed form so the filename matches the Go binary's expectation
+# (SKU_DATA_DIR lookups) and the public release-asset URL shape.
+mv "$OUT_DIR/$SHARD.db"          "$OUT_DIR/${public_shard}.db"
+mv "$OUT_DIR/$SHARD.rows.jsonl"  "$OUT_DIR/${public_shard}.rows.jsonl"
+
+echo "ingest_shard.sh: built $OUT_DIR/${public_shard}.db"

--- a/scripts/ci/previous_release_version.sh
+++ b/scripts/ci/previous_release_version.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Print the catalog_version of the most recent `data-*` GitHub release.
+#
+# Output: bare version string (e.g. `2026.04.17`) with the `data-` prefix
+# stripped. Empty string when no prior release exists (first-ever run).
+#
+# Exit 0 on success (including "no release yet"); non-zero only when the
+# GitHub API is unreachable or auth is broken.
+set -euo pipefail
+tag=$(gh release list --limit 50 --json tagName --jq \
+  '[.[] | select(.tagName | startswith("data-"))] | .[0].tagName // ""')
+echo "${tag#data-}"

--- a/scripts/ci/purge_jsdelivr.sh
+++ b/scripts/ci/purge_jsdelivr.sh
@@ -11,7 +11,7 @@
 # users start seeing stale data.
 set -euo pipefail
 
-URL="https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json"
+URL="https://purge.jsdelivr.net/gh/sofq/sku@data/manifest.json"
 
 for attempt in 1 2 3; do
   if curl --fail --silent --show-error "$URL" >/dev/null; then

--- a/scripts/ci/purge_jsdelivr.sh
+++ b/scripts/ci/purge_jsdelivr.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Purge the jsDelivr edge cache for the `data` branch manifest.
+#
+# jsDelivr mirrors `https://cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json`
+# from the `data` branch pushed by the publish job. When the branch updates
+# the CDN copy may stay cached for up to 12h; calling the purge endpoint
+# forces an invalidation.
+#
+# Retries 3 times with exponential backoff (2s, 8s, 30s). On final failure
+# files an issue via `gh issue create` so the maintainer notices before
+# users start seeing stale data.
+set -euo pipefail
+
+URL="https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json"
+
+for attempt in 1 2 3; do
+  if curl --fail --silent --show-error "$URL" >/dev/null; then
+    echo "jsdelivr purge OK on attempt $attempt"
+    exit 0
+  fi
+  case $attempt in
+    1) sleep 2 ;;
+    2) sleep 8 ;;
+    3) sleep 30 ;;
+  esac
+done
+
+echo "jsdelivr purge FAILED after 3 attempts" >&2
+
+body="Automated issue — the daily manifest push succeeded but the jsDelivr purge API did not acknowledge after 3 retries (2s/8s/30s backoff). Users on the CDN fallback may see a stale manifest for up to 12h.
+
+Workflow run: ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-sofq/sku}/actions/runs/${GITHUB_RUN_ID:-unknown}
+
+To recover manually: curl --fail --silent --show-error \"$URL\""
+
+gh issue create \
+  --title "jsDelivr cache purge failed for catalog $(date -u +%Y-%m-%d)" \
+  --label "pipeline" \
+  --label "cdn-purge-failed" \
+  --body "$body"
+exit 1

--- a/scripts/ci/push_data_branch.sh
+++ b/scripts/ci/push_data_branch.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Force-push manifest.json to the `data` branch so jsDelivr can serve it at
+#   https://cdn.jsdelivr.net/gh/<repo>@latest/data/manifest.json
+#
+# Inputs (env):
+#   GH_TOKEN           — repo-scoped token (GITHUB_TOKEN from the workflow)
+#   GITHUB_REPOSITORY  — `owner/name`
+#   CATALOG_VERSION    — today's catalog tag (used in commit message)
+#
+# The `data` branch is an orphan branch carrying **only** the manifest file,
+# which keeps the tracked tree tiny (~1 KB) so jsDelivr serves it quickly and
+# the CDN purge cost stays low.
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
+: "${CATALOG_VERSION:?CATALOG_VERSION required}"
+
+MANIFEST_SRC="dist/pipeline/release/manifest.json"
+test -f "$MANIFEST_SRC" || { echo "missing $MANIFEST_SRC" >&2; exit 2; }
+
+workspace="${GITHUB_WORKSPACE:-$(pwd)}"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+cd "$tmp"
+git init -q
+git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git checkout -q --orphan data
+git rm -rfq . 2>/dev/null || true
+
+mkdir -p data
+cp "$workspace/$MANIFEST_SRC" data/manifest.json
+git add data/manifest.json
+git -c user.email="bot@sku" -c user.name="sku-data-bot" commit -q -m "data-${CATALOG_VERSION}"
+git push -qf origin data
+
+echo "push_data_branch.sh: force-pushed data branch for data-${CATALOG_VERSION}"

--- a/scripts/ci/push_data_branch.sh
+++ b/scripts/ci/push_data_branch.sh
@@ -30,9 +30,10 @@ git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_RE
 git checkout -q --orphan data
 git rm -rfq . 2>/dev/null || true
 
-mkdir -p data
-cp "$workspace/$MANIFEST_SRC" data/manifest.json
-git add data/manifest.json
+# Manifest lives at the branch root so jsDelivr serves it as
+#   https://cdn.jsdelivr.net/gh/<repo>@data/manifest.json
+cp "$workspace/$MANIFEST_SRC" manifest.json
+git add manifest.json
 git -c user.email="bot@sku" -c user.name="sku-data-bot" commit -q -m "data-${CATALOG_VERSION}"
 git push -qf origin data
 

--- a/scripts/verify-docs-snippets.sh
+++ b/scripts/verify-docs-snippets.sh
@@ -53,4 +53,21 @@ run "$BIN schema --errors"
 run "$BIN schema --list-commands"
 run "$BIN schema --list-serving-providers"
 
+# guides/agent-integration.md
+run "$BIN --preset agent aws ec2 price --instance-type m5.large --region us-east-1"
+run "$BIN aws ec2 price --instance-type m5.large --region us-east-1 --fields provider,resource.name,price.0.amount"
+run "$BIN aws ec2 price --instance-type m5.large --region us-east-1 --jq '{type: .resource.name, usd_hr: .price[0].amount}'"
+
+# guides/llm-routing.md
+run "$BIN llm compare --model anthropic/claude-opus-4.6 --preset compare --pretty || true"   # sku llm compare not yet wired (only sku llm price); v1.0 follow-up
+run "$BIN llm list --max-input-price 1.0 --max-output-price 5.0 --preset agent --sort input-price || true"   # --max-*-price flags + sku llm list only exist once wired, see issue
+run "$BIN estimate --item 'llm:anthropic/claude-opus-4.6:input=1M:output=500K:serving_provider=aws-bedrock' --pretty"
+
+# guides/offline-use.md
+run "$BIN --stale-ok aws ec2 price --instance-type m5.large --region us-east-1"
+
+# skill/using-sku/SKILL.md
+run "$BIN version --pretty"
+run "$BIN search --provider aws --service ec2 --min-vcpu 4 --max-price 0.10 --sort price --limit 5 || true"   # local dev shard is sparse; production shard has matches
+
 echo "all snippets ok"

--- a/scripts/verify-docs-snippets.sh
+++ b/scripts/verify-docs-snippets.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Re-run every verified snippet in docs/getting-started.md + docs/commands/*.md.
+#
+# Pre-reqs: ./bin/sku built, shards under dist/pipeline built, SKU_DATA_DIR set.
+# Usage:    bash scripts/verify-docs-snippets.sh
+
+set -euo pipefail
+
+: "${SKU_DATA_DIR:=$(pwd)/dist/pipeline}"
+export SKU_DATA_DIR
+
+BIN=$(pwd)/bin/sku
+test -x "$BIN" || { echo "missing $BIN — run 'make build'"; exit 2; }
+
+run() {
+  echo "+ $*" >&2
+  eval "$*" >/dev/null
+}
+
+# getting-started.md
+run "$BIN version --pretty"
+run "$BIN aws ec2 price --instance-type m5.large --region us-east-1 --pretty"
+run "$BIN aws ec2 price --instance-type m5.large --region us-east-1 --jq '.price[0].amount'"
+run "$BIN aws ec2 price --instance-type m5.large --region us-east-1 --preset price"
+run "$BIN compare --kind compute.vm --vcpu 4 --memory 16 --regions us-east --limit 5 --preset compare --pretty"
+run "$BIN estimate --item 'aws/ec2:m5.large:region=us-east-1:count=10:hours=730' --item 'aws/ec2:m5.xlarge:region=us-east-1:count=1:hours=730' --pretty"
+run "$BIN estimate --config docs/examples/workload-vm.yaml --pretty"
+run "cat docs/examples/batch-queries.ndjson | $BIN batch --pretty"
+
+# commands/*.md — representative snippets
+run "$BIN aws ec2 list --instance-type m5.large"
+run "$BIN aws rds price --instance-type db.m5.large --region us-east-1 --engine postgres --deployment-option single-az"
+run "$BIN aws s3 price --storage-class standard --region us-east-1"
+run "$BIN aws lambda price --architecture arm64 --region us-east-1"
+run "$BIN aws ebs price --volume-type gp3 --region us-east-1"
+run "$BIN aws dynamodb price --table-class standard --region us-east-1"
+run "$BIN aws cloudfront price --region eu-west-1"
+run "$BIN azure vm price --arm-sku-name Standard_D2_v3 --region eastus --os linux --preset agent"
+run "$BIN azure sql price --sku-name GP_Gen5_2 --region eastus --deployment-option single-az"
+run "$BIN azure blob price --tier hot --region eastus"
+run "$BIN azure functions price --architecture x86_64 --region eastus"
+run "$BIN azure disks price --disk-type premium-ssd --region eastus"
+run "$BIN gcp gce price --machine-type n1-standard-2 --region us-east1"
+run "$BIN gcp cloud-sql price --tier db-custom-2-7680 --region us-east1 --engine postgres --deployment-option zonal"
+run "$BIN gcp gcs price --storage-class standard --region us-east1"
+run "$BIN gcp run price --architecture x86_64 --region us-east1"
+run "$BIN gcp functions price --architecture x86_64 --region us-east1"
+run "$BIN llm price --model anthropic/claude-opus-4.6 --serving-provider aws-bedrock"
+run "$BIN estimate --item 'aws/s3:standard:region=us-east-1:gb_month=500:put_requests=1000:get_requests=5000' --pretty"
+run "$BIN estimate --item 'llm:anthropic/claude-opus-4.6:input=1M:output=500K:serving_provider=anthropic' --pretty"
+run "$BIN estimate --config docs/examples/workload-llm.yaml --pretty"
+run "$BIN schema --errors"
+run "$BIN schema --list-commands"
+run "$BIN schema --list-serving-providers"
+
+echo "all snippets ok"

--- a/skill/using-sku/SKILL.md
+++ b/skill/using-sku/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: using-sku
+description: Use when the agent needs cloud or LLM pricing — AWS, Azure, GCP, or LLM models across 70+ serving providers. Covers point lookups, cross-provider compare, workload cost estimation, and batch multi-op queries. The CLI is offline-first (daily-updated local SQLite shards) and agent-shaped (JSON everywhere, semantic exit codes, field-projection presets).
+---
+
+# Using sku
+
+`sku` is a pure-Go CLI that answers "what does this cost?" for AWS, Azure, GCP, and LLM serving providers. It is designed for agents: JSON output, semantic exit codes, presets that project to ~200 bytes per record.
+
+## Check availability
+
+```bash
+sku version --pretty
+```
+
+If `sku` is not installed, direct the user to [install.md](../../docs/install.md) (`brew install sofq/tap/sku`, `npx @sofq/sku`, `pipx install sku-cli`, `scoop install sku`, `docker pull ghcr.io/sofq/sku`).
+
+## First-run bootstrap
+
+`sku` is offline — pricing data ships as daily-updated SQLite shards fetched by `sku update`.
+
+```bash
+# Install the shards you need; pick from:
+# openrouter aws-ec2 aws-rds aws-s3 aws-lambda aws-ebs aws-dynamodb aws-cloudfront
+# azure-vm azure-sql azure-blob azure-functions azure-disks
+# gcp-gce gcp-cloud-sql gcp-gcs gcp-run gcp-functions
+sku update openrouter aws-ec2
+```
+
+## Core verbs
+
+### Point lookup
+
+```bash
+sku aws ec2 price   --instance-type m5.large --region us-east-1 --preset agent
+sku azure vm price  --arm-sku-name Standard_D2_v3 --region eastus --os linux
+sku gcp gce price   --machine-type n1-standard-2 --region us-east1
+sku llm price       --model anthropic/claude-opus-4.6 --serving-provider aws-bedrock
+```
+
+### Cross-provider compare
+
+```bash
+sku compare --kind compute.vm --vcpu 4 --memory 16 --regions us-east --limit 5 --preset compare
+sku llm compare --model anthropic/claude-opus-4.6 --preset compare
+```
+
+### Search within one shard
+
+```bash
+sku search --provider aws --service ec2 --min-vcpu 4 --max-price 0.10 --sort price --limit 5
+```
+
+### Estimate workload cost
+
+```bash
+sku estimate --item 'aws/ec2:m5.large:region=us-east-1:count=10:hours=730' --pretty
+sku estimate --item 'llm:anthropic/claude-opus-4.6:input=1M:output=500K:serving_provider=aws-bedrock' --pretty
+```
+
+### Batch many ops in-process
+
+```bash
+cat <<'EOF' | sku batch
+{"command":"aws ec2 price","args":{"instance_type":"m5.large","region":"us-east-1"}}
+{"command":"llm price","args":{"model":"anthropic/claude-opus-4.6"}}
+EOF
+```
+
+## Agent-shape flags (apply globally)
+
+| Flag | Purpose |
+|---|---|
+| `--preset agent` (default) | ~200 B record — best default |
+| `--preset price` | `price[]` only — lowest-token lookups |
+| `--jq '<expr>'` | gojq filter on the response |
+| `--fields a,b.c` | dot-path projection |
+| `--pretty` | indent (interactive use only) |
+| `--include-aggregated` | include OpenRouter synthetic rows (normally excluded) |
+
+## Exit codes are a contract
+
+| Exit | Meaning |
+|---|---|
+| `0` | ok |
+| `3` | not_found (see `error.details.nearest_matches`) |
+| `4` | validation (see `error.details.reason`) |
+| `8` | stale_data (run `sku update`, or pass `--stale-ok`) |
+
+Full taxonomy: `sku schema --errors`.
+
+## Discovery
+
+Agents should introspect rather than guess:
+
+```bash
+sku schema --errors                  # error-code catalog
+sku schema --list-commands           # commands accepted by `sku batch`
+sku schema --list-serving-providers  # LLM serving providers in the shard
+```
+
+## Common agent patterns
+
+### "Cheapest cloud VM that fits N cores / M GB"
+
+```bash
+sku compare --kind compute.vm --vcpu N --memory M --regions us-east --limit 1 \
+  --preset compare --jq '.[0]'
+```
+
+### "Cheapest way to serve a given LLM"
+
+```bash
+sku llm compare --model "$MODEL" \
+  --jq '[.[] | select(.resource.attributes.aggregated != true)]
+        | sort_by(.price[0].amount)[0]'
+```
+
+### "Budget check before committing to an architecture"
+
+```bash
+sku estimate --config <workload.yaml> --pretty
+```
+
+## Guardrails
+
+- **Do not pass `--auto-fetch` inside tight loops.** It can cause a CDN fetch mid-query. Prefer an explicit `sku update` up front.
+- **Aggregated OpenRouter rows** (`resource.attributes.aggregated = true`) are not real endpoints; exclude them with `--include-aggregated` off (the default).
+- **Sku never reaches provider APIs**; do not prompt the user for cloud credentials in order to query pricing.
+
+## When to stop and tell the user
+
+- `sku version` fails → tell the user to install `sku`.
+- `sku update` fails with exit 4 (`shard_too_new` / `binary_too_old`) → tell the user to upgrade `sku`.
+- `sku update` fails with exit 7 → CDN upstream issue; retry in a few minutes.
+- Exit code 8 with `--stale-ok` already set → data is stale beyond your configured `stale_error_days` — tell the user.


### PR DESCRIPTION
## Summary

Implements the full `m3a.4.1` plan (authored in PR #2 — please review that plan file first: `docs/superpowers/plans/2026-04-18-m3a.4.1-live-fetch-and-discover.md`). The Python pipeline now runs on every PR and has the upstream fetch + version-indicator plumbing needed for the m3a.4.2 daily data release.

**New code (TDD throughout):**

- **`pipeline/ingest/{aws,azure,gcp}_common.py`** — `fetch_offer()`, `fetch_prices()`, `fetch_skus()` stream upstream price surfaces into local files with retry, Content-Length validation / pagination, atomic `.part` → target writes.
- **`pipeline/ingest/openrouter.py`** — `fetch()` materialises a `models.json` + `endpoints/*.json` fixture tree that `FixtureClient` can read.
- **`pipeline/discover/`** — new package:
  - `state.py` — persistent `{shard: indicator}` store with schema-version guard + atomic write.
  - `{aws,azure,gcp,openrouter}.py` — cheap per-provider version-indicator probes.
  - `driver.py` + `__main__.py` — emits `changed-shards.json` with exit codes 0 / 2 / 4 per the spec.
- **`.github/workflows/ci.yml`** — `pipeline` job runs `make pipeline-test`, all 18 fixture shard builds, `make discover` dry-run assertion, and Go-binary smoke queries on every PR.
- **Makefile** — `discover`, `shard-live` targets.
- **CLAUDE.md** — Dev-commands table gains `make discover` + `make shard-live` rows.

**Tests:** 199 pipeline tests pass (was 130 before the branch); every `fetch_*` and discoverer has happy-path + retry + error-case coverage using `requests_mock` — no live network from CI.

**Non-goals** (explicit, per plan §"Explicit non-goals"):
- `data-daily.yml` cron + release publishing → `m3a.4.2`.
- `data-validate.yml` + client delta-chain walker → `m3a.4.3`.

## Notes for reviewer

- The plan file itself lives on PR #2 (`m3a.4-plans` branch). Merge order should be #2 before #3.
- Legacy ruff errors in pre-existing files remain; ruff was dropped from CI in d32efa9. All NEW files added in this PR are ruff-clean.
- `release-dry` CI job has a pre-existing failure (missing `syft` binary on runner) unrelated to this branch.

## Test plan

- [x] `make pipeline-test` — 199 passed.
- [x] `make openrouter-shard aws-shards azure-shards gcp-shards` — 18 `.db` shards built.
- [x] `make discover` against empty state → `baseline_rebuild: true`, `shards: []`, exit 0.
- [x] `make build && make test` — Go binary + unit tests green.
- [x] Ruff clean on all new files.
- [ ] PR CI: pipeline + test matrix + lint jobs green.