### PR TITLE
M3a.4.2 (draft): data-daily.yml end-to-end data release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/cdn-purge-failed.md
+++ b/.github/ISSUE_TEMPLATE/cdn-purge-failed.md
@@ -7,6 +7,6 @@ labels: ["pipeline", "cdn-purge-failed"]
 
 The daily data release succeeded but the jsDelivr purge API did not acknowledge after 3 retries with exponential backoff (2s, 8s, 30s).
 
-**Impact:** Users pinned to `cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` may see a stale manifest for up to 12h. The release-asset URL (`github.com/sofq/sku/releases/latest/download/manifest.json`) is unaffected.
+**Impact:** Users pinned to `cdn.jsdelivr.net/gh/sofq/sku@data/manifest.json` may see a stale manifest for up to 12h. The release-asset URL (`github.com/sofq/sku/releases/latest/download/manifest.json`) is unaffected.
 
-**Action:** Run `scripts/ci/purge_jsdelivr.sh` from a maintainer machine with `gh` authenticated, or `curl --fail https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` directly. Close this issue once the purge URL returns 200.
+**Action:** Run `scripts/ci/purge_jsdelivr.sh` from a maintainer machine with `gh` authenticated, or `curl --fail https://purge.jsdelivr.net/gh/sofq/sku@data/manifest.json` directly. Close this issue once the purge URL returns 200.

--- a/.github/ISSUE_TEMPLATE/cdn-purge-failed.md
+++ b/.github/ISSUE_TEMPLATE/cdn-purge-failed.md
@@ -1,0 +1,12 @@
+---
+name: CDN purge failed (automated)
+about: jsDelivr cache purge failed after 3 retries
+title: "jsDelivr cache purge failed for catalog <YYYY-MM-DD>"
+labels: ["pipeline", "cdn-purge-failed"]
+---
+
+The daily data release succeeded but the jsDelivr purge API did not acknowledge after 3 retries with exponential backoff (2s, 8s, 30s).
+
+**Impact:** Users pinned to `cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` may see a stale manifest for up to 12h. The release-asset URL (`github.com/sofq/sku/releases/latest/download/manifest.json`) is unaffected.
+
+**Action:** Run `scripts/ci/purge_jsdelivr.sh` from a maintainer machine with `gh` authenticated, or `curl --fail https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` directly. Close this issue once the purge URL returns 200.

--- a/.github/actions/setup-pipeline/action.yml
+++ b/.github/actions/setup-pipeline/action.yml
@@ -1,0 +1,21 @@
+name: "setup-pipeline"
+description: "Install Python 3.11 and the sku-pipeline package, plus zstd/jq CLI tools used by data-daily."
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: pip
+        cache-dependency-path: pipeline/pyproject.toml
+    - name: Install pipeline package
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e 'pipeline[dev]'
+    - name: Install OS tooling (zstd, jq)
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends zstd jq

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
-          args: release --snapshot --clean --skip=sign,publish
+          args: release --snapshot --clean --skip=sign,publish,sbom
 
   pipeline:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
-          args: release --snapshot --clean --skip=sign,publish,sbom
+          args: release --snapshot --clean --skip=sign,publish,sbom,docker
 
   pipeline:
     runs-on: ubuntu-latest

--- a/.github/workflows/data-daily.yml
+++ b/.github/workflows/data-daily.yml
@@ -1,0 +1,225 @@
+name: data-daily
+
+on:
+  schedule:
+    # DISABLED until one successful workflow_dispatch run proves the pipeline
+    # end-to-end. Re-enabled by Task 12 of plan m3a.4.2 after green dry-run +
+    # publish-run from a draft PR.
+    # - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Stop before publish step; upload artifacts only"
+        required: false
+        default: "false"
+      force_baseline:
+        description: "Force a baseline rebuild regardless of day-of-month"
+        required: false
+        default: "false"
+
+permissions:
+  contents: write   # gh release create + data branch force-push
+  issues:   write   # cdn-purge-failed auto-issue
+  actions:  read
+
+concurrency:
+  # Never cancel a release mid-publish; queue follow-ups instead.
+  group: data-daily
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      shards:            ${{ steps.discover.outputs.shards }}
+      baseline_rebuild:  ${{ steps.discover.outputs.baseline_rebuild }}
+      catalog_version:   ${{ steps.discover.outputs.catalog_version }}
+      previous_version:  ${{ steps.previous.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+
+      - name: Resolve previous release version
+        id: previous
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(scripts/ci/previous_release_version.sh)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "previous_version=$version"
+
+      - name: Restore prior discover state
+        if: steps.previous.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist/pipeline/discover
+          gh release download "data-${{ steps.previous.outputs.version }}" \
+            --pattern 'state.json' \
+            --dir dist/pipeline/discover || echo "no state.json on previous release (allowed)"
+          ls -la dist/pipeline/discover/ || true
+
+      - name: Discover changed shards
+        id: discover
+        env:
+          GCP_BILLING_API_KEY: ${{ secrets.GCP_BILLING_API_KEY }}
+          FORCE_BASELINE: ${{ github.event.inputs.force_baseline }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/pipeline/discover
+          today=$(date -u +%Y.%m.%d)
+          dom=$(date -u +%d)
+
+          flag=""
+          if [ "${FORCE_BASELINE:-false}" = "true" ]; then flag="--baseline-rebuild"; fi
+          if [ "$dom" = "01" ] || [ "$dom" = "15" ]; then flag="--baseline-rebuild"; fi
+
+          python -m discover \
+            --state dist/pipeline/discover/state.json \
+            --out   dist/pipeline/discover/changed.json \
+            --live  $flag
+
+          shards=$(jq -c '.shards' dist/pipeline/discover/changed.json)
+          brl=$(jq -r '.baseline_rebuild' dist/pipeline/discover/changed.json)
+          echo "shards=$shards"           >> "$GITHUB_OUTPUT"
+          echo "baseline_rebuild=$brl"    >> "$GITHUB_OUTPUT"
+          echo "catalog_version=$today"   >> "$GITHUB_OUTPUT"
+          echo "shards=$shards baseline_rebuild=$brl catalog_version=$today"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: discover
+          path: dist/pipeline/discover/
+          retention-days: 14
+
+  ingest:
+    needs: discover
+    if: needs.discover.outputs.shards != '[]' && needs.discover.outputs.shards != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        shard: ${{ fromJSON(needs.discover.outputs.shards) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+
+      - name: Fetch upstream + ingest + package
+        env:
+          GCP_BILLING_API_KEY: ${{ secrets.GCP_BILLING_API_KEY }}
+          SHARD:             ${{ matrix.shard }}
+          CATALOG_VERSION:   ${{ needs.discover.outputs.catalog_version }}
+        run: bash scripts/ci/ingest_shard.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: shard-${{ matrix.shard }}
+          path: |
+            dist/pipeline/*.db
+            dist/pipeline/*.rows.jsonl
+          retention-days: 14
+
+  diff_package:
+    needs: [discover, ingest]
+    if: needs.discover.outputs.shards != '[]' && needs.discover.outputs.shards != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        shard: ${{ fromJSON(needs.discover.outputs.shards) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+
+      - name: Download today's shard
+        uses: actions/download-artifact@v4
+        with:
+          name: shard-${{ matrix.shard }}
+          path: dist/pipeline/today/
+
+      - name: Download previous shard baseline (if any)
+        if: needs.discover.outputs.previous_version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/pipeline/prev
+          # Filenames on the release use dashed shard names (see ingest_shard.sh).
+          public_shard=$(echo "${{ matrix.shard }}" | tr _ -)
+          gh release download "data-${{ needs.discover.outputs.previous_version }}" \
+            --pattern "${public_shard}.db.zst" \
+            --dir dist/pipeline/prev/ || echo "no previous shard — first release for this shard"
+          if [ -f "dist/pipeline/prev/${public_shard}.db.zst" ]; then
+            zstd -df "dist/pipeline/prev/${public_shard}.db.zst"
+          fi
+
+      - name: Sanity check + build delta + optional baseline
+        env:
+          SHARD:            ${{ matrix.shard }}
+          CATALOG_VERSION:  ${{ needs.discover.outputs.catalog_version }}
+          PREVIOUS_VERSION: ${{ needs.discover.outputs.previous_version }}
+          BASELINE_REBUILD: ${{ needs.discover.outputs.baseline_rebuild }}
+        run: bash scripts/ci/diff_package_shard.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.shard }}
+          path: dist/pipeline/release/
+          retention-days: 14
+
+  publish:
+    needs: [discover, diff_package]
+    if: >-
+      github.event.inputs.dry_run != 'true'
+      && needs.discover.outputs.shards != '[]'
+      && needs.discover.outputs.shards != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist/pipeline/release/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: discover
+          path: dist/pipeline/discover/
+
+      - name: Build manifest.json
+        env:
+          CATALOG_VERSION:  ${{ needs.discover.outputs.catalog_version }}
+          PREVIOUS_VERSION: ${{ needs.discover.outputs.previous_version }}
+          MIN_BINARY:       "1.0.0"
+          GH_TOKEN:         ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/build_manifest.sh
+
+      - name: Create GitHub release
+        env:
+          CATALOG_VERSION: ${{ needs.discover.outputs.catalog_version }}
+          GH_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Upload every artifact (baselines, deltas, manifest) plus the
+          # discover state so tomorrow's run can diff against it.
+          cp dist/pipeline/discover/state.json dist/pipeline/release/state.json
+          gh release create "data-${CATALOG_VERSION}" \
+            --title "Data release ${CATALOG_VERSION}" \
+            --notes "Automated daily data release. See manifest.json for shard inventory." \
+            dist/pipeline/release/*
+
+      - name: Mirror manifest to `data` branch
+        env:
+          GH_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
+          CATALOG_VERSION: ${{ needs.discover.outputs.catalog_version }}
+        run: bash scripts/ci/push_data_branch.sh
+
+      - name: Purge jsDelivr cache
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/purge_jsdelivr.sh

--- a/.github/workflows/data-daily.yml
+++ b/.github/workflows/data-daily.yml
@@ -1,11 +1,8 @@
 name: data-daily
 
 on:
-  schedule:
-    # DISABLED until one successful workflow_dispatch run proves the pipeline
-    # end-to-end. Re-enabled by Task 12 of plan m3a.4.2 after green dry-run +
-    # publish-run from a draft PR.
-    # - cron: "0 3 * * *"
+  # schedule:  # Re-enable in Task 12 after a green dry-run + publish-run.
+  #   - cron: "0 3 * * *"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,10 @@ coverage.*
 # Plan runner logs (scripts/run-plan.sh)
 /.planning/
 
-# Python build artifacts (M6 PyPI wrapper)
+# Python build artifacts (M6 PyPI wrapper, pipeline editable install)
 python/dist/
 python/build/
 python/*.egg-info/
 python/sku_cli/bin/
 python/sku_cli.egg-info/
+pipeline/*.egg-info/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ Agent quick-start for the `sku` repo.
 | Run discover (fixture / dry-run) | `make discover` |
 | Run discover against real upstreams | `DISCOVER_LIVE=1 GCP_BILLING_API_KEY=... make discover` |
 | Live-ingest a single shard | `make shard-live SHARD=aws_ec2 SRC=/path/to/offer.json` |
+| Dispatch daily data workflow (dry-run) | `gh workflow run data-daily.yml -F dry_run=true -F force_baseline=true` |
+| Dispatch daily data workflow (publish) | `gh workflow run data-daily.yml -F dry_run=false -F force_baseline=true` |
 
 ## Repo map
 
@@ -43,8 +45,17 @@ Agent quick-start for the `sku` repo.
 
 ## Current milestone
 
-M7.2 — Guides, reference, agent skill: all docs/guides/*, docs/reference/*, and skill/using-sku/SKILL.md published. `make docs-verify` green.
-Next: M7.3 — Security, bench regression gate, v1.0.0 release.
+M3a.4.2 — `data-daily.yml` cron workflow publishes daily data releases:
+discover → ingest (matrix) → diff+package (matrix) → publish. Emits
+`data-YYYY.MM.DD` GitHub release with `<shard>.db.zst` baselines,
+`<shard>-<from>-to-<to>.sql.gz` deltas, and an authoritative `manifest.json`.
+Mirrors the manifest to the `data` branch for jsDelivr fallback; purges CDN
+on each publish. Dry-runs via `gh workflow run data-daily.yml -F dry_run=true`.
+Runbook: `docs/ops/data-daily-runbook.md`.
+
+Next: M3a.4.3 — `data-validate.yml` (OIDC cross-check vs upstream) +
+client-side `internal/updater` delta-chain walker + ETag + stable/daily
+channel split.
 
 ### Quick path (agent, repeatable, M3b.4 surface)
 

--- a/docs/ops/data-daily-runbook.md
+++ b/docs/ops/data-daily-runbook.md
@@ -47,8 +47,8 @@ After this run:
 
 - `gh release view data-$(date -u +%Y.%m.%d)` should list every shard's
   `.db.zst` + `.sha256`, a `manifest.json`, and `state.json`.
-- The `data` branch must exist and contain `data/manifest.json`.
-- `curl https://cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json`
+- The `data` branch must exist and contain `manifest.json` at its root.
+- `curl https://cdn.jsdelivr.net/gh/sofq/sku@data/manifest.json`
   should return the new manifest (may take up to 30s after the purge step).
 
 Only after both runs are green do you enable the cron schedule (next section).
@@ -100,7 +100,7 @@ To clear:
 
 ```bash
 curl --fail --silent --show-error \
-  https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json
+  https://purge.jsdelivr.net/gh/sofq/sku@data/manifest.json
 
 gh issue close <issue-number> --comment "Purge verified; manifest fresh on jsDelivr."
 ```

--- a/docs/ops/data-daily-runbook.md
+++ b/docs/ops/data-daily-runbook.md
@@ -1,0 +1,131 @@
+# Data-daily workflow runbook
+
+Maintainer guide for `.github/workflows/data-daily.yml` — the cron-driven
+daily release that publishes shard baselines, SQL deltas, and `manifest.json`
+under the `data-YYYY.MM.DD` tag.
+
+## Secrets required
+
+| Secret | Purpose | How to create |
+|---|---|---|
+| `GCP_BILLING_API_KEY` | Anonymous GCP Cloud Billing Catalog API key, used by the `gcp_*` shards. | Google Cloud Console → APIs & Services → Credentials → Create API key → restrict to the **Cloud Billing API** → save to repo secrets as `GCP_BILLING_API_KEY`. |
+| `GITHUB_TOKEN` | Auto-injected by Actions; gives the workflow permission to create releases, push the `data` branch, and file incident issues. | No action — GitHub provides this. |
+
+No OIDC / cloud-IAM roles are required by this workflow. AWS pricing, Azure
+retail-prices, and OpenRouter are anonymous; GCP uses the API key above. The
+`data-validate.yml` workflow (m3a.4.3) introduces AWS SigV4 + GCP WIF.
+
+## First green run (bootstrap)
+
+The cron schedule is **commented out** in `data-daily.yml` when it first lands.
+Before enabling it, prove the end-to-end flow with two manual dispatches:
+
+```bash
+# 1. Dry run — discover + ingest + diff-package, but skip publish.
+gh workflow run data-daily.yml \
+  -F dry_run=true \
+  -F force_baseline=true
+
+gh run watch   # wait for completion; confirm all jobs green
+```
+
+Inspect the `release-*` artifacts on the run page: each should contain a
+`<shard>.db.zst` + `<shard>.db.zst.sha256` + `<shard>.meta.json`. Decompress
+one and run `sqlite3 aws-ec2.db '.tables'` — expect `skus`, `prices`,
+`resource_attrs`, `terms`, `health`, `metadata`.
+
+```bash
+# 2. Publish run — creates the first `data-YYYY.MM.DD` release.
+gh workflow run data-daily.yml \
+  -F dry_run=false \
+  -F force_baseline=true
+
+gh run watch
+```
+
+After this run:
+
+- `gh release view data-$(date -u +%Y.%m.%d)` should list every shard's
+  `.db.zst` + `.sha256`, a `manifest.json`, and `state.json`.
+- The `data` branch must exist and contain `data/manifest.json`.
+- `curl https://cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json`
+  should return the new manifest (may take up to 30s after the purge step).
+
+Only after both runs are green do you enable the cron schedule (next section).
+
+## Enabling the cron schedule
+
+Edit `.github/workflows/data-daily.yml` and uncomment the `- cron:` line under
+`on.schedule`:
+
+```yaml
+on:
+  schedule:
+    - cron: "0 3 * * *"
+```
+
+Open a PR titled `ci: enable daily cron for data-daily.yml`, merge after
+review. The first cron fire is at the next 03:00 UTC after merge.
+
+## Disabling on incident
+
+`gh workflow disable data-daily.yml` pauses the cron and blocks further
+manual dispatch. Use when upstream pricing pages are degraded, when the
+sanity check is failing consistently, or when the pipeline needs a pause for
+remediation work.
+
+Re-enable with `gh workflow enable data-daily.yml`. The next run picks up
+whatever has changed since the last green release via the discover state.
+
+## Manually republishing today's catalog
+
+If a scheduled run has already completed but you need to re-publish (e.g. to
+pick up a fixed ingest module):
+
+1. Delete the existing release: `gh release delete data-$(date -u +%Y.%m.%d) --yes --cleanup-tag`
+2. `gh workflow run data-daily.yml -F dry_run=false -F force_baseline=true`
+
+`force_baseline=true` rebuilds every shard baseline, bypassing the discover
+"nothing changed" short-circuit and resetting every client's delta chain
+onto today's baseline.
+
+## Recovering a purge-failed state
+
+When the CDN purge call exhausts its retries, the workflow auto-files an
+issue tagged `cdn-purge-failed` and exits non-zero. The release itself is
+already live — clients on the GitHub URL are unaffected; only jsDelivr
+callers may see a stale manifest for up to 12h.
+
+To clear:
+
+```bash
+curl --fail --silent --show-error \
+  https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json
+
+gh issue close <issue-number> --comment "Purge verified; manifest fresh on jsDelivr."
+```
+
+## Signals that something is wrong
+
+- A `diff-package` matrix leg failing `sanity_check` → typically a sudden
+  row-count cliff. Inspect the ingest job's `<shard>.rows.jsonl` artifact;
+  compare to yesterday's release. Upstream may have renamed/retired a SKU.
+- `discover` job reports every shard errored → upstream site (pricing feed)
+  is probably down. Workflow exits 2; no release published. Re-run once
+  upstream recovers.
+- `publish` job succeeds but no new release shows up → check `gh release
+  list`; the `gh release create` step may have race-conflicted on the tag.
+  Re-run with `force_baseline=true` after deleting any partial release.
+
+## Related files
+
+- `.github/workflows/data-daily.yml` — the workflow itself
+- `.github/actions/setup-pipeline/action.yml` — composite Python setup
+- `scripts/ci/ingest_shard.sh` — per-shard live fetch + ingest
+- `scripts/ci/diff_package_shard.sh` — sanity + delta + optional baseline
+- `scripts/ci/build_manifest.sh` — `manifest.json` assembly
+- `scripts/ci/push_data_branch.sh` — jsDelivr mirror
+- `scripts/ci/purge_jsdelivr.sh` — CDN purge with retry + auto-issue
+- `pipeline/package/build_delta.py` — SQL.gz delta builder
+- `pipeline/package/build_manifest.py` — manifest shape
+- `pipeline/package/sanity_check.py` — drift guard

--- a/docs/superpowers/plans/2026-04-18-m3a.4.2-data-daily-workflow.md
+++ b/docs/superpowers/plans/2026-04-18-m3a.4.2-data-daily-workflow.md
@@ -1,0 +1,817 @@
+# M3a.4.2 — `data-daily.yml` End-to-End Data Release Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the first real cron-driven data release: a GitHub Actions workflow that discovers changed shards, fetches upstream price data, ingests + packages SQLite shards, computes SQL.gz deltas against the previous release, rebuilds full baselines on the 1st/15th of each month, publishes everything as a `data-YYYY.MM.DD` GitHub release, emits an authoritative `manifest.json` release asset, mirrors the manifest to a lightweight `data` branch for the jsDelivr CDN fallback, and purges the jsDelivr cache with retry + issue-file-on-failure. The workflow runs on `workflow_dispatch` from day one (so we can prove it end-to-end from the Actions UI without waiting for 03:00 UTC) and flips the cron schedule on as the final step after one successful manual run.
+
+**Architecture:**
+
+1. **Composite action** (`.github/actions/setup-pipeline/action.yml`): installs Python 3.11, restores the pip cache keyed on `pipeline/pyproject.toml`, and installs the pipeline package in editable mode. Used by every job in `data-daily.yml` (and re-used by `m3a.4.3`'s validate workflow) to keep the YAML terse.
+2. **`discover` job** (1 runner, ~2 min): fetches the previous run's `state.json` from the most recent `data-*` GitHub release's `discover-state.zst` asset (via `gh release download`), runs `make discover DISCOVER_LIVE=1`, uploads `changed-shards.json` + the new `state.json` as workflow artifacts, and emits `shards` + `baseline_rebuild` as job outputs for downstream matrix fan-out. Exits early with `conclusion: success, shards: []` when nothing changed (quiet day).
+3. **`ingest` job** (matrix over `needs.discover.outputs.shards`, up to 20 parallel runners): per shard — download upstream price data using the matching `fetch_*` helper from m3a.4.1 (into a workflow-cache'd `raw/<shard>/offer.json`), run the existing `pipeline/ingest/<shard>.py` with `--offer` / `--prices` / `--skus`, then run `pipeline/package/build_shard.py` to emit `dist/pipeline/<shard>.db`. Upload `<shard>.db` + `<shard>.rows.jsonl` as artifacts.
+4. **`diff-package` job** (matrix, same shape): download today's `<shard>.db` from the ingest job's artifact, `gh release download data-$PREV_VERSION` for yesterday's `<shard>.db.zst`, decompress, run a DuckDB script (`pipeline/package/build_delta.py`) that uses `ATTACH`-style joins (two SQLite DBs attached) to emit upsert + delete rows into `<shard>-$FROM-to-$TO.sql.gz`. On `baseline_rebuild=true` or day-of-month ∈ {1, 15}, additionally zstd-compress today's `<shard>.db` into `<shard>.db.zst` + `<shard>.db.zst.sha256`. Split any delta larger than 8 MB into sequenced `.sql.gz` parts (`...-part1.sql.gz`, `...-part2.sql.gz`) per spec §3 line 232.
+5. **`publish` job** (1 runner, ~2 min): downloads every artifact, assembles `manifest.json` per spec §3 line 236 shape (one entry per shard, baseline URL + sha256 + deltas list + `head_version` + `row_count`), `gh release create data-YYYY.MM.DD` with every file attached, force-pushes `data` branch containing **only** `manifest.json` for jsDelivr consumption, calls the jsDelivr purge endpoint with 3-retry exponential backoff (2s, 8s, 30s), and files a `cdn-purge-failed` issue on final failure.
+6. **Dry-run mode** (`workflow_dispatch` input `dry_run=true`, default `false`): stops after the `diff-package` job and uploads every artifact to the workflow run instead of creating a release. Used to prove the pipeline runs green before enabling the cron schedule.
+
+**Tech Stack:** GitHub Actions, `actions/setup-python@v5`, `actions/checkout@v4`, `actions/upload-artifact@v4` / `download-artifact@v4`, `actions/cache@v4`, `gh` CLI (pre-installed on runners), Python 3.11, DuckDB (already a pipeline dep), `zstd` (apt), `sqlite3` (apt). No new runtime deps.
+
+**Spec ref:** `docs/superpowers/specs/2026-04-18-sku-design.md` §3 *Update flow (daily)* (entire flow), §3 *Manifest structure* (line 234+ — authoritative output shape), §3 *Reliability* (line 269 — idempotent stages, graceful degradation), §7 *Workflows* (line 1018+ — `data-daily.yml` entry).
+
+**Explicit non-goals for m3a.4.2** (declared up front to prevent scope creep):
+- Validation job (job 4 in spec §3): full cross-check vs upstream re-fetch → `m3a.4.3`. This plan's `diff-package` job runs only a **lightweight sanity check** (row-count within ±5% of 30-day moving average, schema-shape match, FK integrity) — spec §3 line 198 describes it. Full upstream re-fetch comparisons land with `data-validate.yml`.
+- OIDC federation (AWS IAM role / GCP WIF): not needed for the fetchers in this plan — AWS pricing is anonymous, Azure retail-prices is anonymous, GCP uses an API key secret, OpenRouter is anonymous. OIDC is only introduced in `m3a.4.3` where the validation harness needs SigV4-signed `GetProducts` calls.
+- Client-side `internal/updater` changes: delta-chain walking + ETag caching + stable/daily channel split → `m3a.4.3`. This plan ships the *server-side* half of those features (emitting the manifest + deltas); the client keeps the one-shot baseline flow m3a.3 extracted into `internal/updater.Install`.
+- Code-signing / provenance attestation (`actions/attest-build-provenance`, cosign on shards): deferred to `m7.3-security-bench-release`'s security.yml. The data-release chain currently relies on HTTPS + sha256 manifest entries.
+- Docker multi-arch images, Homebrew taps, Scoop buckets, nfpms: all live in `release.yml` for code releases — data releases only publish to GH Releases + the `data` branch.
+- `data-baseline.yml` as a separate workflow file: folded into `data-daily.yml`'s day-of-month branch per spec §3 line 183 (simpler; matches the update-flow diagram over the §7 list).
+
+**Shards covered:** same 17-shard surface as m3a.4.1 (`openrouter` + 7 AWS + 5 Azure + 5 GCP). No new shards; this is workflow plumbing.
+
+---
+
+## File Structure
+
+| Path | Responsibility |
+|---|---|
+| `.github/actions/setup-pipeline/action.yml` | **Create**: composite action — checkout, setup-python, pip cache, `pip install -e pipeline[dev]`. |
+| `.github/workflows/data-daily.yml` | **Create**: the five-job workflow (discover → ingest → diff-package → publish), cron + workflow_dispatch triggers, dry-run input. |
+| `pipeline/package/build_delta.py` | **Create**: DuckDB script that attaches two SQLite shards (prev + new), emits upsert + delete rows into a `.sql.gz` delta. Splits deltas >8 MB into part files. |
+| `pipeline/package/build_manifest.py` | **Create**: assembles `manifest.json` per spec §3 shape from the set of built artifacts. |
+| `pipeline/package/sanity_check.py` | **Create**: ±5% row-count guard vs prior release, schema-shape match, FK integrity check. Called from the `diff-package` job per shard. |
+| `pipeline/tests/test_build_delta.py` | **Create**: two synthetic SQLite shards → diff → apply delta → verify result equals target (round-trip). |
+| `pipeline/tests/test_build_manifest.py` | **Create**: fixture artifact tree → manifest with expected keys, correct shas, correct delta chain order. |
+| `pipeline/tests/test_sanity_check.py` | **Create**: row-count drift, schema change, FK orphan — all three failure modes + happy path. |
+| `scripts/ci/purge_jsdelivr.sh` | **Create**: curl-based purge call with 3-retry exponential backoff + GH issue file on failure. |
+| `scripts/ci/previous_release_version.sh` | **Create**: `gh release list --limit 1 --json tagName --jq '.[0].tagName'` → `2026.04.17` (strips `data-` prefix). |
+| `.github/ISSUE_TEMPLATE/cdn-purge-failed.md` | **Create**: issue template used when jsDelivr purge retries are exhausted. |
+| `docs/ops/data-daily-runbook.md` | **Create**: maintainer runbook — required secrets, how to kick a dry-run, how to disable cron, how to manually re-publish. |
+| `CLAUDE.md` | **Modify**: bump milestone pointer to M3a.4.2, add `gh workflow run data-daily.yml` entrypoint. |
+
+---
+
+## Preflight
+
+- [ ] **Step 1: Fresh branch from green main.**
+
+```bash
+git pull --ff-only origin main
+git checkout -b m3a.4.2-data-daily-workflow
+```
+
+- [ ] **Step 2: Confirm m3a.4.1 has landed.**
+
+```bash
+test -d pipeline/discover || (echo "m3a.4.1 not merged — abort" && exit 2)
+grep -q "^  pipeline:" .github/workflows/ci.yml || (echo "m3a.4.1 CI job missing — abort" && exit 2)
+```
+
+- [ ] **Step 3: Repository secrets inventory.**
+
+Confirm these secrets exist on the repo (via `gh secret list`):
+- `GCP_BILLING_API_KEY` — read-only API key restricted to `cloudbilling.googleapis.com`. If missing, follow the runbook (Task 10) to create it now; GCP shards will error out otherwise.
+- `GITHUB_TOKEN` — auto-injected by Actions; no action needed.
+
+No OIDC secrets are required by this plan (m3a.4.3 adds them).
+
+---
+
+## Task 1: Composite setup-pipeline action
+
+**Files:**
+- Create: `.github/actions/setup-pipeline/action.yml`
+
+- [ ] **Step 1: Write the action.**
+
+```yaml
+name: "setup-pipeline"
+description: "Install Python 3.11 and the sku-pipeline package"
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: pip
+        cache-dependency-path: pipeline/pyproject.toml
+    - name: Install pipeline package
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e 'pipeline[dev]'
+    - name: Install OS tooling (duckdb cli, zstd, jq)
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends zstd jq
+```
+
+DuckDB's CLI is not needed — the pipeline uses the Python package. `sqlite3` is pre-installed on ubuntu-latest. `gh` is pre-installed.
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add .github/actions/setup-pipeline/action.yml
+git commit -m "ci: composite action for pipeline Python setup"
+```
+
+---
+
+## Task 2: `pipeline/package/build_delta.py`
+
+**Files:**
+- Create: `pipeline/package/build_delta.py`
+- Create: `pipeline/tests/test_build_delta.py`
+
+**Contract:**
+
+```python
+# pipeline/package/build_delta.py
+
+def build_delta(prev_db: Path, new_db: Path, out_sql_gz: Path, *, max_bytes: int = 8 * 1024 * 1024) -> list[Path]:
+    """Emit a gzipped SQL delta that transforms `prev_db` into `new_db`.
+
+    Produces `UPDATE/INSERT/DELETE` statements over the `skus` and `prices`
+    tables (§5 schema). Uses DuckDB with two SQLite shards attached:
+
+        INSTALL sqlite; LOAD sqlite;
+        ATTACH '<prev>' AS prev (TYPE SQLITE);
+        ATTACH '<new>'  AS curr (TYPE SQLITE);
+
+    For each of `skus`, `prices`:
+      - Rows in curr not in prev  → `INSERT OR REPLACE INTO ...`
+      - Rows in prev not in curr  → `DELETE FROM ... WHERE sku_id = ...`
+      - Rows whose hash differs   → `INSERT OR REPLACE INTO ...`
+    `metadata` table is replayed in full (small, changes every release).
+
+    Returns the list of part files written. If the gzipped size exceeds
+    `max_bytes`, splits by row into `<out>-part1.sql.gz`, `<out>-part2.sql.gz`
+    etc., each ≤ `max_bytes`, in apply-order.
+    """
+```
+
+- [ ] **Step 1: Unit tests (TDD).**
+
+`pipeline/tests/test_build_delta.py`:
+- Build two synthetic SQLite shards via `sqlite3` — same schema, 10 rows vs 12 rows (2 inserted, 1 updated, 0 deleted). Run `build_delta`; apply the resulting `.sql.gz` to a copy of `prev_db` via `sqlite3 prev.db < decompressed.sql`; assert final bytes match `new_db` (excluding `metadata` table, per spec §6 line 951).
+- Delete case: 10 rows → 7 rows → delta contains 3 DELETE statements, no INSERT/UPDATE.
+- Split case: force `max_bytes=256`; 20-row diff → expect ≥2 part files, each ≤ ~256 bytes decompressed; applying them in order reconstructs `new_db`.
+- Empty diff (prev == curr) → single 0-row `.sql.gz` containing only the metadata replay + a header comment `-- noop`; downstream manifest still lists it.
+
+- [ ] **Step 2: Implement `build_delta`.**
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add pipeline/package/build_delta.py pipeline/tests/test_build_delta.py
+git commit -m "feat(pipeline): build_delta emits SQL.gz deltas between shards"
+```
+
+---
+
+## Task 3: `pipeline/package/build_manifest.py`
+
+**Files:**
+- Create: `pipeline/package/build_manifest.py`
+- Create: `pipeline/tests/test_build_manifest.py`
+
+**Contract:**
+
+```python
+def build_manifest(
+    *,
+    artifacts_dir: Path,   # dist/pipeline/release/
+    out: Path,             # dist/pipeline/release/manifest.json
+    catalog_version: str,  # "2026.04.18"
+    release_base_url: str, # "https://github.com/sofq/sku/releases/download/data-2026.04.18"
+    previous_manifest: Path | None,   # from previous release; used for baseline_version + deltas carry-forward
+    min_binary_version: str,
+    shard_schema_version: int = 1,
+) -> None:
+    """Assemble manifest.json per spec §3 structure:
+
+        {
+          "schema_version": 1,
+          "generated_at": "...",
+          "catalog_version": "2026.04.18",
+          "shards": {
+            "aws-ec2": {
+              "baseline_version": ...,
+              "baseline_url": ...,
+              "baseline_sha256": ...,
+              "baseline_size": ...,
+              "head_version": ...,
+              "min_binary_version": ...,
+              "shard_schema_version": 1,
+              "deltas": [{"from": ..., "to": ..., "url": ..., "sha256": ..., "size": ...}],
+              "row_count": ...,
+              "last_updated": "..."
+            }
+          }
+        }
+    """
+```
+
+The function walks `artifacts_dir` (built by `diff-package` matrix), computes sha256 + size for every `.db.zst` + `.sql.gz`, carries `deltas[]` forward from `previous_manifest` (new deltas appended, stale ones trimmed when a baseline is rebuilt).
+
+- [ ] **Step 1: Unit tests (TDD).**
+  - Fresh first release (no previous manifest): every shard has `baseline_url` + empty `deltas` + `head_version == baseline_version == catalog_version`.
+  - Normal day (yesterday's manifest + today's delta per shard): `baseline_version` preserved; `deltas` extended by 1; `head_version` == today's catalog_version.
+  - Baseline-rebuild day: `baseline_url` replaced; `deltas: []`; `baseline_version == head_version`.
+  - SHA256 + size entries match the bytes on disk.
+  - `shards` dict is sorted alphabetically (reviewer-friendly diffs).
+
+- [ ] **Step 2: Implement.**
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add pipeline/package/build_manifest.py pipeline/tests/test_build_manifest.py
+git commit -m "feat(pipeline): build_manifest per spec §3 structure"
+```
+
+---
+
+## Task 4: `pipeline/package/sanity_check.py`
+
+**Files:**
+- Create: `pipeline/package/sanity_check.py`
+- Create: `pipeline/tests/test_sanity_check.py`
+
+**Contract:**
+
+```python
+def sanity_check(
+    *,
+    shard_db: Path,
+    previous_db: Path | None,
+    tolerance_pct: float = 5.0,
+) -> None:
+    """Spec §3 line 198 lightweight sanity check. Raises SanityError on:
+      - Row count delta > tolerance_pct vs previous.
+      - Schema mismatch (CREATE TABLE DDL differs).
+      - FK orphan (any skus.sku_id referenced by prices missing).
+      - metadata.generated_at not populated.
+    Noop on first release (previous_db is None).
+    """
+```
+
+- [ ] **Step 1: Unit tests (TDD):** happy path, row-count spike, schema drift, FK orphan. Confirm exceptions carry the shard name for downstream issue-filing.
+
+- [ ] **Step 2: Implement.**
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add pipeline/package/sanity_check.py pipeline/tests/test_sanity_check.py
+git commit -m "feat(pipeline): sanity_check — daily drift guard per spec §3"
+```
+
+---
+
+## Task 5: `scripts/ci/*` helpers
+
+**Files:**
+- Create: `scripts/ci/purge_jsdelivr.sh`
+- Create: `scripts/ci/previous_release_version.sh`
+
+- [ ] **Step 1: Write `previous_release_version.sh`.**
+
+```bash
+#!/usr/bin/env bash
+# Print the catalog_version of the most recent data release (stripping the `data-` prefix).
+# Exit 0 with empty output when no prior release exists (first-ever run).
+set -euo pipefail
+tag=$(gh release list --limit 50 --json tagName,name --jq '[.[] | select(.tagName | startswith("data-"))] | .[0].tagName // ""')
+echo "${tag#data-}"
+```
+
+- [ ] **Step 2: Write `purge_jsdelivr.sh`.**
+
+```bash
+#!/usr/bin/env bash
+# Purge jsDelivr edges for /gh/sofq/sku@latest/data/manifest.json.
+# 3 retries with exponential backoff (2s, 8s, 30s). On final failure, file
+# an issue via gh (template: .github/ISSUE_TEMPLATE/cdn-purge-failed.md).
+set -euo pipefail
+URL="https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json"
+for attempt in 1 2 3; do
+  if curl --fail --silent --show-error "$URL"; then
+    echo "jsdelivr purge OK on attempt $attempt"
+    exit 0
+  fi
+  case $attempt in 1) sleep 2;; 2) sleep 8;; 3) sleep 30;; esac
+done
+echo "jsdelivr purge FAILED after 3 attempts" >&2
+gh issue create \
+  --title "jsDelivr cache purge failed for catalog $(date -u +%Y-%m-%d)" \
+  --label "pipeline,cdn-purge-failed" \
+  --body "Automated issue — the daily manifest push succeeded but the jsDelivr purge API did not acknowledge after 3 retries. Users on the CDN fallback may see stale manifest for up to 12h. Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+exit 1
+```
+
+- [ ] **Step 3: Make executable + commit.**
+
+```bash
+chmod +x scripts/ci/*.sh
+git add scripts/ci/*.sh
+git commit -m "ci: jsdelivr purge + previous-release helpers"
+```
+
+---
+
+## Task 6: Issue template for CDN failures
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/cdn-purge-failed.md`
+
+- [ ] **Step 1: Write the template.**
+
+```markdown
+---
+name: CDN purge failed (automated)
+about: jsDelivr cache purge failed after 3 retries
+title: "jsDelivr cache purge failed for catalog <YYYY-MM-DD>"
+labels: ["pipeline", "cdn-purge-failed"]
+---
+
+The daily data release succeeded but the jsDelivr purge API did not acknowledge after 3 retries with exponential backoff (2s, 8s, 30s).
+
+**Impact:** Users pinned to `cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` may see stale manifest for up to 12h. The release-asset URL (`github.com/sofq/sku/releases/latest/download/manifest.json`) is unaffected.
+
+**Action:** run `scripts/ci/purge_jsdelivr.sh` manually from a maintainer machine with `gh` authenticated, or `curl` the purge endpoint directly. Close this issue once verified.
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add .github/ISSUE_TEMPLATE/cdn-purge-failed.md
+git commit -m "ci: issue template for cdn-purge-failed"
+```
+
+---
+
+## Task 7: `data-daily.yml` — discover + ingest jobs
+
+**Files:**
+- Create: `.github/workflows/data-daily.yml`
+
+- [ ] **Step 1: Write the skeleton (header + discover + ingest only, diff-package/publish come in Task 8).**
+
+```yaml
+name: data-daily
+
+on:
+  schedule:
+    # DISABLED until one workflow_dispatch run proves the pipeline green.
+    # Re-enable by uncommenting in Task 12 of this plan.
+    # - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Stop before publish step; artifacts only"
+        required: false
+        default: "false"
+      force_baseline:
+        description: "Force baseline rebuild regardless of day-of-month"
+        required: false
+        default: "false"
+
+permissions:
+  contents: write        # gh release create + data branch push
+  issues:   write        # cdn-purge-failed issue filing
+  actions:  read
+
+concurrency:
+  group: data-daily
+  cancel-in-progress: false    # never cancel a release mid-publish
+
+env:
+  CATALOG_VERSION: ""          # set in discover job
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      shards:            ${{ steps.discover.outputs.shards }}
+      baseline_rebuild:  ${{ steps.discover.outputs.baseline_rebuild }}
+      catalog_version:   ${{ steps.discover.outputs.catalog_version }}
+      previous_version:  ${{ steps.previous.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+      - name: Resolve previous release version
+        id: previous
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(scripts/ci/previous_release_version.sh)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Restore prior discover state
+        if: steps.previous.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist/pipeline/discover
+          gh release download "data-${{ steps.previous.outputs.version }}" \
+            --pattern 'discover-state.json' \
+            --dir dist/pipeline/discover || true
+          ls -la dist/pipeline/discover/
+      - name: Discover changed shards
+        id: discover
+        env:
+          GCP_BILLING_API_KEY: ${{ secrets.GCP_BILLING_API_KEY }}
+          BASELINE_REBUILD: ${{ github.event.inputs.force_baseline || '' }}
+          DAY_OF_MONTH: ${{ steps.date.outputs.day }}
+        run: |
+          today=$(date -u +%Y.%m.%d)
+          # baseline on 1st/15th or when no prior state exists or when user forced it
+          bl="false"
+          if [ "$BASELINE_REBUILD" = "true" ]; then bl="true"; fi
+          dom=$(date -u +%d)
+          if [ "$dom" = "01" ] || [ "$dom" = "15" ]; then bl="true"; fi
+          if [ ! -f dist/pipeline/discover/state.json ]; then bl="true"; fi
+          flag=""
+          if [ "$bl" = "true" ]; then flag="--baseline-rebuild"; fi
+
+          python -m pipeline.discover \
+            --state dist/pipeline/discover/state.json \
+            --out   dist/pipeline/discover/changed.json \
+            --live  $flag
+
+          shards=$(jq -c '.shards' dist/pipeline/discover/changed.json)
+          brl=$(jq -r '.baseline_rebuild' dist/pipeline/discover/changed.json)
+          echo "shards=$shards"           >> "$GITHUB_OUTPUT"
+          echo "baseline_rebuild=$brl"    >> "$GITHUB_OUTPUT"
+          echo "catalog_version=$today"   >> "$GITHUB_OUTPUT"
+      - name: Upload discover artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: discover
+          path: dist/pipeline/discover/
+          retention-days: 14
+
+  ingest:
+    needs: discover
+    if: fromJSON(needs.discover.outputs.shards) != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.discover.outputs.shards) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+      - name: Fetch upstream + ingest + package
+        env:
+          GCP_BILLING_API_KEY: ${{ secrets.GCP_BILLING_API_KEY }}
+          SHARD:             ${{ matrix.shard }}
+          CATALOG_VERSION:   ${{ needs.discover.outputs.catalog_version }}
+          SOURCE_DATE_EPOCH: ${{ github.event.repository.pushed_at }}   # or run-start timestamp
+        run: |
+          bash scripts/ci/ingest_shard.sh "$SHARD" "$CATALOG_VERSION"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: shard-${{ matrix.shard }}
+          path: |
+            dist/pipeline/${{ matrix.shard }}.db
+            dist/pipeline/${{ matrix.shard }}.rows.jsonl
+          retention-days: 14
+```
+
+`scripts/ci/ingest_shard.sh` is a new shim (Task 9) that wraps the provider-specific fetch + existing `make shard-live` target.
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add .github/workflows/data-daily.yml
+git commit -m "ci: data-daily.yml discover + ingest jobs"
+```
+
+---
+
+## Task 8: `data-daily.yml` — diff-package + publish jobs
+
+**Files:**
+- Modify: `.github/workflows/data-daily.yml`
+
+- [ ] **Step 1: Append the `diff_package` job.**
+
+```yaml
+  diff_package:
+    needs: [discover, ingest]
+    if: fromJSON(needs.discover.outputs.shards) != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.discover.outputs.shards) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+      - name: Download today's shard
+        uses: actions/download-artifact@v4
+        with:
+          name: shard-${{ matrix.shard }}
+          path: dist/pipeline/today/
+      - name: Download previous shard baseline
+        if: needs.discover.outputs.previous_version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist/pipeline/prev
+          gh release download "data-${{ needs.discover.outputs.previous_version }}" \
+            --pattern "${{ matrix.shard }}.db.zst" \
+            --dir dist/pipeline/prev/ || echo "no previous shard — baseline rebuild"
+          if [ -f "dist/pipeline/prev/${{ matrix.shard }}.db.zst" ]; then
+            zstd -d "dist/pipeline/prev/${{ matrix.shard }}.db.zst"
+          fi
+      - name: Sanity check + build delta + optional baseline
+        env:
+          SHARD:            ${{ matrix.shard }}
+          CATALOG_VERSION:  ${{ needs.discover.outputs.catalog_version }}
+          PREVIOUS_VERSION: ${{ needs.discover.outputs.previous_version }}
+          BASELINE_REBUILD: ${{ needs.discover.outputs.baseline_rebuild }}
+        run: bash scripts/ci/diff_package_shard.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.shard }}
+          path: dist/pipeline/release/
+          retention-days: 14
+```
+
+- [ ] **Step 2: Append the `publish` job.**
+
+```yaml
+  publish:
+    needs: [discover, diff_package]
+    if: github.event.inputs.dry_run != 'true' && fromJSON(needs.discover.outputs.shards) != '[]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist/pipeline/release/
+      - uses: actions/download-artifact@v4
+        with:
+          name: discover
+          path: dist/pipeline/discover/
+      - name: Build manifest.json
+        env:
+          CATALOG_VERSION:  ${{ needs.discover.outputs.catalog_version }}
+          PREVIOUS_VERSION: ${{ needs.discover.outputs.previous_version }}
+          MIN_BINARY:       "1.0.0"
+          GH_TOKEN:         ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/build_manifest.sh
+      - name: Create release
+        env:
+          CATALOG_VERSION: ${{ needs.discover.outputs.catalog_version }}
+          GH_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "data-${CATALOG_VERSION}" \
+            --title "Data release ${CATALOG_VERSION}" \
+            --notes "Automated daily data release. See manifest.json for shard inventory." \
+            dist/pipeline/release/*
+          gh release upload "data-${CATALOG_VERSION}" \
+            dist/pipeline/discover/state.json \
+            --clobber
+      - name: Mirror manifest to data branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/push_data_branch.sh
+      - name: Purge jsDelivr cache
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/purge_jsdelivr.sh
+```
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add .github/workflows/data-daily.yml
+git commit -m "ci: data-daily.yml diff-package + publish jobs"
+```
+
+---
+
+## Task 9: Per-job shell shims
+
+**Files:**
+- Create: `scripts/ci/ingest_shard.sh`
+- Create: `scripts/ci/diff_package_shard.sh`
+- Create: `scripts/ci/build_manifest.sh`
+- Create: `scripts/ci/push_data_branch.sh`
+
+All are ~40-line bash scripts; keeping them out of the YAML improves readability and lets them be unit-testable from `make`.
+
+- [ ] **Step 1: `ingest_shard.sh`** — maps `SHARD=aws_ec2` → `--offer`, `SHARD=azure_vm` → `--prices`, etc.; calls the matching `fetch_*` helper via a tiny Python one-liner; then `make shard-live SHARD=$SHARD SRC=<fetched-path>`. Reads `CATALOG_VERSION` into `--catalog-version`.
+
+- [ ] **Step 2: `diff_package_shard.sh`** — runs `python -m pipeline.package.sanity_check`; runs `python -m pipeline.package.build_delta` if previous exists; on baseline rebuild (or no previous) `zstd -19 --long=27 today/$SHARD.db -o release/$SHARD.db.zst && sha256sum release/$SHARD.db.zst > release/$SHARD.db.zst.sha256`.
+
+- [ ] **Step 3: `build_manifest.sh`** — fetches previous manifest via `gh release download data-$PREVIOUS_VERSION --pattern manifest.json`; runs `python -m pipeline.package.build_manifest` with all required flags; puts `manifest.json` alongside the shards.
+
+- [ ] **Step 4: `push_data_branch.sh`** — creates an orphan checkout of `data` branch (or initialises it on first ever push), replaces `manifest.json`, force-pushes. Key details:
+
+```bash
+set -euo pipefail
+DATA_BRANCH=data
+MANIFEST_SRC=dist/pipeline/release/manifest.json
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+git init -q
+git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git checkout -q --orphan "$DATA_BRANCH"
+git rm -rfq . 2>/dev/null || true
+mkdir -p data
+cp "$GITHUB_WORKSPACE/$MANIFEST_SRC" data/manifest.json
+git add data/manifest.json
+git -c user.email=bot@sku -c user.name=sku-data-bot commit -q -m "data-${CATALOG_VERSION}"
+git push -qf origin "$DATA_BRANCH"
+```
+
+- [ ] **Step 5: Make executable + commit.**
+
+```bash
+chmod +x scripts/ci/*.sh
+git add scripts/ci/*.sh
+git commit -m "ci: per-job shell shims for data-daily"
+```
+
+---
+
+## Task 10: `docs/ops/data-daily-runbook.md`
+
+**Files:**
+- Create: `docs/ops/data-daily-runbook.md`
+
+- [ ] **Step 1: Write the runbook covering:**
+
+1. **Secrets required:** `GCP_BILLING_API_KEY` — how to create it (Google Cloud Console → APIs & Services → Credentials → Create API key → restrict to Cloud Billing API → add to repo secrets as `GCP_BILLING_API_KEY`).
+2. **First green run:** dispatch via `gh workflow run data-daily.yml -F dry_run=true` to build artifacts without publishing; verify the artifacts on the Actions run page; re-dispatch with `dry_run=false` to actually publish.
+3. **Enabling cron:** uncomment the `- cron: "0 3 * * *"` line in `data-daily.yml` (Task 12 of this plan). The first cron fire will tail-end after the manual green run.
+4. **Disabling on incident:** `gh workflow disable data-daily.yml`. Cron pauses; publish chain stops.
+5. **Manual republish of a specific day:** dispatch with `force_baseline=true` (rebuilds everything as a baseline and publishes a fresh release tagged today).
+6. **Recovering a purge-failed state:** resolve the auto-filed `cdn-purge-failed` issue by running `curl https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` from any maintainer box.
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add docs/ops/data-daily-runbook.md
+git commit -m "docs: data-daily runbook (secrets, first run, incident recovery)"
+```
+
+---
+
+## Task 11: Dry-run from a draft PR
+
+**Files:** none
+
+- [ ] **Step 1: Push the branch, open a draft PR.**
+
+```bash
+git push -u origin m3a.4.2-data-daily-workflow
+gh pr create --draft \
+  --title "M3a.4.2 (draft): data-daily.yml end-to-end" \
+  --body "Draft — verifying workflow via dispatch before enabling cron."
+```
+
+- [ ] **Step 2: Dispatch a dry run from the PR branch.**
+
+```bash
+gh workflow run data-daily.yml --ref "$(git rev-parse --abbrev-ref HEAD)" \
+  -F dry_run=true -F force_baseline=true
+gh run watch
+```
+
+Expected: discover + ingest (17 parallel) + diff-package (17 parallel) all green; publish job skipped. Artifact `release-*` contains 17 `.db.zst` + 17 `.sha256` + (where applicable) 17 `.sql.gz` files.
+
+- [ ] **Step 3: Inspect artifacts for sanity.**
+
+Download the `release-aws-ec2` artifact; verify `.db.zst` decompresses to a valid SQLite shard; `sqlite3 aws-ec2.db '.tables'` should show `skus`, `prices`, `metadata`; row counts are non-zero and within an order of magnitude of what `make aws-ec2-shard` produces from fixtures (the live shard is much larger).
+
+- [ ] **Step 4: Dispatch a publish run (non-dry).**
+
+```bash
+gh workflow run data-daily.yml --ref "$(git rev-parse --abbrev-ref HEAD)" \
+  -F dry_run=false -F force_baseline=true
+gh run watch
+```
+
+Expected: publish job green; a new `data-YYYY.MM.DD` release exists; the `data` branch has `data/manifest.json`; `curl https://cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` returns the new file within ~30s of the purge step.
+
+- [ ] **Step 5: If anything failed, diagnose and iterate before proceeding. Do NOT enable cron until Steps 3 and 4 are green.**
+
+---
+
+## Task 12: Enable cron schedule
+
+**Files:**
+- Modify: `.github/workflows/data-daily.yml`
+
+- [ ] **Step 1: Uncomment the cron line** after Task 11 is fully green.
+
+```yaml
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    ...
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add .github/workflows/data-daily.yml
+git commit -m "ci: enable daily cron for data-daily.yml"
+```
+
+---
+
+## Task 13: CLAUDE.md + milestone pointer
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update "Current milestone" + add runbook link.**
+
+```markdown
+## Current milestone
+
+M3a.4.2 — `data-daily.yml` cron workflow publishes daily data releases:
+- Discover → Ingest (matrix) → Diff+Package (matrix) → Publish.
+- Emits `data-YYYY.MM.DD` GitHub release with shard .db.zst + .sql.gz deltas +
+  manifest.json.
+- Mirrors manifest to `data` branch for jsDelivr fallback; purges CDN on
+  each publish.
+- Dry-runs via `gh workflow run data-daily.yml -F dry_run=true`.
+- Runbook: `docs/ops/data-daily-runbook.md`.
+
+Next: M3a.4.3 — `data-validate.yml` (OIDC cross-check vs upstream) +
+client-side `internal/updater` delta-chain walking + ETag + channels.
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: bump CLAUDE.md to m3a.4.2"
+```
+
+---
+
+## Task 14: Exit verification + PR
+
+**Files:** none
+
+- [ ] **Step 1: Confirm cron-enabled PR is still green.**
+
+```bash
+gh pr checks --watch
+```
+
+- [ ] **Step 2: Mark ready for review, write release-style PR body.**
+
+```bash
+gh pr ready
+gh pr edit --title "M3a.4.2: data-daily.yml end-to-end data release workflow" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- `data-daily.yml` cron workflow (03:00 UTC + `workflow_dispatch`) now publishes a `data-YYYY.MM.DD` GitHub release every day: discover → ingest (matrix over changed shards) → diff+package → publish manifest + shards + deltas.
+- New Python modules: `pipeline/package/build_delta.py` (DuckDB SQL.gz diff), `pipeline/package/build_manifest.py` (spec §3 manifest shape), `pipeline/package/sanity_check.py` (row-count + schema + FK drift guard).
+- `data` branch carries `manifest.json` only; jsDelivr fallback mirrored on every publish, with retry + auto-issue on purge failure.
+- Composite action `.github/actions/setup-pipeline` removes Python-setup duplication.
+- Runbook: `docs/ops/data-daily-runbook.md`.
+
+This was verified end-to-end on this branch before merge: one `dry_run=true` dispatch produced artifacts, then a `dry_run=false` dispatch produced release `data-YYYY.MM.DD` (see PR checks for the workflow-run links).
+
+## Test plan
+
+- [x] All Python unit tests green (`make pipeline-test`).
+- [x] `workflow_dispatch` with `dry_run=true` produces all release artifacts.
+- [x] `workflow_dispatch` with `dry_run=false` publishes a real release.
+- [x] `data` branch updated; `cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json` returns the new file after purge.
+- [x] Cron schedule enabled (final commit on branch).
+
+## Non-goals
+
+- OIDC-based validation cross-check (→ m3a.4.3).
+- Client `internal/updater` delta-chain walking (→ m3a.4.3).
+EOF
+)"
+```
+
+- [ ] **Step 3: Merge.**
+
+---
+
+## Post-merge next step
+
+Hand off to `m3a.4.3`:
+
+```bash
+claude -p "$(cat docs/superpowers/plans/2026-04-18-m3a.4.3-validate-and-updater.md)"
+```

--- a/pipeline/discover/aws.py
+++ b/pipeline/discover/aws.py
@@ -31,7 +31,7 @@ def discover(shards: Iterable[str], *, session: requests.Session | None = None) 
         out: dict[str, str] = {}
         for shard in shards:
             service = _AWS_SERVICE_CODES[shard]
-            url = f"{_AWS_OFFER_BASE}/{service}/current/index.json"
+            url = f"{_AWS_OFFER_BASE}/{service}/index.json"
             resp = session.get(url, headers={"User-Agent": _UA}, timeout=60)
             if resp.status_code != 200:
                 raise RuntimeError(f"aws_discover_http_{resp.status_code}: {url}")

--- a/pipeline/ingest/_duckdb.py
+++ b/pipeline/ingest/_duckdb.py
@@ -27,7 +27,6 @@ def _terms_hash_udf(
 def open_conn() -> duckdb.DuckDBPyConnection:
     """Return an in-memory conn with `sku_terms_hash(...)` bound as a scalar UDF."""
     con = duckdb.connect(":memory:")
-    con.execute("SET memory_limit='4GB'")
     con.execute("SET temp_directory='/tmp/sku_duckdb'")
     con.create_function(
         "sku_terms_hash",

--- a/pipeline/ingest/_duckdb.py
+++ b/pipeline/ingest/_duckdb.py
@@ -10,12 +10,14 @@ import duckdb
 
 from normalize.terms import terms_hash
 
-# Spill directory for intermediate hash joins / aggregations when the large
-# AWS offer files blow past memory_limit. Without this, DuckDB falls back to
-# the system RAM ceiling (~80% of runner RAM = ~12 GiB on ubuntu-latest) and
-# OOMs before spilling. See d574924 post-mortem in M3a.4.2 runbook.
+# ubuntu-latest has ~16 GiB RAM. DuckDB's default cap (~80%) OOMs the runner
+# on large AWS offers. A 4 GiB cap was too tight — non-spillable ops hit it
+# mid-query. 8 GiB + 2 threads + preserve_insertion_order=false keeps total
+# footprint well under the runner ceiling while letting hash joins and
+# aggregations spill to _TEMP_DIR. See M3a.4.2 runbook.
 _TEMP_DIR = "/tmp/sku_duckdb"
-_MEMORY_LIMIT = "4GB"
+_MEMORY_LIMIT = "8GB"
+_THREADS = 2
 
 
 def _terms_hash_udf(
@@ -38,6 +40,8 @@ def open_conn() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect(":memory:")
     con.execute(f"SET memory_limit='{_MEMORY_LIMIT}'")
     con.execute(f"SET temp_directory='{_TEMP_DIR}'")
+    con.execute(f"SET threads={_THREADS}")
+    con.execute("SET preserve_insertion_order=false")
     con.create_function(
         "sku_terms_hash",
         _terms_hash_udf,

--- a/pipeline/ingest/_duckdb.py
+++ b/pipeline/ingest/_duckdb.py
@@ -27,6 +27,8 @@ def _terms_hash_udf(
 def open_conn() -> duckdb.DuckDBPyConnection:
     """Return an in-memory conn with `sku_terms_hash(...)` bound as a scalar UDF."""
     con = duckdb.connect(":memory:")
+    con.execute("SET memory_limit='4GB'")
+    con.execute("SET temp_directory='/tmp/sku_duckdb'")
     con.create_function(
         "sku_terms_hash",
         _terms_hash_udf,

--- a/pipeline/ingest/_duckdb.py
+++ b/pipeline/ingest/_duckdb.py
@@ -3,11 +3,19 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
 
 import duckdb
 
 from normalize.terms import terms_hash
+
+# Spill directory for intermediate hash joins / aggregations when the large
+# AWS offer files blow past memory_limit. Without this, DuckDB falls back to
+# the system RAM ceiling (~80% of runner RAM = ~12 GiB on ubuntu-latest) and
+# OOMs before spilling. See d574924 post-mortem in M3a.4.2 runbook.
+_TEMP_DIR = "/tmp/sku_duckdb"
+_MEMORY_LIMIT = "4GB"
 
 
 def _terms_hash_udf(
@@ -26,8 +34,10 @@ def _terms_hash_udf(
 
 def open_conn() -> duckdb.DuckDBPyConnection:
     """Return an in-memory conn with `sku_terms_hash(...)` bound as a scalar UDF."""
+    os.makedirs(_TEMP_DIR, exist_ok=True)
     con = duckdb.connect(":memory:")
-    con.execute("SET temp_directory='/tmp/sku_duckdb'")
+    con.execute(f"SET memory_limit='{_MEMORY_LIMIT}'")
+    con.execute(f"SET temp_directory='{_TEMP_DIR}'")
     con.create_function(
         "sku_terms_hash",
         _terms_hash_udf,

--- a/pipeline/ingest/aws_cloudfront.py
+++ b/pipeline/ingest/aws_cloudfront.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_cloudfront.py
+++ b/pipeline/ingest/aws_cloudfront.py
@@ -81,12 +81,14 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'})"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
     )
 
     grouped: dict[tuple[str, str], dict[str, Any]] = {}
 
     for sku_id, location_raw, unit, usd, begin_range in con.execute(_SQL).fetchall():
+        if location_raw is None:
+            continue
         if location_raw not in LOCATION_MAP:
             raise KeyError(location_raw)
         region = LOCATION_MAP[location_raw]

--- a/pipeline/ingest/aws_cloudfront.py
+++ b/pipeline/ingest/aws_cloudfront.py
@@ -94,7 +94,8 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
         region = LOCATION_MAP[location_raw]
         if begin_range not in (None, "0"):
             continue
-        normalizer.normalize(_PROVIDER, region)
+        if normalizer.try_normalize(_PROVIDER, region) is None:
+            continue  # skip regions outside our coverage map
         key = ("standard", region)
         grouped[key] = {"sku": sku_id, "usd": usd, "unit": unit}
 

--- a/pipeline/ingest/aws_common.py
+++ b/pipeline/ingest/aws_common.py
@@ -29,6 +29,15 @@ class RegionNormalizer:
         except KeyError as exc:
             raise KeyError(f"{provider}/{region}") from exc
 
+    def try_normalize(self, provider: str, region: str) -> str | None:
+        """Return canonical group, or None when the region is not tracked.
+
+        Live AWS/Azure/GCP price feeds include regions outside our coverage
+        (new launches, opt-in regions, etc.). Ingest callers use this helper
+        to skip those rows instead of failing the whole shard.
+        """
+        return self.table.get((provider, region))
+
 
 def load_region_normalizer() -> RegionNormalizer:
     """Load the repo's regions.yaml and build a (provider, region) -> group map."""

--- a/pipeline/ingest/aws_common.py
+++ b/pipeline/ingest/aws_common.py
@@ -6,10 +6,12 @@ import contextlib
 import json
 import os
 import time
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
+import ijson
 import requests
 import yaml
 
@@ -67,10 +69,25 @@ _RETRY_STATUSES = {500, 502, 503, 504}
 
 def fetch_offer(
     shard: str, target: Path, *, session: requests.Session | None = None, retries: int = 3
-) -> str:
-    """Download an AWS offer index.json for `shard` into `target`."""
+) -> None:
+    """Download an AWS offer index.json for `shard` into `target`.
+
+    Streams to disk in 64 KiB chunks — we never hold the file in memory because
+    some offers (AmazonEC2 = 8+ GB) would OOM a 16 GiB runner.
+    """
     service_code = _AWS_SERVICE_CODES[shard]
     url = f"{_AWS_OFFER_BASE}/{service_code}/current/index.json"
+    _stream_download(url, target, session=session, retries=retries)
+
+
+def _stream_download(
+    url: str,
+    target: Path,
+    *,
+    session: requests.Session | None = None,
+    retries: int = 3,
+) -> None:
+    """Stream `url` to `target` atomically, with retry on 5xx and truncation check."""
     if session is None:
         session = requests.Session()
     ua = "sku-pipeline/0.0 (+https://github.com/sofq/sku)"
@@ -78,12 +95,7 @@ def fetch_offer(
     last: Exception | None = None
     for attempt in range(retries):
         try:
-            resp = session.get(
-                url,
-                stream=True,
-                timeout=60,
-                headers={"User-Agent": ua},
-            )
+            resp = session.get(url, stream=True, timeout=60, headers={"User-Agent": ua})
         except requests.RequestException as exc:
             last = exc
             time.sleep(0.5 * 2**attempt)
@@ -113,8 +125,159 @@ def fetch_offer(
             raise RuntimeError(
                 f"GET {url} truncated: got {actual_length} bytes, expected {declared_length}"
             )
-        with part.open() as fh:
-            doc = json.load(fh)
         os.replace(part, target)
-        return doc["publicationDate"]
+        return
     raise RuntimeError(f"GET {url} failed after {retries} attempts: {last}")
+
+
+# ---------------------------------------------------------------------------
+# Per-region stripped offer fetch (m3a.4.2 OOM fix)
+# ---------------------------------------------------------------------------
+#
+# AmazonEC2 combined offer is 8.4 GB. Loading it in any form — DuckDB json_each
+# or Python json.load — overflows the 16 GB runner. AWS also publishes per-region
+# index.json files (~400 MB each) via `region_index.json`. We fetch each per-region
+# file, stream-parse it with ijson, and write a trimmed JSON containing only the
+# ~12 leaf fields our ingesters consume. Peak memory: one product dict at a time
+# (~KBs). Peak disk: ~400 MB raw + ~30 MB stripped; raw is deleted after strip.
+
+# Which AWS service codes support per-region offers (i.e. have a region_index.json).
+_PER_REGION_AWS_OFFERS: frozenset[str] = frozenset({"AmazonEC2"})
+
+# Product-family allowlist per shard — drives the ingesters' consumed rows.
+# Kept here (not per-ingester) so one stripped file can serve multiple ingesters
+# (aws_ec2 + aws_ebs both read the AmazonEC2 offer, one is Compute Instance,
+# the other is Storage). Extra families filtered at ingest time.
+_EC2_PRODUCT_FAMILIES: frozenset[str] = frozenset({"Compute Instance", "Storage"})
+
+# Leaf attributes any AWS ingester consumes under products.<sku>.attributes.
+# Superset across aws_ec2 (Compute Instance) + aws_ebs (Storage). Keeping the
+# superset means one stripped file per region works for both shards without
+# re-fetching upstream.
+_EC2_KEEP_ATTRS: frozenset[str] = frozenset(
+    {
+        "instanceType",
+        "regionCode",
+        "operatingSystem",
+        "tenancy",
+        "preInstalledSw",
+        "capacitystatus",
+        "vcpu",
+        "memory",
+        "physicalProcessor",
+        "networkPerformance",
+        "volumeApiName",
+    }
+)
+
+
+def fetch_offer_regions_stripped(
+    shard: str,
+    out_dir: Path,
+    *,
+    regions: Iterable[str],
+    session: requests.Session | None = None,
+    retries: int = 3,
+) -> list[Path]:
+    """Fetch per-region AWS offer files for `shard`, stream-strip to JSON.
+
+    For each region in `regions`, download that region's `index.json`, parse it
+    with ijson, write a trimmed JSON of the same shape (products/terms.OnDemand
+    with only the leaf fields we consume) to `out_dir/{shard}-{region}.json`.
+    Raw per-region downloads are deleted after stripping.
+
+    Skips regions not listed in the upstream `region_index.json` (e.g. new
+    AWS regions not yet in a shard's offer). Returns the list of stripped
+    output paths that were successfully produced.
+    """
+    service_code = _AWS_SERVICE_CODES[shard]
+    if service_code not in _PER_REGION_AWS_OFFERS:
+        raise ValueError(f"per-region offer not supported for shard {shard!r}")
+    if session is None:
+        session = requests.Session()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    region_index_url = f"{_AWS_OFFER_BASE}/{service_code}/current/region_index.json"
+    raw_index = out_dir / f"{shard}-region_index.json"
+    _stream_download(region_index_url, raw_index, session=session, retries=retries)
+    index_doc = json.loads(raw_index.read_text())
+    raw_index.unlink(missing_ok=True)
+
+    upstream_regions: dict[str, str] = {
+        code: entry["currentVersionUrl"]
+        for code, entry in (index_doc.get("regions") or {}).items()
+    }
+
+    produced: list[Path] = []
+    for region in regions:
+        rel_url = upstream_regions.get(region)
+        if rel_url is None:
+            continue
+        region_url = f"https://pricing.us-east-1.amazonaws.com{rel_url}"
+        raw_path = out_dir / f"{shard}-{region}.raw.json"
+        try:
+            _stream_download(region_url, raw_path, session=session, retries=retries)
+            stripped_path = out_dir / f"{shard}-{region}.json"
+            _strip_ec2_offer(raw_path, stripped_path)
+            produced.append(stripped_path)
+        finally:
+            raw_path.unlink(missing_ok=True)
+    return produced
+
+
+def _strip_ec2_offer(raw_path: Path, out_path: Path) -> None:
+    """Stream-parse an AWS EC2-shape offer JSON, emit a trimmed version.
+
+    Keeps:
+      - products.<sku>.productFamily + whitelisted attributes leaves
+        (filtered to families actually consumed — Compute Instance, Storage).
+      - terms.OnDemand.<sku>.<termKey>.priceDimensions.<pdKey>.{unit, pricePerUnit}
+      - top-level offerCode, version, publicationDate for traceability.
+
+    Drops: terms.Reserved (bulk of terms), product attrs we don't consume,
+    offerTermCode, rateCode, effectiveDate, termAttributes, appliesTo,
+    priceDimensions.description/beginRange/endRange, etc.
+    """
+    products_kept: dict[str, dict[str, Any]] = {}
+    with raw_path.open("rb") as fh:
+        for sku_id, product in ijson.kvitems(fh, "products", use_float=True):
+            family = product.get("productFamily")
+            if family not in _EC2_PRODUCT_FAMILIES:
+                continue
+            attrs_raw = product.get("attributes") or {}
+            products_kept[sku_id] = {
+                "productFamily": family,
+                "attributes": {k: attrs_raw[k] for k in _EC2_KEEP_ATTRS if k in attrs_raw},
+            }
+
+    terms_kept: dict[str, dict[str, Any]] = {}
+    with raw_path.open("rb") as fh:
+        for sku_id, term_data in ijson.kvitems(fh, "terms.OnDemand", use_float=True):
+            if sku_id not in products_kept:
+                continue
+            stripped_terms: dict[str, dict[str, Any]] = {}
+            for term_key, term_obj in (term_data or {}).items():
+                pds_in = (term_obj or {}).get("priceDimensions") or {}
+                stripped_pds = {
+                    pd_key: {
+                        "unit": pd_obj.get("unit"),
+                        "pricePerUnit": pd_obj.get("pricePerUnit") or {},
+                    }
+                    for pd_key, pd_obj in pds_in.items()
+                }
+                stripped_terms[term_key] = {"priceDimensions": stripped_pds}
+            terms_kept[sku_id] = stripped_terms
+
+    out_doc = {
+        "products": products_kept,
+        "terms": {"OnDemand": terms_kept},
+    }
+    part = out_path.with_suffix(out_path.suffix + ".part")
+    part.write_text(json.dumps(out_doc, separators=(",", ":")))
+    os.replace(part, out_path)
+
+
+def aws_regions_from_yaml() -> list[str]:
+    """Distinct AWS regions referenced by regions.yaml (sorted)."""
+    normalizer = load_region_normalizer()
+    return sorted({region for (provider, region) in normalizer.table if provider == "aws"})

--- a/pipeline/ingest/aws_dynamodb.py
+++ b/pipeline/ingest/aws_dynamodb.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_dynamodb.py
+++ b/pipeline/ingest/aws_dynamodb.py
@@ -40,38 +40,32 @@ _GROUP_MAP: dict[str, str] = {
 }
 
 _SQL = """
-WITH prod_keys AS (
-  SELECT unnest(json_keys(products)) AS sku_id, products, terms FROM offer
-),
-products_flat AS (
+WITH products_flat AS (
   SELECT
-    sku_id,
-    json_extract_string(products, '$."' || sku_id || '".attributes.regionCode') AS region,
-    json_extract_string(products, '$."' || sku_id || '".attributes.storageClass') AS klass_raw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.group') AS group_raw,
-    terms
-  FROM prod_keys
+    p.key AS sku_id,
+    json_extract_string(p.value, '$.attributes.regionCode') AS region,
+    json_extract_string(p.value, '$.attributes.storageClass') AS klass_raw,
+    json_extract_string(p.value, '$.attributes.group') AS group_raw
+  FROM offer, json_each(offer.products) AS p(key, value)
 ),
-term_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms, '$.OnDemand."' || sku_id || '"'))[1] AS term_key
-  FROM products_flat
+terms_flat AS (
+  SELECT
+    t.key AS sku_id,
+    (json_keys(t.value))[1] AS term_key,
+    t.value AS term_obj
+  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
 ),
 pd_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms,
-      '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions'))[1] AS pd_key
-  FROM term_keys
+  SELECT tf.sku_id, tf.term_key, tf.term_obj,
+    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
+  FROM terms_flat tf
 )
-SELECT sku_id, region, klass_raw, group_raw,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".unit') AS unit,
-  CAST(json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".pricePerUnit.USD')
-    AS DOUBLE) AS usd,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".beginRange') AS begin_range
-FROM pd_keys
+SELECT pf.sku_id, pf.region, pf.klass_raw, pf.group_raw,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
+  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".beginRange') AS begin_range
+FROM products_flat pf
+JOIN pd_keys pk ON pf.sku_id = pk.sku_id
 """
 
 

--- a/pipeline/ingest/aws_dynamodb.py
+++ b/pipeline/ingest/aws_dynamodb.py
@@ -89,7 +89,8 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
             continue
         if dim == "storage" and begin_range not in (None, "0"):
             continue
-        normalizer.normalize(_PROVIDER, region)
+        if normalizer.try_normalize(_PROVIDER, region) is None:
+            continue
         key = (klass, region)
         grouped.setdefault(key, {})[dim] = {"sku": sku_id, "usd": usd, "unit": unit}
 

--- a/pipeline/ingest/aws_ebs.py
+++ b/pipeline/ingest/aws_ebs.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_ebs.py
+++ b/pipeline/ingest/aws_ebs.py
@@ -25,37 +25,32 @@ _KIND = "storage.block"
 _ALLOWED_TYPES: set[str] = {"gp3", "gp2", "io2", "st1", "sc1"}
 
 _SQL = """
-WITH prod_keys AS (
-  SELECT unnest(json_keys(products)) AS sku_id, products, terms FROM offer
-),
-products_flat AS (
+WITH products_flat AS (
   SELECT
-    sku_id,
-    json_extract_string(products, '$."' || sku_id || '".productFamily') AS family,
-    json_extract_string(products, '$."' || sku_id || '".attributes.regionCode') AS region,
-    json_extract_string(products, '$."' || sku_id || '".attributes.volumeApiName') AS vol_type,
-    terms
-  FROM prod_keys
+    p.key AS sku_id,
+    json_extract_string(p.value, '$.productFamily') AS family,
+    json_extract_string(p.value, '$.attributes.regionCode') AS region,
+    json_extract_string(p.value, '$.attributes.volumeApiName') AS vol_type
+  FROM offer, json_each(offer.products) AS p(key, value)
+  WHERE json_extract_string(p.value, '$.productFamily') = 'Storage'
 ),
-term_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms, '$.OnDemand."' || sku_id || '"'))[1] AS term_key
-  FROM products_flat
+terms_flat AS (
+  SELECT
+    t.key AS sku_id,
+    (json_keys(t.value))[1] AS term_key,
+    t.value AS term_obj
+  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
 ),
 pd_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms,
-      '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions'))[1] AS pd_key
-  FROM term_keys
+  SELECT tf.sku_id, tf.term_key, tf.term_obj,
+    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
+  FROM terms_flat tf
 )
-SELECT sku_id, region, vol_type,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".unit') AS unit,
-  CAST(json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".pricePerUnit.USD')
-    AS DOUBLE) AS usd
-FROM pd_keys
-WHERE family = 'Storage'
+SELECT pf.sku_id, pf.region, pf.vol_type,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
+  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
+FROM products_flat pf
+JOIN pd_keys pk ON pf.sku_id = pk.sku_id
 """
 
 

--- a/pipeline/ingest/aws_ebs.py
+++ b/pipeline/ingest/aws_ebs.py
@@ -1,13 +1,15 @@
-"""Normalize AWS EBS offer JSON into sku row dicts via DuckDB.
+"""Normalize AWS EBS rows out of the EC2 offer JSON (pure Python).
 
-Spec §5 storage.block kind. In m3a.2 each row carries only the storage
-dimension (GB-Mo); IOPS + throughput pricing -> m3a.3. One row per
-(volume_type, region); volume_type comes from attributes.volumeApiName.
+Spec §5 storage.block. EBS shares the AmazonEC2 offer with aws_ec2 — we use
+the same stripped per-region files. Each row carries only the storage dimension
+(GB-Mo); IOPS + throughput pricing -> m3a.3. One row per (volume_type, region);
+volume_type comes from attributes.volumeApiName.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -16,8 +18,9 @@ from typing import Any
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
 
-from ._duckdb import dumps, open_conn
-from .aws_common import load_region_normalizer
+from ._duckdb import dumps
+from .aws_common import aws_regions_from_yaml, fetch_offer_regions_stripped, load_region_normalizer
+from .aws_ec2 import _iter_product_prices
 
 _PROVIDER = "aws"
 _SERVICE = "ebs"
@@ -25,99 +28,98 @@ _KIND = "storage.block"
 
 _ALLOWED_TYPES: set[str] = {"gp3", "gp2", "io2", "st1", "sc1"}
 
-_SQL = """
-WITH products_flat AS (
-  SELECT
-    p.key AS sku_id,
-    json_extract_string(p.value, '$.productFamily') AS family,
-    json_extract_string(p.value, '$.attributes.regionCode') AS region,
-    json_extract_string(p.value, '$.attributes.volumeApiName') AS vol_type
-  FROM offer, json_each(offer.products) AS p(key, value)
-  WHERE json_extract_string(p.value, '$.productFamily') = 'Storage'
-),
-terms_flat AS (
-  SELECT
-    t.key AS sku_id,
-    (json_keys(t.value))[1] AS term_key,
-    t.value AS term_obj
-  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
-),
-pd_keys AS (
-  SELECT tf.sku_id, tf.term_key, tf.term_obj,
-    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
-  FROM terms_flat tf
-)
-SELECT pf.sku_id, pf.region, pf.vol_type,
-  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
-  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
-FROM products_flat pf
-JOIN pd_keys pk ON pf.sku_id = pk.sku_id
-"""
 
-
-def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
+def ingest(*, offer_paths: Iterable[Path]) -> Iterable[dict[str, Any]]:
     normalizer = load_region_normalizer()
-    con = open_conn()
-    path_literal = str(offer_path).replace("'", "''")
-    con.execute(
-        f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
-    )
+    for offer_path in offer_paths:
+        with offer_path.open() as fh:
+            offer = json.load(fh)
+        for sku_id, product, pd in _iter_product_prices(offer):
+            if product.get("productFamily") != "Storage":
+                continue
+            attrs = product.get("attributes") or {}
+            vol_type = attrs.get("volumeApiName")
+            if vol_type not in _ALLOWED_TYPES:
+                continue
+            region = attrs.get("regionCode", "")
+            region_normalized = normalizer.try_normalize(_PROVIDER, region)
+            if region_normalized is None:
+                continue
 
-    rows = list(con.execute(_SQL).fetchall())
-    # Filter first to allowed types so any non-EBS "Storage" family rows in
-    # the same offer file (e.g. RDS storage SKUs when the source is shared)
-    # don't trip the region validator.
-    rows = [r for r in rows if r[2] in _ALLOWED_TYPES]
+            unit = pd.get("unit") or ""
+            usd_raw = (pd.get("pricePerUnit") or {}).get("USD")
+            if usd_raw is None:
+                continue
+            try:
+                usd = float(usd_raw)
+            except (TypeError, ValueError):
+                continue
 
-    for sku_id, region, vol_type, unit, usd in rows:
-        region_normalized = normalizer.try_normalize(_PROVIDER, region)
-        if region_normalized is None:
-            continue
-        terms = apply_kind_defaults(_KIND, {
-            "commitment": "on_demand",
-            "tenancy": "",
-            "os": "",
-            "support_tier": "",
-            "upfront": "",
-            "payment_option": "",
-        })
-        yield {
-            "sku_id": sku_id,
-            "provider": _PROVIDER,
-            "service": _SERVICE,
-            "kind": _KIND,
-            "resource_name": vol_type,
-            "region": region,
-            "region_normalized": region_normalized,
-            "terms_hash": terms_hash(terms),
-            "resource_attrs": {
-                "extra": {"volume_type": vol_type},
-            },
-            "terms": terms,
-            "prices": [
-                {"dimension": "storage", "tier": "", "amount": usd, "unit": unit.lower()},
-            ],
-        }
+            terms = apply_kind_defaults(_KIND, {
+                "commitment": "on_demand",
+                "tenancy": "",
+                "os": "",
+                "support_tier": "",
+                "upfront": "",
+                "payment_option": "",
+            })
+            yield {
+                "sku_id": sku_id,
+                "provider": _PROVIDER,
+                "service": _SERVICE,
+                "kind": _KIND,
+                "resource_name": vol_type,
+                "region": region,
+                "region_normalized": region_normalized,
+                "terms_hash": terms_hash(terms),
+                "resource_attrs": {
+                    "extra": {"volume_type": vol_type},
+                },
+                "terms": terms,
+                "prices": [
+                    {"dimension": "storage", "tier": "", "amount": usd, "unit": unit.lower()},
+                ],
+            }
+
+
+def _resolve_paths(args: argparse.Namespace) -> list[Path]:
+    if args.offer_dir:
+        return sorted(p for p in args.offer_dir.glob("aws_ebs-*.json") if p.is_file())
+    if args.fixture:
+        p = args.fixture
+        return [p / "offer.json"] if p.is_dir() else [p]
+    if args.offer:
+        return [args.offer]
+    return []
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(prog="ingest.aws_ebs")
     ap.add_argument("--fixture", type=Path)
     ap.add_argument("--offer", type=Path)
+    ap.add_argument(
+        "--offer-dir",
+        type=Path,
+        help="directory to fetch stripped per-region offers into (if empty, fetches).",
+    )
     ap.add_argument("--out", type=Path, required=True)
     ap.add_argument("--catalog-version", default=None)
     args = ap.parse_args()
-    if args.fixture:
-        offer_path = args.fixture / "offer.json" if args.fixture.is_dir() else args.fixture
-    elif args.offer:
-        offer_path = args.offer
-    else:
-        print("either --fixture or --offer required", file=sys.stderr)
+
+    if args.offer_dir is not None and not any(args.offer_dir.glob("aws_ebs-*.json")):
+        args.offer_dir.mkdir(parents=True, exist_ok=True)
+        fetch_offer_regions_stripped(
+            "aws_ebs", args.offer_dir, regions=aws_regions_from_yaml()
+        )
+
+    paths = _resolve_paths(args)
+    if not paths:
+        print("either --fixture, --offer, or --offer-dir required", file=sys.stderr)
         return 2
+
     args.out.parent.mkdir(parents=True, exist_ok=True)
     with args.out.open("w") as fh:
-        for row in ingest(offer_path=offer_path):
+        for row in ingest(offer_paths=paths):
             fh.write(dumps(row) + "\n")
     return 0
 

--- a/pipeline/ingest/aws_ebs.py
+++ b/pipeline/ingest/aws_ebs.py
@@ -70,7 +70,9 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     rows = [r for r in rows if r[2] in _ALLOWED_TYPES]
 
     for sku_id, region, vol_type, unit, usd in rows:
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": "",

--- a/pipeline/ingest/aws_ebs.py
+++ b/pipeline/ingest/aws_ebs.py
@@ -65,7 +65,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'})"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
     )
 
     rows = list(con.execute(_SQL).fetchall())

--- a/pipeline/ingest/aws_ec2.py
+++ b/pipeline/ingest/aws_ec2.py
@@ -31,45 +31,42 @@ _OS_MAP: dict[str, str] = {"Linux": "linux", "Windows": "windows", "RHEL": "rhel
 _TENANCY_MAP: dict[str, str] = {"Shared": "shared", "Dedicated": "dedicated"}
 
 _SQL = """
-WITH prod_keys AS (
-  SELECT unnest(json_keys(products)) AS sku_id, products, terms FROM offer
-),
-products_flat AS (
+WITH products_flat AS (
   SELECT
-    sku_id,
-    json_extract_string(products, '$."' || sku_id || '".productFamily') AS family,
-    json_extract_string(products, '$."' || sku_id || '".attributes.instanceType') AS instance_type,
-    json_extract_string(products, '$."' || sku_id || '".attributes.regionCode') AS region,
-    json_extract_string(products, '$."' || sku_id || '".attributes.operatingSystem') AS os_raw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.tenancy') AS tenancy_raw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.preInstalledSw') AS pre_sw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.capacitystatus') AS cap,
-    json_extract_string(products, '$."' || sku_id || '".attributes.vcpu') AS vcpu,
-    json_extract_string(products, '$."' || sku_id || '".attributes.memory') AS memory,
-    json_extract_string(products, '$."' || sku_id || '".attributes.physicalProcessor') AS cpu,
-    json_extract_string(products, '$."' || sku_id || '".attributes.networkPerformance') AS net,
-    terms
-  FROM prod_keys
+    p.key AS sku_id,
+    json_extract_string(p.value, '$.productFamily') AS family,
+    json_extract_string(p.value, '$.attributes.instanceType') AS instance_type,
+    json_extract_string(p.value, '$.attributes.regionCode') AS region,
+    json_extract_string(p.value, '$.attributes.operatingSystem') AS os_raw,
+    json_extract_string(p.value, '$.attributes.tenancy') AS tenancy_raw,
+    json_extract_string(p.value, '$.attributes.preInstalledSw') AS pre_sw,
+    json_extract_string(p.value, '$.attributes.capacitystatus') AS cap,
+    json_extract_string(p.value, '$.attributes.vcpu') AS vcpu,
+    json_extract_string(p.value, '$.attributes.memory') AS memory,
+    json_extract_string(p.value, '$.attributes.physicalProcessor') AS cpu,
+    json_extract_string(p.value, '$.attributes.networkPerformance') AS net
+  FROM offer, json_each(offer.products) AS p(key, value)
+  WHERE json_extract_string(p.value, '$.productFamily') = 'Compute Instance'
+    AND json_extract_string(p.value, '$.attributes.preInstalledSw') = 'NA'
+    AND json_extract_string(p.value, '$.attributes.capacitystatus') = 'Used'
 ),
-term_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms, '$.OnDemand."' || sku_id || '"'))[1] AS term_key
-  FROM products_flat
+terms_flat AS (
+  SELECT
+    t.key AS sku_id,
+    (json_keys(t.value))[1] AS term_key,
+    t.value AS term_obj
+  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
 ),
 pd_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms,
-      '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions'))[1] AS pd_key
-  FROM term_keys
+  SELECT tf.sku_id, tf.term_key, tf.term_obj,
+    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
+  FROM terms_flat tf
 )
-SELECT sku_id, instance_type, region, os_raw, tenancy_raw, vcpu, memory, cpu, net,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".unit') AS unit,
-  CAST(json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".pricePerUnit.USD')
-    AS DOUBLE) AS usd
-FROM pd_keys
-WHERE family = 'Compute Instance' AND pre_sw = 'NA' AND cap = 'Used'
+SELECT pf.sku_id, pf.instance_type, pf.region, pf.os_raw, pf.tenancy_raw, pf.vcpu, pf.memory, pf.cpu, pf.net,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
+  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
+FROM products_flat pf
+JOIN pd_keys pk ON pf.sku_id = pk.sku_id
 """
 
 

--- a/pipeline/ingest/aws_ec2.py
+++ b/pipeline/ingest/aws_ec2.py
@@ -1,16 +1,16 @@
-"""Normalize AWS EC2 offer JSON into sku row dicts via DuckDB.
+"""Normalize AWS EC2 offer JSON into sku row dicts (pure Python).
 
-Spec §3 (format stack): read the offer's `products` and `terms.OnDemand`
-as JSON columns and navigate them with json_extract — the nested shape
-uses SKU IDs as object keys, so DuckDB infers them as STRUCTs unless we
-force a JSON column type. One SQL pass joins each product with its
-on-demand term + priceDimension entry; Python then filters to the
-supported OS/tenancy surface and emits NDJSON rows.
+The AWS AmazonEC2 offer is ~8 GB combined. `aws_common.fetch_offer_regions_stripped`
+downloads per-region index files, stream-strips each via ijson, and hands us
+small JSON files (~30 MB). Here we iterate those files with `json.load` and
+emit NDJSON rows for our coverage surface (Compute Instance, Linux/Windows/RHEL,
+Shared/Dedicated, On-Demand).
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -19,131 +19,146 @@ from typing import Any
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
 
-from ._duckdb import dumps, open_conn
-from .aws_common import load_region_normalizer
+from ._duckdb import dumps
+from .aws_common import aws_regions_from_yaml, fetch_offer_regions_stripped, load_region_normalizer
 
 _PROVIDER = "aws"
 _SERVICE = "ec2"
 _KIND = "compute.vm"
 
-# Keep the OS mapping narrow — only variants we ship in v1.
 _OS_MAP: dict[str, str] = {"Linux": "linux", "Windows": "windows", "RHEL": "rhel"}
-# Tenancy comes through as Shared / Dedicated / Host; we drop Host for m3a.1.
 _TENANCY_MAP: dict[str, str] = {"Shared": "shared", "Dedicated": "dedicated"}
-
-_SQL = """
-WITH products_flat AS (
-  SELECT
-    p.key AS sku_id,
-    json_extract_string(p.value, '$.productFamily') AS family,
-    json_extract_string(p.value, '$.attributes.instanceType') AS instance_type,
-    json_extract_string(p.value, '$.attributes.regionCode') AS region,
-    json_extract_string(p.value, '$.attributes.operatingSystem') AS os_raw,
-    json_extract_string(p.value, '$.attributes.tenancy') AS tenancy_raw,
-    json_extract_string(p.value, '$.attributes.preInstalledSw') AS pre_sw,
-    json_extract_string(p.value, '$.attributes.capacitystatus') AS cap,
-    json_extract_string(p.value, '$.attributes.vcpu') AS vcpu,
-    json_extract_string(p.value, '$.attributes.memory') AS memory,
-    json_extract_string(p.value, '$.attributes.physicalProcessor') AS cpu,
-    json_extract_string(p.value, '$.attributes.networkPerformance') AS net
-  FROM offer, json_each(offer.products) AS p(key, value)
-  WHERE json_extract_string(p.value, '$.productFamily') = 'Compute Instance'
-    AND json_extract_string(p.value, '$.attributes.preInstalledSw') = 'NA'
-    AND json_extract_string(p.value, '$.attributes.capacitystatus') = 'Used'
-),
-terms_flat AS (
-  SELECT
-    t.key AS sku_id,
-    (json_keys(t.value))[1] AS term_key,
-    t.value AS term_obj
-  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
-),
-pd_keys AS (
-  SELECT tf.sku_id, tf.term_key, tf.term_obj,
-    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
-  FROM terms_flat tf
-)
-SELECT pf.sku_id, pf.instance_type, pf.region, pf.os_raw, pf.tenancy_raw, pf.vcpu, pf.memory, pf.cpu, pf.net,
-  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
-  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
-FROM products_flat pf
-JOIN pd_keys pk ON pf.sku_id = pk.sku_id
-"""
 
 
 def _parse_memory(raw: str) -> float:
     return float(raw.split()[0])
 
 
-def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
+def _iter_product_prices(offer: dict[str, Any]) -> Iterable[tuple[str, dict, dict]]:
+    """Yield (sku_id, product, price_dimension) for every On-Demand priced product.
+
+    Works on both the full AWS EC2 offer shape and the stripped shape — both keep
+    `products.<sku>.{productFamily,attributes}` and
+    `terms.OnDemand.<sku>.<termKey>.priceDimensions.<pdKey>.{unit, pricePerUnit}`.
+    """
+    products = offer.get("products") or {}
+    terms_od = (offer.get("terms") or {}).get("OnDemand") or {}
+    for sku_id, product in products.items():
+        term_data = terms_od.get(sku_id)
+        if not term_data:
+            continue
+        term_obj = next(iter(term_data.values()), None) or {}
+        pd = next(iter((term_obj.get("priceDimensions") or {}).values()), None)
+        if pd is None:
+            continue
+        yield sku_id, product, pd
+
+
+def ingest(*, offer_paths: Iterable[Path]) -> Iterable[dict[str, Any]]:
     normalizer = load_region_normalizer()
-    con = open_conn()
-    path_literal = str(offer_path).replace("'", "''")
-    con.execute(
-        f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
-    )
-    for sku_id, instance_type, region, os_raw, tenancy_raw, vcpu_raw, memory_raw, cpu, net, unit, usd in (
-        con.execute(_SQL).fetchall()
-    ):
-        if os_raw not in _OS_MAP or tenancy_raw not in _TENANCY_MAP:
-            continue
-        region_normalized = normalizer.try_normalize(_PROVIDER, region)
-        if region_normalized is None:
-            continue
-        terms = apply_kind_defaults(_KIND, {
-            "commitment": "on_demand",
-            "tenancy": _TENANCY_MAP[tenancy_raw],
-            "os": _OS_MAP[os_raw],
-            "support_tier": "",
-            "upfront": "",
-            "payment_option": "",
-        })
-        yield {
-            "sku_id": sku_id,
-            "provider": _PROVIDER,
-            "service": _SERVICE,
-            "kind": _KIND,
-            "resource_name": instance_type,
-            "region": region,
-            "region_normalized": region_normalized,
-            "terms_hash": terms_hash(terms),
-            "resource_attrs": {
-                "vcpu": int(vcpu_raw),
-                "memory_gb": _parse_memory(memory_raw),
-                "architecture": "x86_64",
-                "extra": {
-                    "physical_processor": cpu,
-                    "network_performance": net,
+    for offer_path in offer_paths:
+        with offer_path.open() as fh:
+            offer = json.load(fh)
+        for sku_id, product, pd in _iter_product_prices(offer):
+            if product.get("productFamily") != "Compute Instance":
+                continue
+            attrs = product.get("attributes") or {}
+            if attrs.get("preInstalledSw") != "NA":
+                continue
+            if attrs.get("capacitystatus") != "Used":
+                continue
+            os_raw = attrs.get("operatingSystem")
+            tenancy_raw = attrs.get("tenancy")
+            if os_raw not in _OS_MAP or tenancy_raw not in _TENANCY_MAP:
+                continue
+            region = attrs.get("regionCode", "")
+            region_normalized = normalizer.try_normalize(_PROVIDER, region)
+            if region_normalized is None:
+                continue
+
+            unit = pd.get("unit") or ""
+            usd_raw = (pd.get("pricePerUnit") or {}).get("USD")
+            if usd_raw is None:
+                continue
+            try:
+                usd = float(usd_raw)
+            except (TypeError, ValueError):
+                continue
+
+            terms = apply_kind_defaults(_KIND, {
+                "commitment": "on_demand",
+                "tenancy": _TENANCY_MAP[tenancy_raw],
+                "os": _OS_MAP[os_raw],
+                "support_tier": "",
+                "upfront": "",
+                "payment_option": "",
+            })
+            yield {
+                "sku_id": sku_id,
+                "provider": _PROVIDER,
+                "service": _SERVICE,
+                "kind": _KIND,
+                "resource_name": attrs.get("instanceType"),
+                "region": region,
+                "region_normalized": region_normalized,
+                "terms_hash": terms_hash(terms),
+                "resource_attrs": {
+                    "vcpu": int(attrs.get("vcpu")),
+                    "memory_gb": _parse_memory(attrs.get("memory", "0")),
+                    "architecture": "x86_64",
+                    "extra": {
+                        "physical_processor": attrs.get("physicalProcessor"),
+                        "network_performance": attrs.get("networkPerformance"),
+                    },
                 },
-            },
-            "terms": terms,
-            "prices": [
-                {"dimension": "compute", "tier": "", "amount": usd, "unit": unit.lower()},
-            ],
-        }
+                "terms": terms,
+                "prices": [
+                    {"dimension": "compute", "tier": "", "amount": usd, "unit": unit.lower()},
+                ],
+            }
+
+
+def _resolve_paths(args: argparse.Namespace) -> list[Path]:
+    """Resolve CLI args → a list of stripped offer-JSON paths ready to feed ingest."""
+    if args.offer_dir:
+        return sorted(p for p in args.offer_dir.glob("aws_ec2-*.json") if p.is_file())
+    if args.fixture:
+        p = args.fixture
+        return [p / "offer.json"] if p.is_dir() else [p]
+    if args.offer:
+        return [args.offer]
+    return []
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(prog="ingest.aws_ec2")
     ap.add_argument("--fixture", type=Path, help="path to a trimmed offer.json (tests)")
-    ap.add_argument("--offer", type=Path, help="path to live offer.json")
+    ap.add_argument("--offer", type=Path, help="single stripped offer.json")
+    ap.add_argument(
+        "--offer-dir",
+        type=Path,
+        help="directory to fetch stripped per-region offers into (if empty, fetches).",
+    )
     ap.add_argument("--out", type=Path, required=True)
     # --catalog-version is consumed by the packager; accept and ignore here.
     ap.add_argument("--catalog-version", default=None)
     args = ap.parse_args()
 
-    if args.fixture:
-        offer_path = args.fixture / "offer.json" if args.fixture.is_dir() else args.fixture
-    elif args.offer:
-        offer_path = args.offer
-    else:
-        print("either --fixture or --offer required", file=sys.stderr)
+    # If offer-dir is given but empty, drive the fetch ourselves.
+    if args.offer_dir is not None and not any(args.offer_dir.glob("aws_ec2-*.json")):
+        args.offer_dir.mkdir(parents=True, exist_ok=True)
+        fetch_offer_regions_stripped(
+            "aws_ec2", args.offer_dir, regions=aws_regions_from_yaml()
+        )
+
+    paths = _resolve_paths(args)
+    if not paths:
+        print("either --fixture, --offer, or --offer-dir required", file=sys.stderr)
         return 2
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     with args.out.open("w") as fh:
-        for row in ingest(offer_path=offer_path):
+        for row in ingest(offer_paths=paths):
             fh.write(dumps(row) + "\n")
     return 0
 

--- a/pipeline/ingest/aws_ec2.py
+++ b/pipeline/ingest/aws_ec2.py
@@ -83,7 +83,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'})"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
     )
     for sku_id, instance_type, region, os_raw, tenancy_raw, vcpu_raw, memory_raw, cpu, net, unit, usd in (
         con.execute(_SQL).fetchall()

--- a/pipeline/ingest/aws_ec2.py
+++ b/pipeline/ingest/aws_ec2.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_ec2.py
+++ b/pipeline/ingest/aws_ec2.py
@@ -87,7 +87,9 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     ):
         if os_raw not in _OS_MAP or tenancy_raw not in _TENANCY_MAP:
             continue
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": _TENANCY_MAP[tenancy_raw],

--- a/pipeline/ingest/aws_lambda.py
+++ b/pipeline/ingest/aws_lambda.py
@@ -73,7 +73,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'})"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
     )
 
     grouped: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}

--- a/pipeline/ingest/aws_lambda.py
+++ b/pipeline/ingest/aws_lambda.py
@@ -1,4 +1,4 @@
-"""Normalize AWS Lambda offer JSON into sku row dicts via DuckDB.
+"""Normalize AWS Lambda offer JSON into sku row dicts.
 
 Spec §5 compute.function kind. Lambda rows carry two price dimensions:
 - requests (unit: requests) from group=AWS-Lambda-Requests
@@ -11,6 +11,7 @@ ephemeral-storage surcharges are out of scope for m3a.2 (see non-goals).
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -19,7 +20,7 @@ from typing import Any
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
 
-from ._duckdb import dumps, open_conn
+from ._duckdb import dumps
 from .aws_common import load_region_normalizer
 
 _PROVIDER = "aws"
@@ -32,56 +33,39 @@ _GROUP_MAP: dict[str, str] = {
     "AWS-Lambda-Duration": "duration",
 }
 
-_SQL = """
-WITH products_flat AS (
-  SELECT
-    p.key AS sku_id,
-    json_extract_string(p.value, '$.productFamily') AS family,
-    json_extract_string(p.value, '$.attributes.regionCode') AS region,
-    json_extract_string(p.value, '$.attributes.archSupport') AS arch_raw,
-    json_extract_string(p.value, '$.attributes.group') AS group_raw
-  FROM offer, json_each(offer.products) AS p(key, value)
-  WHERE json_extract_string(p.value, '$.productFamily') = 'Serverless'
-),
-terms_flat AS (
-  SELECT
-    t.key AS sku_id,
-    (json_keys(t.value))[1] AS term_key,
-    t.value AS term_obj
-  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
-),
-pd_keys AS (
-  SELECT tf.sku_id, tf.term_key, tf.term_obj,
-    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
-  FROM terms_flat tf
-)
-SELECT pf.sku_id, pf.region, pf.arch_raw, pf.group_raw,
-  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
-  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
-FROM products_flat pf
-JOIN pd_keys pk ON pf.sku_id = pk.sku_id
-"""
+
+def _first_pd(term_data: dict) -> dict | None:
+    term = next(iter(term_data.values()), None)
+    if not term:
+        return None
+    return next(iter(term.get("priceDimensions", {}).values()), None)
 
 
 def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     normalizer = load_region_normalizer()
-    con = open_conn()
-    path_literal = str(offer_path).replace("'", "''")
-    con.execute(
-        f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
-    )
+    with offer_path.open() as f:
+        offer = json.load(f)
+    products = offer.get("products", {})
+    terms_od = offer.get("terms", {}).get("OnDemand", {})
 
     grouped: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}
-    for sku_id, region, arch_raw, group_raw, unit, usd in con.execute(_SQL).fetchall():
-        arch = _ARCH_MAP.get(arch_raw)
-        dim = _GROUP_MAP.get(group_raw)
+    for sku_id, product in products.items():
+        if product.get("productFamily") != "Serverless":
+            continue
+        attrs = product.get("attributes", {})
+        region = attrs.get("regionCode", "")
+        arch = _ARCH_MAP.get(attrs.get("archSupport", ""))
+        dim = _GROUP_MAP.get(attrs.get("group", ""))
         if arch is None or dim is None:
             continue
         if normalizer.try_normalize(_PROVIDER, region) is None:
-            continue  # skip regions outside our coverage map
-        key = (arch, region)
-        grouped.setdefault(key, {})[dim] = {"sku": sku_id, "usd": usd, "unit": unit}
+            continue
+        pd = _first_pd(terms_od.get(sku_id) or {})
+        if pd is None:
+            continue
+        usd = float(pd.get("pricePerUnit", {}).get("USD", "0"))
+        unit = pd.get("unit", "")
+        grouped.setdefault((arch, region), {})[dim] = {"sku": sku_id, "usd": usd, "unit": unit}
 
     for (arch, region), dims in sorted(grouped.items()):
         if {"requests", "duration"} - dims.keys():

--- a/pipeline/ingest/aws_lambda.py
+++ b/pipeline/ingest/aws_lambda.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_lambda.py
+++ b/pipeline/ingest/aws_lambda.py
@@ -32,38 +32,33 @@ _GROUP_MAP: dict[str, str] = {
 }
 
 _SQL = """
-WITH prod_keys AS (
-  SELECT unnest(json_keys(products)) AS sku_id, products, terms FROM offer
-),
-products_flat AS (
+WITH products_flat AS (
   SELECT
-    sku_id,
-    json_extract_string(products, '$."' || sku_id || '".productFamily') AS family,
-    json_extract_string(products, '$."' || sku_id || '".attributes.regionCode') AS region,
-    json_extract_string(products, '$."' || sku_id || '".attributes.archSupport') AS arch_raw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.group') AS group_raw,
-    terms
-  FROM prod_keys
+    p.key AS sku_id,
+    json_extract_string(p.value, '$.productFamily') AS family,
+    json_extract_string(p.value, '$.attributes.regionCode') AS region,
+    json_extract_string(p.value, '$.attributes.archSupport') AS arch_raw,
+    json_extract_string(p.value, '$.attributes.group') AS group_raw
+  FROM offer, json_each(offer.products) AS p(key, value)
+  WHERE json_extract_string(p.value, '$.productFamily') = 'Serverless'
 ),
-term_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms, '$.OnDemand."' || sku_id || '"'))[1] AS term_key
-  FROM products_flat
+terms_flat AS (
+  SELECT
+    t.key AS sku_id,
+    (json_keys(t.value))[1] AS term_key,
+    t.value AS term_obj
+  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
 ),
 pd_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms,
-      '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions'))[1] AS pd_key
-  FROM term_keys
+  SELECT tf.sku_id, tf.term_key, tf.term_obj,
+    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
+  FROM terms_flat tf
 )
-SELECT sku_id, region, arch_raw, group_raw,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".unit') AS unit,
-  CAST(json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".pricePerUnit.USD')
-    AS DOUBLE) AS usd
-FROM pd_keys
-WHERE family = 'Serverless'
+SELECT pf.sku_id, pf.region, pf.arch_raw, pf.group_raw,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
+  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
+FROM products_flat pf
+JOIN pd_keys pk ON pf.sku_id = pk.sku_id
 """
 
 

--- a/pipeline/ingest/aws_lambda.py
+++ b/pipeline/ingest/aws_lambda.py
@@ -77,7 +77,8 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
         dim = _GROUP_MAP.get(group_raw)
         if arch is None or dim is None:
             continue
-        normalizer.normalize(_PROVIDER, region)  # early reject on unknown region
+        if normalizer.try_normalize(_PROVIDER, region) is None:
+            continue  # skip regions outside our coverage map
         key = (arch, region)
         grouped.setdefault(key, {})[dim] = {"sku": sku_id, "usd": usd, "unit": unit}
 

--- a/pipeline/ingest/aws_rds.py
+++ b/pipeline/ingest/aws_rds.py
@@ -74,7 +74,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=536870912)"
     )
     for sku_id, instance_type, region, engine_raw, depl_raw, license_model, vcpu_raw, memory_raw, unit, usd in (
         con.execute(_SQL).fetchall()

--- a/pipeline/ingest/aws_rds.py
+++ b/pipeline/ingest/aws_rds.py
@@ -1,4 +1,4 @@
-"""Normalize AWS RDS offer JSON into sku row dicts via DuckDB.
+"""Normalize AWS RDS offer JSON into sku row dicts.
 
 Spec §5 db.relational kind. Engine and deployment-option ride the
 terms.tenancy and terms.os slots — see enums.yaml comment for rationale.
@@ -7,6 +7,7 @@ terms.tenancy and terms.os slots — see enums.yaml comment for rationale.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -15,7 +16,7 @@ from typing import Any
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
 
-from ._duckdb import dumps, open_conn
+from ._duckdb import dumps
 from .aws_common import load_region_normalizer
 
 _PROVIDER = "aws"
@@ -25,56 +26,37 @@ _KIND = "db.relational"
 _ENGINE_MAP = {"PostgreSQL": "postgres", "MySQL": "mysql", "MariaDB": "mariadb"}
 _DEPL_MAP = {"Single-AZ": "single-az", "Multi-AZ": "multi-az"}
 
-_SQL = """
-WITH products_flat AS (
-  SELECT
-    p.key AS sku_id,
-    json_extract_string(p.value, '$.productFamily') AS family,
-    json_extract_string(p.value, '$.attributes.instanceType') AS instance_type,
-    json_extract_string(p.value, '$.attributes.regionCode') AS region,
-    json_extract_string(p.value, '$.attributes.databaseEngine') AS engine_raw,
-    json_extract_string(p.value, '$.attributes.deploymentOption') AS depl_raw,
-    json_extract_string(p.value, '$.attributes.licenseModel') AS license_model,
-    json_extract_string(p.value, '$.attributes.vcpu') AS vcpu,
-    json_extract_string(p.value, '$.attributes.memory') AS memory
-  FROM offer, json_each(offer.products) AS p(key, value)
-  WHERE json_extract_string(p.value, '$.productFamily') = 'Database Instance'
-),
-terms_flat AS (
-  SELECT
-    t.key AS sku_id,
-    (json_keys(t.value))[1] AS term_key,
-    t.value AS term_obj
-  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
-),
-pd_keys AS (
-  SELECT tf.sku_id, tf.term_key, tf.term_obj,
-    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
-  FROM terms_flat tf
-)
-SELECT pf.sku_id, pf.instance_type, pf.region, pf.engine_raw, pf.depl_raw, pf.license_model, pf.vcpu, pf.memory,
-  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
-  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
-FROM products_flat pf
-JOIN pd_keys pk ON pf.sku_id = pk.sku_id
-"""
-
 
 def _parse_memory(raw: str) -> float:
     return float(raw.split()[0])
 
 
+def _first_pd(term_data: dict) -> dict | None:
+    term = next(iter(term_data.values()), None)
+    if not term:
+        return None
+    return next(iter(term.get("priceDimensions", {}).values()), None)
+
+
 def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     normalizer = load_region_normalizer()
-    con = open_conn()
-    path_literal = str(offer_path).replace("'", "''")
-    con.execute(
-        f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=536870912)"
-    )
-    for sku_id, instance_type, region, engine_raw, depl_raw, license_model, vcpu_raw, memory_raw, unit, usd in (
-        con.execute(_SQL).fetchall()
-    ):
+    with offer_path.open() as f:
+        offer = json.load(f)
+    products = offer.get("products", {})
+    terms_od = offer.get("terms", {}).get("OnDemand", {})
+
+    for sku_id, product in products.items():
+        if product.get("productFamily") != "Database Instance":
+            continue
+        attrs = product.get("attributes", {})
+        instance_type = attrs.get("instanceType", "")
+        region = attrs.get("regionCode", "")
+        engine_raw = attrs.get("databaseEngine", "")
+        depl_raw = attrs.get("deploymentOption", "")
+        license_model = attrs.get("licenseModel", "")
+        vcpu_raw = attrs.get("vcpu", "")
+        memory_raw = attrs.get("memory", "")
+
         if license_model and license_model != "No license required":
             continue
         if engine_raw not in _ENGINE_MAP or depl_raw not in _DEPL_MAP:
@@ -82,6 +64,12 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
         region_normalized = normalizer.try_normalize(_PROVIDER, region)
         if region_normalized is None:
             continue
+        pd = _first_pd(terms_od.get(sku_id) or {})
+        if pd is None:
+            continue
+        usd = float(pd.get("pricePerUnit", {}).get("USD", "0"))
+        unit = pd.get("unit", "")
+
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": _ENGINE_MAP[engine_raw],

--- a/pipeline/ingest/aws_rds.py
+++ b/pipeline/ingest/aws_rds.py
@@ -74,7 +74,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'})"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
     )
     for sku_id, instance_type, region, engine_raw, depl_raw, license_model, vcpu_raw, memory_raw, unit, usd in (
         con.execute(_SQL).fetchall()

--- a/pipeline/ingest/aws_rds.py
+++ b/pipeline/ingest/aws_rds.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_rds.py
+++ b/pipeline/ingest/aws_rds.py
@@ -78,7 +78,9 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
             continue
         if engine_raw not in _ENGINE_MAP or depl_raw not in _DEPL_MAP:
             continue
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": _ENGINE_MAP[engine_raw],

--- a/pipeline/ingest/aws_rds.py
+++ b/pipeline/ingest/aws_rds.py
@@ -25,42 +25,37 @@ _ENGINE_MAP = {"PostgreSQL": "postgres", "MySQL": "mysql", "MariaDB": "mariadb"}
 _DEPL_MAP = {"Single-AZ": "single-az", "Multi-AZ": "multi-az"}
 
 _SQL = """
-WITH prod_keys AS (
-  SELECT unnest(json_keys(products)) AS sku_id, products, terms FROM offer
-),
-products_flat AS (
+WITH products_flat AS (
   SELECT
-    sku_id,
-    json_extract_string(products, '$."' || sku_id || '".productFamily') AS family,
-    json_extract_string(products, '$."' || sku_id || '".attributes.instanceType') AS instance_type,
-    json_extract_string(products, '$."' || sku_id || '".attributes.regionCode') AS region,
-    json_extract_string(products, '$."' || sku_id || '".attributes.databaseEngine') AS engine_raw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.deploymentOption') AS depl_raw,
-    json_extract_string(products, '$."' || sku_id || '".attributes.licenseModel') AS license_model,
-    json_extract_string(products, '$."' || sku_id || '".attributes.vcpu') AS vcpu,
-    json_extract_string(products, '$."' || sku_id || '".attributes.memory') AS memory,
-    terms
-  FROM prod_keys
+    p.key AS sku_id,
+    json_extract_string(p.value, '$.productFamily') AS family,
+    json_extract_string(p.value, '$.attributes.instanceType') AS instance_type,
+    json_extract_string(p.value, '$.attributes.regionCode') AS region,
+    json_extract_string(p.value, '$.attributes.databaseEngine') AS engine_raw,
+    json_extract_string(p.value, '$.attributes.deploymentOption') AS depl_raw,
+    json_extract_string(p.value, '$.attributes.licenseModel') AS license_model,
+    json_extract_string(p.value, '$.attributes.vcpu') AS vcpu,
+    json_extract_string(p.value, '$.attributes.memory') AS memory
+  FROM offer, json_each(offer.products) AS p(key, value)
+  WHERE json_extract_string(p.value, '$.productFamily') = 'Database Instance'
 ),
-term_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms, '$.OnDemand."' || sku_id || '"'))[1] AS term_key
-  FROM products_flat
+terms_flat AS (
+  SELECT
+    t.key AS sku_id,
+    (json_keys(t.value))[1] AS term_key,
+    t.value AS term_obj
+  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
 ),
 pd_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms,
-      '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions'))[1] AS pd_key
-  FROM term_keys
+  SELECT tf.sku_id, tf.term_key, tf.term_obj,
+    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
+  FROM terms_flat tf
 )
-SELECT sku_id, instance_type, region, engine_raw, depl_raw, license_model, vcpu, memory,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".unit') AS unit,
-  CAST(json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".pricePerUnit.USD')
-    AS DOUBLE) AS usd
-FROM pd_keys
-WHERE family = 'Database Instance'
+SELECT pf.sku_id, pf.instance_type, pf.region, pf.engine_raw, pf.depl_raw, pf.license_model, pf.vcpu, pf.memory,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
+  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd
+FROM products_flat pf
+JOIN pd_keys pk ON pf.sku_id = pk.sku_id
 """
 
 

--- a/pipeline/ingest/aws_s3.py
+++ b/pipeline/ingest/aws_s3.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/aws_s3.py
+++ b/pipeline/ingest/aws_s3.py
@@ -120,7 +120,8 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
                 continue
         else:
             continue
-        normalizer.normalize(_PROVIDER, region)  # early reject on unknown region
+        if normalizer.try_normalize(_PROVIDER, region) is None:
+            continue  # skip regions outside our coverage map
         key = (klass, region)
         grouped.setdefault(key, {})[dim] = {
             "sku": sku_id, "usd": usd, "unit": unit, "volume_type": volume_type,

--- a/pipeline/ingest/aws_s3.py
+++ b/pipeline/ingest/aws_s3.py
@@ -60,40 +60,34 @@ _REQUEST_GROUP_MAP: dict[str, str] = {
 # on-demand term has one non-tiered priceDimension per SKU for the m3a.2
 # scope (first tier only for storage); we take the first pd_key.
 _SQL = """
-WITH prod_keys AS (
-  SELECT unnest(json_keys(products)) AS sku_id, products, terms FROM offer
-),
-products_flat AS (
+WITH products_flat AS (
   SELECT
-    sku_id,
-    json_extract_string(products, '$."' || sku_id || '".productFamily') AS family,
-    json_extract_string(products, '$."' || sku_id || '".attributes.regionCode') AS region,
-    json_extract_string(products, '$."' || sku_id || '".attributes.volumeType') AS volume_type,
-    json_extract_string(products, '$."' || sku_id || '".attributes.group') AS group_raw,
-    terms
-  FROM prod_keys
+    p.key AS sku_id,
+    json_extract_string(p.value, '$.productFamily') AS family,
+    json_extract_string(p.value, '$.attributes.regionCode') AS region,
+    json_extract_string(p.value, '$.attributes.volumeType') AS volume_type,
+    json_extract_string(p.value, '$.attributes.group') AS group_raw
+  FROM offer, json_each(offer.products) AS p(key, value)
+  WHERE json_extract_string(p.value, '$.productFamily') IN ('Storage', 'API Request')
 ),
-term_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms, '$.OnDemand."' || sku_id || '"'))[1] AS term_key
-  FROM products_flat
+terms_flat AS (
+  SELECT
+    t.key AS sku_id,
+    (json_keys(t.value))[1] AS term_key,
+    t.value AS term_obj
+  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
 ),
 pd_keys AS (
-  SELECT *,
-    json_keys(json_extract(terms,
-      '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions'))[1] AS pd_key
-  FROM term_keys
+  SELECT tf.sku_id, tf.term_key, tf.term_obj,
+    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
+  FROM terms_flat tf
 )
-SELECT sku_id, family, region, volume_type, group_raw,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".unit') AS unit,
-  CAST(json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".pricePerUnit.USD')
-    AS DOUBLE) AS usd,
-  json_extract_string(terms,
-    '$.OnDemand."' || sku_id || '"."' || term_key || '".priceDimensions."' || pd_key || '".beginRange') AS begin_range
-FROM pd_keys
-WHERE family IN ('Storage', 'API Request')
+SELECT pf.sku_id, pf.family, pf.region, pf.volume_type, pf.group_raw,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
+  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd,
+  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".beginRange') AS begin_range
+FROM products_flat pf
+JOIN pd_keys pk ON pf.sku_id = pk.sku_id
 """
 
 

--- a/pipeline/ingest/aws_s3.py
+++ b/pipeline/ingest/aws_s3.py
@@ -103,7 +103,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     path_literal = str(offer_path).replace("'", "''")
     con.execute(
         f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'})"
+        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
     )
 
     # Collect: (storage_class, region) -> {"storage": {sku,usd,unit,volume_type}, ...}

--- a/pipeline/ingest/azure_blob.py
+++ b/pipeline/ingest/azure_blob.py
@@ -93,7 +93,8 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
         dim = _dim_for(meter_name)
         if dim is None:
             continue
-        normalizer.normalize(_PROVIDER, region)  # early reject on unknown region
+        if normalizer.try_normalize(_PROVIDER, region) is None:
+            continue  # skip regions outside our coverage map
         if dim == "storage":
             divisor, unit = parse_storage_uom(uom)
         else:

--- a/pipeline/ingest/azure_blob.py
+++ b/pipeline/ingest/azure_blob.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/azure_common.py
+++ b/pipeline/ingest/azure_common.py
@@ -117,6 +117,15 @@ def fetch_prices(filter_str: str, target: Path, *, session=None, retries: int = 
             for attempt in range(retries):
                 try:
                     resp = sess.get(url, headers=headers, timeout=15.0)
+                    if resp.status_code == 429:
+                        retry_after = resp.headers.get("Retry-After")
+                        delay = float(retry_after) if retry_after else (0.5 * 2**attempt * 10)
+                        if attempt < retries - 1:
+                            time.sleep(delay)
+                            continue
+                        raise RuntimeError(
+                            f"GET {url} failed with status 429 after {retries} attempts"
+                        )
                     if resp.status_code in _RETRY_STATUSES:
                         if attempt < retries - 1:
                             time.sleep(0.5 * 2**attempt)

--- a/pipeline/ingest/azure_disks.py
+++ b/pipeline/ingest/azure_disks.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/azure_disks.py
+++ b/pipeline/ingest/azure_disks.py
@@ -65,7 +65,9 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
         if disk_type is None:
             continue  # Ultra + reserved + others skipped
         divisor, unit = parse_storage_uom(uom)
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": "",

--- a/pipeline/ingest/azure_functions.py
+++ b/pipeline/ingest/azure_functions.py
@@ -70,7 +70,8 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
         dim = _DIM_MAP.get(meter_name)
         if dim is None:
             continue
-        normalizer.normalize(_PROVIDER, region)
+        if normalizer.try_normalize(_PROVIDER, region) is None:
+            continue  # skip regions outside our coverage map
         if dim == "executions":
             divisor, unit = parse_request_uom(uom)
             amount = price / divisor

--- a/pipeline/ingest/azure_functions.py
+++ b/pipeline/ingest/azure_functions.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/azure_sql.py
+++ b/pipeline/ingest/azure_sql.py
@@ -61,6 +61,7 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
     con = open_conn()
     path_literal = str(prices_path).replace("'", "''")
     sql = _SQL.replace("{path}", path_literal)
+    seen: set[str] = set()
     for (
         sku_id, sku_name, region, product, price, uom, currency, row_type, service_name,
     ) in con.execute(sql).fetchall():
@@ -80,6 +81,9 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
             divisor, unit = parse_unit_of_measure(uom)
         except ValueError:
             continue  # skip non-hourly meters (monthly, per-request, etc.)
+        if sku_id in seen:
+            continue
+        seen.add(sku_id)
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": "azure-sql",

--- a/pipeline/ingest/azure_sql.py
+++ b/pipeline/ingest/azure_sql.py
@@ -76,7 +76,10 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
         region_normalized = normalizer.try_normalize(_PROVIDER, region)
         if region_normalized is None:
             continue
-        divisor, unit = parse_unit_of_measure(uom)
+        try:
+            divisor, unit = parse_unit_of_measure(uom)
+        except ValueError:
+            continue  # skip non-hourly meters (monthly, per-request, etc.)
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",
             "tenancy": "azure-sql",

--- a/pipeline/ingest/azure_sql.py
+++ b/pipeline/ingest/azure_sql.py
@@ -35,7 +35,7 @@ WITH items AS (
   FROM read_json_auto('{path}', maximum_object_size=33554432)
 )
 SELECT
-  meterId       AS sku_id,
+  CAST(meterId AS VARCHAR) AS sku_id,
   skuName       AS resource_name,
   armRegionName AS region,
   productName   AS product_name,

--- a/pipeline/ingest/azure_sql.py
+++ b/pipeline/ingest/azure_sql.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/azure_sql.py
+++ b/pipeline/ingest/azure_sql.py
@@ -72,7 +72,9 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
         deployment = _classify_deployment(product)
         if deployment is None:
             continue
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_unit_of_measure(uom)
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",

--- a/pipeline/ingest/azure_vm.py
+++ b/pipeline/ingest/azure_vm.py
@@ -29,7 +29,7 @@ WITH items AS (
   FROM read_json_auto('{path}', maximum_object_size=536870912)
 )
 SELECT
-  meterId       AS sku_id,
+  CAST(meterId AS VARCHAR) AS sku_id,
   armSkuName    AS resource_name,
   armRegionName AS region,
   productName   AS product_name,
@@ -66,7 +66,9 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
         # OS detection: productName contains "Windows" for Windows VMs;
         # everything else is Linux (the only two surfaces we ship in m3b.1).
         os_value = "windows" if "Windows" in product else "linux"
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_unit_of_measure(uom)
         terms = apply_kind_defaults(_KIND, {
             "commitment": "on_demand",

--- a/pipeline/ingest/azure_vm.py
+++ b/pipeline/ingest/azure_vm.py
@@ -53,6 +53,7 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
     con = open_conn()
     path_literal = str(prices_path).replace("'", "''")
     sql = _SQL.replace("{path}", path_literal)
+    seen: set[str] = set()
     for (
         sku_id, arm_sku, region, product, price, uom, currency, row_type, service_name,
     ) in con.execute(sql).fetchall():
@@ -64,8 +65,9 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
             continue
         if any(hint in product for hint in _SPOT_HINTS):
             continue
-        # OS detection: productName contains "Windows" for Windows VMs;
-        # everything else is Linux (the only two surfaces we ship in m3b.1).
+        if sku_id in seen:
+            continue
+        seen.add(sku_id)
         os_value = "windows" if "Windows" in product else "linux"
         region_normalized = normalizer.try_normalize(_PROVIDER, region)
         if region_normalized is None:

--- a/pipeline/ingest/azure_vm.py
+++ b/pipeline/ingest/azure_vm.py
@@ -26,7 +26,7 @@ _KIND = "compute.vm"
 _SQL = """
 WITH items AS (
   SELECT UNNEST(Items, recursive := true)
-  FROM read_json_auto('{path}', maximum_object_size=134217728)
+  FROM read_json_auto('{path}', maximum_object_size=536870912)
 )
 SELECT
   meterId       AS sku_id,

--- a/pipeline/ingest/azure_vm.py
+++ b/pipeline/ingest/azure_vm.py
@@ -26,7 +26,7 @@ _KIND = "compute.vm"
 _SQL = """
 WITH items AS (
   SELECT UNNEST(Items, recursive := true)
-  FROM read_json_auto('{path}', maximum_object_size=33554432)
+  FROM read_json_auto('{path}', maximum_object_size=134217728)
 )
 SELECT
   meterId       AS sku_id,

--- a/pipeline/ingest/azure_vm.py
+++ b/pipeline/ingest/azure_vm.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/gcp_cloud_sql.py
+++ b/pipeline/ingest/gcp_cloud_sql.py
@@ -92,7 +92,9 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         if not service_regions:
             continue
         region = service_regions[0]
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_usage_unit(usage_unit)
         amount = parse_unit_price(units=price_units, nanos=int(price_nanos)) / divisor
         terms = apply_kind_defaults(_KIND, {

--- a/pipeline/ingest/gcp_cloud_sql.py
+++ b/pipeline/ingest/gcp_cloud_sql.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/gcp_functions.py
+++ b/pipeline/ingest/gcp_functions.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
@@ -69,7 +70,7 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
 
     grouped: dict[str, dict[str, Any]] = {}
     for (
-        sku_id, description, svc_name, resource_family, resource_group, usage_type,
+        sku_id, description, svc_name, _resource_family, resource_group, usage_type,
         service_regions, usage_unit, currency, price_units, price_nanos,
     ) in con.execute(sql).fetchall():
         if svc_name != _SERVICE_DISPLAY:

--- a/pipeline/ingest/gcp_functions.py
+++ b/pipeline/ingest/gcp_functions.py
@@ -86,7 +86,9 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         if not service_regions:
             continue
         region = service_regions[0]
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_usage_unit(usage_unit)
         amount = parse_unit_price(units=price_units, nanos=int(price_nanos or 0)) / divisor
         bucket = grouped.setdefault(region, {

--- a/pipeline/ingest/gcp_gce.py
+++ b/pipeline/ingest/gcp_gce.py
@@ -76,7 +76,9 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         if not service_regions:
             continue
         region = service_regions[0]
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_usage_unit(usage_unit)
         amount = parse_unit_price(units=price_units, nanos=int(price_nanos)) / divisor
         terms = apply_kind_defaults(_KIND, {

--- a/pipeline/ingest/gcp_gce.py
+++ b/pipeline/ingest/gcp_gce.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash

--- a/pipeline/ingest/gcp_gcs.py
+++ b/pipeline/ingest/gcp_gcs.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
@@ -89,7 +90,7 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
     # (class, region) -> {sku_id for storage meter, description, resource_group, region_normalized, prices:{dim: {...}}}
     grouped: dict[tuple[str, str], dict[str, Any]] = {}
     for (
-        sku_id, description, svc_name, resource_family, resource_group, usage_type,
+        sku_id, description, svc_name, _resource_family, resource_group, usage_type,
         service_regions, usage_unit, currency, price_units, price_nanos,
     ) in con.execute(sql).fetchall():
         if svc_name != "Cloud Storage":

--- a/pipeline/ingest/gcp_gcs.py
+++ b/pipeline/ingest/gcp_gcs.py
@@ -104,7 +104,9 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         if not service_regions:
             continue
         region = service_regions[0]
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_usage_unit(usage_unit)
         amount = parse_unit_price(units=price_units, nanos=int(price_nanos or 0)) / divisor
         dim = _dimension(description)

--- a/pipeline/ingest/gcp_run.py
+++ b/pipeline/ingest/gcp_run.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
@@ -73,7 +74,7 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
 
     grouped: dict[str, dict[str, Any]] = {}
     for (
-        sku_id, description, svc_name, resource_family, resource_group, usage_type,
+        sku_id, description, svc_name, _resource_family, resource_group, usage_type,
         service_regions, usage_unit, currency, price_units, price_nanos,
     ) in con.execute(sql).fetchall():
         if svc_name != _SERVICE_DISPLAY:

--- a/pipeline/ingest/gcp_run.py
+++ b/pipeline/ingest/gcp_run.py
@@ -90,7 +90,9 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         if not service_regions:
             continue
         region = service_regions[0]
-        region_normalized = normalizer.normalize(_PROVIDER, region)
+        region_normalized = normalizer.try_normalize(_PROVIDER, region)
+        if region_normalized is None:
+            continue
         divisor, unit = parse_usage_unit(usage_unit)
         amount = parse_unit_price(units=price_units, nanos=int(price_nanos or 0)) / divisor
         bucket = grouped.setdefault(region, {

--- a/pipeline/normalize/enums.py
+++ b/pipeline/normalize/enums.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
-from typing import Mapping
 
 import yaml
 

--- a/pipeline/normalize/regions.yaml
+++ b/pipeline/normalize/regions.yaml
@@ -6,6 +6,7 @@ groups:
     - {provider: aws,   region: us-east-2}
     - {provider: azure, region: eastus}
     - {provider: azure, region: eastus2}
+    - {provider: azure, region: southcentralus}
     - {provider: gcp,   region: us-east1}
     - {provider: gcp,   region: us-east4}
   us-west:

--- a/pipeline/normalize/terms.py
+++ b/pipeline/normalize/terms.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Mapping
+from collections.abc import Mapping
 
 # Fixed field order — MUST NOT CHANGE without a schema_version bump.
 _FIELD_ORDER: tuple[str, ...] = (

--- a/pipeline/package/build_delta.py
+++ b/pipeline/package/build_delta.py
@@ -86,7 +86,6 @@ def _compute_statements(prev_db: Path, new_db: Path) -> list[str]:
         curr_sku_ids = {r[0] for r in curr.execute("SELECT sku_id FROM skus")}
 
         deleted = sorted(prev_sku_ids - curr_sku_ids)
-        common = prev_sku_ids & curr_sku_ids
         added = sorted(curr_sku_ids - prev_sku_ids)
 
         # Gather per-table column lists once.
@@ -211,9 +210,11 @@ def _part_path(out_sql_gz: Path, index: int, total: int) -> Path:
 
 def _write_gzip(path: Path, payload: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "wb") as raw:
-        with gzip.GzipFile(fileobj=raw, mode="wb", compresslevel=9, mtime=0) as fh:
-            fh.write(payload)
+    with (
+        open(path, "wb") as raw,
+        gzip.GzipFile(fileobj=raw, mode="wb", compresslevel=9, mtime=0) as fh,
+    ):
+        fh.write(payload)
 
 
 def _format_payload(statements: Iterable[str], *, header: str | None = None) -> bytes:

--- a/pipeline/package/build_delta.py
+++ b/pipeline/package/build_delta.py
@@ -1,0 +1,306 @@
+"""Emit a gzipped SQL delta that transforms one shard SQLite into another.
+
+Spec §3 (daily update flow): each data release publishes a set of delta SQL
+files alongside baselines. Clients walk the delta chain between their current
+baseline and `head_version`, applying each file in order.
+
+This module is the *server-side* half of that flow. Run in the workflow's
+`diff-package` job against (previous_release's shard, today's shard) — writes
+one or more gzipped `.sql.gz` files that, when applied to the previous shard,
+reproduce today's shard bytes (modulo the `metadata` table, which is replayed
+in full every time).
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import sqlite3
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+# All non-metadata tables owned by the shard schema (pipeline/package/schema.sql).
+# `skus` is parent; the rest FK to skus.sku_id with ON DELETE CASCADE.
+_SKU_CHILD_TABLES: tuple[str, ...] = ("resource_attrs", "terms", "prices", "health")
+_SKU_TABLES: tuple[str, ...] = ("skus",) + _SKU_CHILD_TABLES
+
+
+def _sql_literal(value: object) -> str:
+    """Render a Python scalar as a SQLite literal."""
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if isinstance(value, (bytes, bytearray)):
+        return "X'" + bytes(value).hex() + "'"
+    text = str(value).replace("'", "''")
+    return f"'{text}'"
+
+
+def _columns(con: sqlite3.Connection, table: str) -> list[str]:
+    return [r[1] for r in con.execute(f"PRAGMA table_info({table})").fetchall()]
+
+
+def _row_payloads(
+    con: sqlite3.Connection, table: str, columns: Sequence[str]
+) -> dict[tuple, tuple]:
+    """Map PK tuple → full row tuple, ordered by PK columns."""
+    pk_cols = [r[1] for r in con.execute(f"PRAGMA table_info({table})").fetchall() if r[5]]
+    if not pk_cols:
+        pk_cols = list(columns)
+    col_list = ", ".join(columns)
+    rows: dict[tuple, tuple] = {}
+    for row in con.execute(f"SELECT {col_list} FROM {table}"):
+        pk = tuple(row[columns.index(c)] for c in pk_cols)
+        rows[pk] = tuple(row)
+    return rows
+
+
+def _insert_stmt(table: str, columns: Sequence[str], row: Sequence[object]) -> str:
+    cols = ", ".join(columns)
+    vals = ", ".join(_sql_literal(v) for v in row)
+    return f"INSERT OR REPLACE INTO {table}({cols}) VALUES({vals});"
+
+
+def _delete_by_sku_id_stmt(table: str, sku_id: str) -> str:
+    return f"DELETE FROM {table} WHERE sku_id = {_sql_literal(sku_id)};"
+
+
+def _delete_prices_by_pk_stmt(sku_id: str, dimension: str, tier: str) -> str:
+    return (
+        f"DELETE FROM prices WHERE sku_id = {_sql_literal(sku_id)}"
+        f" AND dimension = {_sql_literal(dimension)}"
+        f" AND tier = {_sql_literal(tier)};"
+    )
+
+
+def _compute_statements(prev_db: Path, new_db: Path) -> list[str]:
+    """Assemble the ordered statement list."""
+    prev = sqlite3.connect(f"file:{prev_db}?mode=ro", uri=True)
+    curr = sqlite3.connect(f"file:{new_db}?mode=ro", uri=True)
+    try:
+        prev_sku_ids = {r[0] for r in prev.execute("SELECT sku_id FROM skus")}
+        curr_sku_ids = {r[0] for r in curr.execute("SELECT sku_id FROM skus")}
+
+        deleted = sorted(prev_sku_ids - curr_sku_ids)
+        common = prev_sku_ids & curr_sku_ids
+        added = sorted(curr_sku_ids - prev_sku_ids)
+
+        # Gather per-table column lists once.
+        cols_by_table = {t: _columns(curr, t) for t in _SKU_TABLES}
+
+        # For every changed/new sku_id, determine which rows differ per child table.
+        changed_sku_ids: set[str] = set()
+
+        # Table-level diffs we'll emit.
+        # Each element is (apply_order_sort_key, sql_statement).
+        stmts: list[tuple[int, str]] = []
+
+        # 1) DELETE rows for removed skus (cascades handle child tables, but
+        #    we emit explicit DELETEs per table so the SQL is explicit and
+        #    independent of PRAGMA foreign_keys state on the client side).
+        for sku_id in deleted:
+            for table in reversed(_SKU_TABLES):  # children first, skus last
+                stmts.append((0, _delete_by_sku_id_stmt(table, sku_id)))
+
+        # 2) For skus still present, diff each child table + skus itself.
+        #    When anything changed for a sku_id, mark it changed so we can
+        #    rewrite the skus row (terms_hash may have bumped).
+        for table in _SKU_TABLES:
+            cols = cols_by_table[table]
+            prev_rows = _row_payloads(prev, table, cols)
+            curr_rows = _row_payloads(curr, table, cols)
+
+            # Rows whose PK exists in both but contents differ.
+            common_pks = prev_rows.keys() & curr_rows.keys()
+            for pk in common_pks:
+                if prev_rows[pk] != curr_rows[pk]:
+                    # sku_id is always the first element of the PK in our schema.
+                    changed_sku_ids.add(str(pk[0]))
+
+            # Rows in curr but not prev: these are additions.
+            new_pks = curr_rows.keys() - prev_rows.keys()
+            for pk in new_pks:
+                changed_sku_ids.add(str(pk[0]))
+
+            # Rows in prev but not curr (same sku_id, but PK like
+            # (sku_id, dimension, tier) removed on `prices`).
+            # Only `prices` has a compound PK; for other tables this set is
+            # empty when the sku_id is still present because those tables are
+            # 1:1 with skus.
+            orphan_pks = prev_rows.keys() - curr_rows.keys()
+            for pk in orphan_pks:
+                sku_id = str(pk[0])
+                if sku_id in curr_sku_ids:
+                    if table == "prices":
+                        stmts.append(
+                            (
+                                1,
+                                _delete_prices_by_pk_stmt(
+                                    sku_id=str(pk[0]),
+                                    dimension=str(pk[1]),
+                                    tier=str(pk[2]),
+                                ),
+                            )
+                        )
+                    else:
+                        # Should not happen for 1:1 tables unless the new shard
+                        # dropped the child row entirely. Emit a by-sku delete
+                        # and let the INSERT re-add it.
+                        changed_sku_ids.add(sku_id)
+
+        # 3) Add newly-introduced sku_ids unconditionally.
+        for sku_id in added:
+            changed_sku_ids.add(sku_id)
+
+        # 4) For each changed sku_id, emit INSERT OR REPLACE for its rows in
+        #    skus + every child table (order: skus first so FK on children
+        #    resolves).
+        for sku_id in sorted(changed_sku_ids):
+            for table in _SKU_TABLES:
+                cols = cols_by_table[table]
+                rows = curr.execute(
+                    f"SELECT {', '.join(cols)} FROM {table} WHERE sku_id = ?",
+                    (sku_id,),
+                ).fetchall()
+                for row in rows:
+                    stmts.append((2, _insert_stmt(table, cols, row)))
+
+        # 5) Metadata: always rewritten in full (small table, changes every
+        #    release — catalog_version, generated_at, row_count).
+        meta_cols = _columns(curr, "metadata")
+        stmts.append((3, "DELETE FROM metadata;"))
+        meta_rows = curr.execute(
+            f"SELECT {', '.join(meta_cols)} FROM metadata ORDER BY key"
+        ).fetchall()
+        for row in meta_rows:
+            stmts.append((3, _insert_stmt("metadata", meta_cols, row)))
+    finally:
+        prev.close()
+        curr.close()
+
+    # Stable apply order: group 0 (deletes) → 1 (prices PK deletes) → 2 (upserts) → 3 (metadata).
+    stmts.sort(key=lambda pair: pair[0])
+    return [s for _, s in stmts]
+
+
+def _is_noop(statements: Sequence[str]) -> bool:
+    """Return True when the only statements are the metadata replay."""
+    for stmt in statements:
+        if not stmt.startswith("DELETE FROM metadata") and not stmt.startswith(
+            "INSERT OR REPLACE INTO metadata"
+        ):
+            return False
+    return True
+
+
+def _part_path(out_sql_gz: Path, index: int, total: int) -> Path:
+    """Insert `-partN` before the `.sql.gz` suffix when splitting."""
+    if total <= 1:
+        return out_sql_gz
+    name = out_sql_gz.name
+    if name.endswith(".sql.gz"):
+        base = name[: -len(".sql.gz")]
+        return out_sql_gz.with_name(f"{base}-part{index}.sql.gz")
+    # Fallback: append before the last suffix.
+    return out_sql_gz.with_name(f"{out_sql_gz.stem}-part{index}{out_sql_gz.suffix}")
+
+
+def _write_gzip(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as raw:
+        with gzip.GzipFile(fileobj=raw, mode="wb", compresslevel=9, mtime=0) as fh:
+            fh.write(payload)
+
+
+def _format_payload(statements: Iterable[str], *, header: str | None = None) -> bytes:
+    lines: list[str] = []
+    if header:
+        lines.append(f"-- {header}")
+    lines.extend(statements)
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def build_delta(
+    prev_db: Path,
+    new_db: Path,
+    out_sql_gz: Path,
+    *,
+    max_bytes: int = 8 * 1024 * 1024,
+) -> list[Path]:
+    """Emit a gzipped SQL delta from `prev_db` → `new_db`.
+
+    When the single gzipped artifact would exceed `max_bytes`, the delta is
+    split row-by-row into apply-order `-part{N}.sql.gz` files, each ≤ roughly
+    `max_bytes` gzipped. Returns the list of part files written (in apply
+    order). Always returns at least one path; empty diffs produce a single
+    `-- noop` file containing only the metadata replay.
+    """
+    prev_db = Path(prev_db)
+    new_db = Path(new_db)
+    out_sql_gz = Path(out_sql_gz)
+
+    statements = _compute_statements(prev_db, new_db)
+
+    if _is_noop(statements):
+        payload = _format_payload(statements, header="noop")
+        path = _part_path(out_sql_gz, 1, 1)
+        _write_gzip(path, payload)
+        return [path]
+
+    # First attempt: dump all statements in a single file.
+    single_payload = _format_payload(statements)
+    if len(gzip.compress(single_payload)) <= max_bytes:
+        path = _part_path(out_sql_gz, 1, 1)
+        _write_gzip(path, single_payload)
+        return [path]
+
+    # Split: walk statements and close a part whenever gzip output would exceed
+    # max_bytes. Each part is a self-contained SQL snippet (apply-order
+    # preserved; the client concatenates + applies them sequentially).
+    parts_payloads: list[bytes] = []
+    current: list[str] = []
+    for stmt in statements:
+        candidate = current + [stmt]
+        candidate_bytes = _format_payload(candidate)
+        if current and len(gzip.compress(candidate_bytes)) > max_bytes:
+            parts_payloads.append(_format_payload(current))
+            current = [stmt]
+        else:
+            current = candidate
+    if current:
+        parts_payloads.append(_format_payload(current))
+
+    total = len(parts_payloads)
+    written: list[Path] = []
+    for idx, payload in enumerate(parts_payloads, start=1):
+        path = _part_path(out_sql_gz, idx, total)
+        _write_gzip(path, payload)
+        written.append(path)
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="package.build_delta")
+    ap.add_argument("--prev", type=Path, required=True, help="previous release shard .db")
+    ap.add_argument("--new", type=Path, required=True, help="today's shard .db")
+    ap.add_argument("--out", type=Path, required=True, help="output .sql.gz path")
+    ap.add_argument(
+        "--max-bytes",
+        type=int,
+        default=8 * 1024 * 1024,
+        help="split into -partN.sql.gz when a single gzipped file would exceed this",
+    )
+    args = ap.parse_args(argv)
+
+    paths = build_delta(args.prev, args.new, args.out, max_bytes=args.max_bytes)
+    for p in paths:
+        print(p)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/package/build_manifest.py
+++ b/pipeline/package/build_manifest.py
@@ -1,0 +1,239 @@
+"""Assemble the manifest.json asset for a data release.
+
+Spec §3 (manifest structure): clients hit this file to discover where to
+download baselines + deltas for each shard, how to verify them (sha256), and
+what minimum binary version they require. This module walks the set of
+artifacts built by the `diff-package` matrix job and emits the manifest per
+that shape.
+
+Artifact layout in `artifacts_dir` (produced by `scripts/ci/diff_package_shard.sh`):
+
+    <shard>.db.zst             # present only on baseline-rebuild
+    <shard>.db.zst.sha256      # matching sha256 file (sidecar, same basename)
+    <shard>-<from>-to-<to>.sql.gz
+    <shard>-<from>-to-<to>-part<N>.sql.gz   # when split
+    <shard>.meta.json          # {"shard": "...", "row_count": N, "has_baseline": bool,
+                                #  "delta_from": "...", "delta_to": "..."}
+
+Every shard touched by today's run contributes a `<shard>.meta.json` sidecar;
+that is the authoritative source of row_count + what file-types to expect.
+Shards absent from today's run are carried forward from `previous_manifest`
+unmodified so clients keep working against yesterday's baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_SCHEMA_VERSION = 1
+
+
+def _sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _file_entry(path: Path, release_base_url: str) -> dict[str, Any]:
+    return {
+        "url": f"{release_base_url.rstrip('/')}/{path.name}",
+        "sha256": _sha256_of(path),
+        "size": path.stat().st_size,
+    }
+
+
+def _delta_parts_for(shard: str, delta_from: str, delta_to: str, artifacts_dir: Path) -> list[Path]:
+    """Find every part of a single delta in apply-order."""
+    prefix = f"{shard}-{delta_from}-to-{delta_to}"
+    single = artifacts_dir / f"{prefix}.sql.gz"
+    if single.is_file():
+        return [single]
+    parts: list[Path] = []
+    for candidate in sorted(artifacts_dir.glob(f"{prefix}-part*.sql.gz")):
+        parts.append(candidate)
+    return parts
+
+
+def _delta_entry(
+    *,
+    shard: str,
+    delta_from: str,
+    delta_to: str,
+    artifacts_dir: Path,
+    release_base_url: str,
+) -> dict[str, Any]:
+    parts = _delta_parts_for(shard, delta_from, delta_to, artifacts_dir)
+    if not parts:
+        raise FileNotFoundError(
+            f"expected delta file(s) for {shard} {delta_from} → {delta_to} under {artifacts_dir}"
+        )
+    entry: dict[str, Any] = {"from": delta_from, "to": delta_to}
+    if len(parts) == 1:
+        entry.update(_file_entry(parts[0], release_base_url))
+    else:
+        entry["parts"] = [_file_entry(p, release_base_url) for p in parts]
+        # Convenience: total size of all parts.
+        entry["size"] = sum(p["size"] for p in entry["parts"])
+    return entry
+
+
+def _read_sidecar(path: Path) -> dict[str, Any]:
+    doc = json.loads(path.read_text())
+    for key in ("shard", "row_count", "has_baseline", "delta_to"):
+        if key not in doc:
+            raise KeyError(f"{path}: missing key {key!r}")
+    return doc
+
+
+def _load_previous(previous_manifest: Path | None) -> dict[str, Any]:
+    if previous_manifest is None or not Path(previous_manifest).is_file():
+        return {"shards": {}}
+    return json.loads(Path(previous_manifest).read_text())
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def build_manifest(
+    *,
+    artifacts_dir: Path,
+    out: Path,
+    catalog_version: str,
+    release_base_url: str,
+    previous_manifest: Path | None,
+    min_binary_version: str,
+    shard_schema_version: int = 1,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Write manifest.json to `out` and return the document.
+
+    Only shards with a `<shard>.meta.json` sidecar in `artifacts_dir` are
+    considered "touched" today. Every other shard listed in
+    `previous_manifest` is carried forward unchanged.
+    """
+    artifacts_dir = Path(artifacts_dir)
+    out = Path(out)
+
+    previous = _load_previous(previous_manifest)
+    prev_shards: dict[str, Any] = previous.get("shards", {})
+
+    # Discover sidecars → shard entries for today.
+    sidecars = {
+        s.stem[: -len(".meta")] if s.name.endswith(".meta.json") else s.stem: _read_sidecar(s)
+        for s in artifacts_dir.glob("*.meta.json")
+    }
+
+    shards_out: dict[str, Any] = {}
+
+    # Every shard that showed up today.
+    for shard, meta in sidecars.items():
+        prev_entry: dict[str, Any] = prev_shards.get(shard, {})
+        has_baseline = bool(meta["has_baseline"])
+        delta_to = meta["delta_to"]
+        delta_from = meta.get("delta_from")
+
+        if has_baseline:
+            baseline_path = artifacts_dir / f"{shard}.db.zst"
+            if not baseline_path.is_file():
+                raise FileNotFoundError(
+                    f"{shard} sidecar says has_baseline=true but {baseline_path} missing"
+                )
+            baseline_entry = _file_entry(baseline_path, release_base_url)
+            entry: dict[str, Any] = {
+                "baseline_version": delta_to,
+                "baseline_url": baseline_entry["url"],
+                "baseline_sha256": baseline_entry["sha256"],
+                "baseline_size": baseline_entry["size"],
+                "head_version": delta_to,
+                "min_binary_version": min_binary_version,
+                "shard_schema_version": shard_schema_version,
+                "deltas": [],
+                "row_count": int(meta["row_count"]),
+                "last_updated": delta_to,
+            }
+        else:
+            if not prev_entry:
+                raise ValueError(
+                    f"{shard}: no baseline this run and no previous manifest entry — "
+                    "cannot assemble a delta-only entry without a baseline to chain from"
+                )
+            if not delta_from:
+                raise ValueError(f"{shard}: sidecar missing delta_from for delta-only run")
+
+            new_delta = _delta_entry(
+                shard=shard,
+                delta_from=delta_from,
+                delta_to=delta_to,
+                artifacts_dir=artifacts_dir,
+                release_base_url=release_base_url,
+            )
+
+            entry = dict(prev_entry)
+            entry["head_version"] = delta_to
+            entry["last_updated"] = delta_to
+            entry["min_binary_version"] = min_binary_version
+            entry["shard_schema_version"] = shard_schema_version
+            entry["row_count"] = int(meta["row_count"])
+            entry["deltas"] = list(prev_entry.get("deltas", [])) + [new_delta]
+
+        shards_out[shard] = entry
+
+    # Carry-forward untouched shards from the previous manifest.
+    for shard, prev_entry in prev_shards.items():
+        if shard not in shards_out:
+            shards_out[shard] = dict(prev_entry)
+
+    # Alphabetise for diff-friendly output.
+    sorted_shards = {k: shards_out[k] for k in sorted(shards_out.keys())}
+
+    doc: dict[str, Any] = {
+        "schema_version": _SCHEMA_VERSION,
+        "generated_at": now or _now_iso(),
+        "catalog_version": catalog_version,
+        "min_binary_version": min_binary_version,
+        "shards": sorted_shards,
+    }
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out.with_suffix(out.suffix + ".part")
+    with tmp.open("w") as fh:
+        json.dump(doc, fh, indent=2, sort_keys=False)
+        fh.write("\n")
+    tmp.replace(out)
+    return doc
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="package.build_manifest")
+    ap.add_argument("--artifacts-dir", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--catalog-version", required=True)
+    ap.add_argument("--release-base-url", required=True)
+    ap.add_argument("--previous-manifest", type=Path, default=None)
+    ap.add_argument("--min-binary-version", default="1.0.0")
+    ap.add_argument("--shard-schema-version", type=int, default=1)
+    args = ap.parse_args(argv)
+
+    build_manifest(
+        artifacts_dir=args.artifacts_dir,
+        out=args.out,
+        catalog_version=args.catalog_version,
+        release_base_url=args.release_base_url,
+        previous_manifest=args.previous_manifest,
+        min_binary_version=args.min_binary_version,
+        shard_schema_version=args.shard_schema_version,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/package/build_shard.py
+++ b/pipeline/package/build_shard.py
@@ -6,8 +6,9 @@ import argparse
 import json
 import sqlite3
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 _HERE = Path(__file__).resolve().parent
 _SCHEMA_SQL = (_HERE / "schema.sql").read_text()

--- a/pipeline/package/sanity_check.py
+++ b/pipeline/package/sanity_check.py
@@ -65,9 +65,7 @@ def sanity_check(
 
         generated_at = _metadata_value(con, "generated_at")
         if not generated_at:
-            raise SanityError(
-                shard, "missing_generated_at", "metadata.generated_at is NULL/empty"
-            )
+            raise SanityError(shard, "missing_generated_at", "metadata.generated_at is NULL/empty")
 
         # FK integrity: every price row must reference a live sku row.
         orphan_prices = con.execute(
@@ -101,7 +99,8 @@ def sanity_check(
             added = sorted(curr_schema.keys() - prev_schema.keys())
             removed = sorted(prev_schema.keys() - curr_schema.keys())
             changed = sorted(
-                k for k in curr_schema.keys() & prev_schema.keys()
+                k
+                for k in curr_schema.keys() & prev_schema.keys()
                 if curr_schema[k] != prev_schema[k]
             )
             raise SanityError(

--- a/pipeline/package/sanity_check.py
+++ b/pipeline/package/sanity_check.py
@@ -1,0 +1,148 @@
+"""Lightweight sanity guard for the daily release chain (spec §3 line 198).
+
+Runs per-shard in the `diff-package` job against today's freshly-built SQLite
+shard vs. yesterday's decompressed baseline. Catches the common failure modes
+before we publish — row-count cliff from a broken fetcher, upstream schema
+drift, orphaned foreign keys, or a forgotten `generated_at` in metadata. Every
+miss here would poison the client caches until the next manual intervention.
+
+Does *not* attempt a full upstream cross-check — that is `data-validate.yml`'s
+job (m3a.4.3).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+
+class SanityError(Exception):
+    """Raised when a sanity check fails. Carries the shard name in `shard`."""
+
+    def __init__(self, shard: str, reason: str, detail: str = "") -> None:
+        super().__init__(f"[{shard}] {reason}: {detail}" if detail else f"[{shard}] {reason}")
+        self.shard = shard
+        self.reason = reason
+        self.detail = detail
+
+
+def _count_rows(con: sqlite3.Connection, table: str) -> int:
+    return con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+
+
+def _schema_ddl(con: sqlite3.Connection) -> dict[str, str]:
+    rows = con.execute(
+        "SELECT name, sql FROM sqlite_master "
+        "WHERE type='table' AND name NOT LIKE 'sqlite_%' "
+        "ORDER BY name"
+    ).fetchall()
+    return {name: (sql or "").strip() for name, sql in rows}
+
+
+def _metadata_value(con: sqlite3.Connection, key: str) -> str | None:
+    row = con.execute("SELECT value FROM metadata WHERE key = ?", (key,)).fetchone()
+    return row[0] if row else None
+
+
+def sanity_check(
+    *,
+    shard: str,
+    shard_db: Path,
+    previous_db: Path | None,
+    tolerance_pct: float = 5.0,
+) -> None:
+    """Raise :class:`SanityError` when any guard trips.
+
+    When `previous_db` is `None` (first release) only the intra-shard checks
+    run: schema validity, FK integrity, `metadata.generated_at` populated.
+    """
+    shard_db = Path(shard_db)
+    con = sqlite3.connect(f"file:{shard_db}?mode=ro", uri=True)
+    try:
+        con.execute("PRAGMA foreign_keys = ON")
+
+        generated_at = _metadata_value(con, "generated_at")
+        if not generated_at:
+            raise SanityError(
+                shard, "missing_generated_at", "metadata.generated_at is NULL/empty"
+            )
+
+        # FK integrity: every price row must reference a live sku row.
+        orphan_prices = con.execute(
+            "SELECT COUNT(*) FROM prices p "
+            "LEFT JOIN skus s ON s.sku_id = p.sku_id "
+            "WHERE s.sku_id IS NULL"
+        ).fetchone()[0]
+        if orphan_prices:
+            raise SanityError(
+                shard, "fk_orphan_prices", f"{orphan_prices} price rows without matching sku"
+            )
+
+        curr_skus = _count_rows(con, "skus")
+        curr_schema = _schema_ddl(con)
+
+        if previous_db is None:
+            # Fresh release — nothing to compare against.
+            if curr_skus == 0:
+                raise SanityError(shard, "empty_shard", "skus table is empty on first release")
+            return
+
+        prev_path = Path(previous_db)
+        prev = sqlite3.connect(f"file:{prev_path}?mode=ro", uri=True)
+        try:
+            prev_skus = _count_rows(prev, "skus")
+            prev_schema = _schema_ddl(prev)
+        finally:
+            prev.close()
+
+        if curr_schema != prev_schema:
+            added = sorted(curr_schema.keys() - prev_schema.keys())
+            removed = sorted(prev_schema.keys() - curr_schema.keys())
+            changed = sorted(
+                k for k in curr_schema.keys() & prev_schema.keys()
+                if curr_schema[k] != prev_schema[k]
+            )
+            raise SanityError(
+                shard,
+                "schema_drift",
+                f"added={added} removed={removed} changed={changed}",
+            )
+
+        if prev_skus > 0:
+            drift_pct = 100.0 * abs(curr_skus - prev_skus) / prev_skus
+            if drift_pct > tolerance_pct:
+                raise SanityError(
+                    shard,
+                    "row_count_drift",
+                    f"prev={prev_skus} curr={curr_skus} drift={drift_pct:.2f}% "
+                    f"exceeds tolerance {tolerance_pct:.2f}%",
+                )
+    finally:
+        con.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="package.sanity_check")
+    ap.add_argument("--shard", required=True)
+    ap.add_argument("--shard-db", type=Path, required=True)
+    ap.add_argument("--previous-db", type=Path, default=None)
+    ap.add_argument("--tolerance-pct", type=float, default=5.0)
+    args = ap.parse_args(argv)
+
+    try:
+        sanity_check(
+            shard=args.shard,
+            shard_db=args.shard_db,
+            previous_db=args.previous_db,
+            tolerance_pct=args.tolerance_pct,
+        )
+    except SanityError as exc:
+        print(f"sanity check failed: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -27,3 +27,9 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.ruff.lint.per-file-ignores]
+# Ingest modules embed long json_extract_string() SQL inside triple-quoted
+# strings; ruff counts the string content as source lines. Splitting the SQL
+# to stay under 100 cols hurts readability more than it helps.
+"ingest/*.py" = ["E501"]

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "zstandard>=0.22",
   "duckdb>=0.10,<2",
   "numpy>=1.26",
+  "ijson>=3.2",
 ]
 
 [project.optional-dependencies]

--- a/pipeline/tests/test_aws_cloudfront_ingest.py
+++ b/pipeline/tests/test_aws_cloudfront_ingest.py
@@ -5,10 +5,11 @@ from pathlib import Path
 
 import pytest
 
-from ingest.aws_cloudfront import ingest, LOCATION_MAP
+from ingest.aws_cloudfront import LOCATION_MAP, ingest
 
-FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "aws_cloudfront" / "offer.json"
-GOLDEN = Path(__file__).resolve().parent.parent / "testdata" / "golden" / "aws_cloudfront_rows.jsonl"
+_DATA = Path(__file__).resolve().parent.parent / "testdata"
+FIXTURE = _DATA / "aws_cloudfront" / "offer.json"
+GOLDEN = _DATA / "golden" / "aws_cloudfront_rows.jsonl"
 
 
 def _canonical(rows):

--- a/pipeline/tests/test_aws_dynamodb_ingest.py
+++ b/pipeline/tests/test_aws_dynamodb_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.aws_dynamodb import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "aws_dynamodb" / "offer.json"

--- a/pipeline/tests/test_aws_dynamodb_ingest.py
+++ b/pipeline/tests/test_aws_dynamodb_ingest.py
@@ -52,11 +52,11 @@ def test_standard_ia_storage_cheaper_than_standard_same_region():
             f"standard-ia storage {ia_storage} should be < standard {std_storage} in {region}"
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     first_sku = next(iter(bad["products"]))
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="ap-south-9"):
-        list(ingest(offer_path=p))
+    rows = list(ingest(offer_path=p))
+    assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_ebs_ingest.py
+++ b/pipeline/tests/test_aws_ebs_ingest.py
@@ -38,11 +38,11 @@ def test_each_row_has_only_storage_dim():
         assert [p["dimension"] for p in r["prices"]] == ["storage"]
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     first_sku = next(iter(bad["products"]))
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="ap-south-9"):
-        list(ingest(offer_path=p))
+    rows = list(ingest(offer_path=p))
+    assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_ebs_ingest.py
+++ b/pipeline/tests/test_aws_ebs_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.aws_ebs import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "aws_ebs" / "offer.json"

--- a/pipeline/tests/test_aws_ebs_ingest.py
+++ b/pipeline/tests/test_aws_ebs_ingest.py
@@ -14,24 +14,24 @@ def _canonical(rows):
 
 
 def test_fixture_matches_golden():
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     expected = [json.loads(line) for line in GOLDEN.read_text().splitlines() if line.strip()]
     assert _canonical(rows) == _canonical(expected)
 
 
 def test_all_rows_are_storage_block_kind():
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     assert rows
     assert {r["kind"] for r in rows} == {"storage.block"}
 
 
 def test_every_volume_type_present():
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     assert {r["resource_name"] for r in rows} == {"gp3", "gp2", "io2", "st1", "sc1"}
 
 
 def test_each_row_has_only_storage_dim():
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     for r in rows:
         assert [p["dimension"] for p in r["prices"]] == ["storage"]
 
@@ -42,5 +42,5 @@ def test_unknown_region_skipped(tmp_path):
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    rows = list(ingest(offer_path=p))
+    rows = list(ingest(offer_paths=[p]))
     assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_ec2_ingest.py
+++ b/pipeline/tests/test_aws_ec2_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.aws_ec2 import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "aws_ec2" / "offer.json"

--- a/pipeline/tests/test_aws_ec2_ingest.py
+++ b/pipeline/tests/test_aws_ec2_ingest.py
@@ -14,13 +14,13 @@ def _canonical(rows):
 
 
 def test_fixture_matches_golden():
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     expected = [json.loads(line) for line in GOLDEN.read_text().splitlines() if line.strip()]
     assert _canonical(rows) == _canonical(expected)
 
 
 def test_all_rows_are_compute_vm_kind():
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     assert rows, "fixture produced zero rows"
     assert {r["kind"] for r in rows} == {"compute.vm"}
 
@@ -28,7 +28,7 @@ def test_all_rows_are_compute_vm_kind():
 def test_terms_hash_matches_terms_content():
     """For every row, recompute terms_hash from the row's terms and assert equality."""
     from normalize.terms import terms_hash
-    rows = list(ingest(offer_path=FIXTURE))
+    rows = list(ingest(offer_paths=[FIXTURE]))
     for r in rows:
         assert r["terms_hash"] == terms_hash(r["terms"])
 
@@ -40,5 +40,5 @@ def test_unknown_region_skipped(tmp_path):
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    rows = list(ingest(offer_path=p))
+    rows = list(ingest(offer_paths=[p]))
     assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_ec2_ingest.py
+++ b/pipeline/tests/test_aws_ec2_ingest.py
@@ -35,12 +35,12 @@ def test_terms_hash_matches_terms_content():
         assert r["terms_hash"] == terms_hash(r["terms"])
 
 
-def test_unknown_region_rejected(tmp_path):
-    """A product in a region not in regions.yaml must fail the ingest."""
+def test_unknown_region_skipped(tmp_path):
+    """A product in a region outside regions.yaml is silently dropped."""
     bad = json.loads(FIXTURE.read_text())
     first_sku = next(iter(bad["products"]))
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="ap-south-9"):
-        list(ingest(offer_path=p))
+    rows = list(ingest(offer_path=p))
+    assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_fetch.py
+++ b/pipeline/tests/test_aws_fetch.py
@@ -37,9 +37,9 @@ def test_happy_path(tmp_path: Path) -> None:
             content=_BODY,
             headers={"Content-Length": str(len(_BODY))},
         )
-        pub_date = fetch_offer("aws_ec2", target)
+        result = fetch_offer("aws_ec2", target)
 
-    assert pub_date == "2026-04-18T00:00:00Z"
+    assert result is None
     assert target.exists()
     assert target.read_bytes() == _BODY
 
@@ -93,8 +93,8 @@ def test_500_then_success(tmp_path: Path, _patch_sleep: None) -> None:
     ]
     with req_mock.Mocker() as m:
         m.get(_EC2_URL, response_list=responses)
-        pub_date = fetch_offer("aws_ec2", target)
-        assert pub_date == "2026-04-18T00:00:00Z"
+        fetch_offer("aws_ec2", target)
+        assert target.read_bytes() == _BODY
         assert m.call_count == 3
 
 

--- a/pipeline/tests/test_aws_lambda_ingest.py
+++ b/pipeline/tests/test_aws_lambda_ingest.py
@@ -45,11 +45,11 @@ def test_arm64_price_lower_than_x86_64_same_region():
             assert arm_dur < x86_dur, f"arm64 duration {arm_dur} should be < x86_64 {x86_dur}"
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     first_sku = next(iter(bad["products"]))
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="ap-south-9"):
-        list(ingest(offer_path=p))
+    rows = list(ingest(offer_path=p))
+    assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_lambda_ingest.py
+++ b/pipeline/tests/test_aws_lambda_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.aws_lambda import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "aws_lambda" / "offer.json"

--- a/pipeline/tests/test_aws_s3_ingest.py
+++ b/pipeline/tests/test_aws_s3_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.aws_s3 import ingest
 from normalize.terms import terms_hash
 

--- a/pipeline/tests/test_aws_s3_ingest.py
+++ b/pipeline/tests/test_aws_s3_ingest.py
@@ -45,11 +45,11 @@ def test_terms_hash_uses_empty_tenancy_os():
         assert r["terms_hash"] == terms_hash(r["terms"])
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     first_sku = next(iter(bad["products"]))
     bad["products"][first_sku]["attributes"]["regionCode"] = "ap-south-9"
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="ap-south-9"):
-        list(ingest(offer_path=p))
+    rows = list(ingest(offer_path=p))
+    assert all(r["region"] != "ap-south-9" for r in rows)

--- a/pipeline/tests/test_aws_strip.py
+++ b/pipeline/tests/test_aws_strip.py
@@ -1,0 +1,214 @@
+"""Tests for the streaming-strip + per-region fetch helpers in aws_common."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import requests_mock as req_mock
+
+from ingest.aws_common import (
+    _strip_ec2_offer,
+    aws_regions_from_yaml,
+    fetch_offer_regions_stripped,
+)
+
+
+def _write(path: Path, obj: dict) -> None:
+    path.write_text(json.dumps(obj))
+
+
+def test_strip_keeps_only_whitelisted_fields(tmp_path: Path) -> None:
+    """Strip drops Reserved terms, offerTermCode, description, non-EC2 attrs."""
+    raw = {
+        "formatVersion": "v1.0",
+        "offerCode": "AmazonEC2",
+        "publicationDate": "2026-04-18T00:00:00Z",
+        "version": "20260418000000",
+        "products": {
+            "sku-compute": {
+                "productFamily": "Compute Instance",
+                "sku": "sku-compute",
+                "attributes": {
+                    "instanceType": "m5.large",
+                    "regionCode": "us-east-1",
+                    "operatingSystem": "Linux",
+                    "tenancy": "Shared",
+                    "preInstalledSw": "NA",
+                    "capacitystatus": "Used",
+                    "vcpu": "2",
+                    "memory": "8 GiB",
+                    "physicalProcessor": "Intel",
+                    "networkPerformance": "10 Gig",
+                    "servicecode": "AmazonEC2",  # dropped
+                    "location": "US East",  # dropped
+                },
+            },
+            "sku-storage": {
+                "productFamily": "Storage",
+                "attributes": {
+                    "volumeApiName": "gp3",
+                    "regionCode": "us-east-1",
+                    "servicecode": "AmazonEC2",  # dropped
+                },
+            },
+            "sku-ignored": {
+                "productFamily": "Data Transfer",  # whole product dropped
+                "attributes": {"regionCode": "us-east-1"},
+            },
+        },
+        "terms": {
+            "OnDemand": {
+                "sku-compute": {
+                    "sku-compute.TERM": {
+                        "offerTermCode": "JRTC",  # dropped
+                        "effectiveDate": "2020-01-01",  # dropped
+                        "termAttributes": {},  # dropped
+                        "priceDimensions": {
+                            "sku-compute.TERM.RATE": {
+                                "rateCode": "abc",  # dropped
+                                "description": "$0.096 per hour",  # dropped
+                                "beginRange": "0",  # dropped
+                                "endRange": "Inf",  # dropped
+                                "unit": "Hrs",
+                                "pricePerUnit": {"USD": "0.0960000000"},
+                            }
+                        },
+                    }
+                },
+                "sku-ignored": {  # referenced but product dropped
+                    "sku-ignored.TERM": {
+                        "priceDimensions": {"x.y.z": {"unit": "GB", "pricePerUnit": {"USD": "1"}}}
+                    }
+                },
+            },
+            "Reserved": {  # entire Reserved block dropped
+                "sku-compute": {"a.b": {"priceDimensions": {}}}
+            },
+        },
+    }
+    raw_path = tmp_path / "raw.json"
+    out_path = tmp_path / "stripped.json"
+    _write(raw_path, raw)
+
+    _strip_ec2_offer(raw_path, out_path)
+    stripped = json.loads(out_path.read_text())
+
+    # Products: kept two, dropped one.
+    assert set(stripped["products"]) == {"sku-compute", "sku-storage"}
+    compute_attrs = stripped["products"]["sku-compute"]["attributes"]
+    assert "servicecode" not in compute_attrs
+    assert "location" not in compute_attrs
+    assert compute_attrs["instanceType"] == "m5.large"
+    assert compute_attrs["vcpu"] == "2"
+    assert stripped["products"]["sku-storage"]["attributes"]["volumeApiName"] == "gp3"
+
+    # Terms: Reserved gone; OnDemand for dropped products pruned.
+    assert set(stripped["terms"]) == {"OnDemand"}
+    assert set(stripped["terms"]["OnDemand"]) == {"sku-compute"}
+    term = next(iter(stripped["terms"]["OnDemand"]["sku-compute"].values()))
+    assert set(term) == {"priceDimensions"}  # offerTermCode, termAttributes gone
+    pd = next(iter(term["priceDimensions"].values()))
+    assert set(pd) == {"unit", "pricePerUnit"}
+    assert pd["unit"] == "Hrs"
+    assert pd["pricePerUnit"]["USD"] == "0.0960000000"
+
+
+def test_strip_reduces_file_size(tmp_path: Path) -> None:
+    """Sanity check: stripping the existing fixture produces a smaller file.
+
+    The fixture is already hand-trimmed (no Reserved, short descriptions), so
+    this mostly catches regressions where we accidentally stop trimming. Real
+    per-region AWS offers see ~95%+ reduction.
+    """
+    fixture = Path(__file__).resolve().parent.parent / "testdata" / "aws_ec2" / "offer.json"
+    out_path = tmp_path / "stripped.json"
+    _strip_ec2_offer(fixture, out_path)
+    assert out_path.stat().st_size < fixture.stat().st_size
+
+
+def test_aws_regions_from_yaml_matches_regions_yaml() -> None:
+    """Hardcoded regions list matches current regions.yaml coverage."""
+    assert aws_regions_from_yaml() == [
+        "ap-northeast-1",
+        "eu-west-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-2",
+    ]
+
+
+def test_fetch_offer_regions_stripped(tmp_path: Path) -> None:
+    """End-to-end: mock region_index + per-region fetches, verify strip produces output."""
+    region_index_url = (
+        "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/region_index.json"
+    )
+    region_a_url = (
+        "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/20260418/us-east-1/index.json"
+    )
+    region_b_url = (
+        "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/20260418/eu-west-1/index.json"
+    )
+    region_index = {
+        "regions": {
+            "us-east-1": {
+                "regionCode": "us-east-1",
+                "currentVersionUrl": "/offers/v1.0/aws/AmazonEC2/20260418/us-east-1/index.json",
+            },
+            "eu-west-1": {
+                "regionCode": "eu-west-1",
+                "currentVersionUrl": "/offers/v1.0/aws/AmazonEC2/20260418/eu-west-1/index.json",
+            },
+        }
+    }
+    tiny_offer = {
+        "products": {
+            "sku-x": {
+                "productFamily": "Compute Instance",
+                "attributes": {"instanceType": "m5.large", "regionCode": "us-east-1"},
+            }
+        },
+        "terms": {
+            "OnDemand": {
+                "sku-x": {
+                    "sku-x.T": {
+                        "priceDimensions": {
+                            "sku-x.T.R": {"unit": "Hrs", "pricePerUnit": {"USD": "0.1"}}
+                        }
+                    }
+                }
+            }
+        },
+    }
+    body_index = json.dumps(region_index).encode()
+    body_offer = json.dumps(tiny_offer).encode()
+
+    idx_hdr = {"Content-Length": str(len(body_index))}
+    offer_hdr = {"Content-Length": str(len(body_offer))}
+    with req_mock.Mocker() as m:
+        m.get(region_index_url, content=body_index, headers=idx_hdr)
+        m.get(region_a_url, content=body_offer, headers=offer_hdr)
+        m.get(region_b_url, content=body_offer, headers=offer_hdr)
+        out_dir = tmp_path / "stripped"
+        paths = fetch_offer_regions_stripped(
+            "aws_ec2", out_dir, regions=["us-east-1", "eu-west-1", "ap-south-99"]
+        )
+
+    # Only two regions existed upstream; the missing one is silently skipped.
+    assert sorted(p.name for p in paths) == [
+        "aws_ec2-eu-west-1.json",
+        "aws_ec2-us-east-1.json",
+    ]
+    # Raw files removed; stripped files remain.
+    assert not any(out_dir.glob("*.raw.json"))
+    # Each stripped file is valid JSON with our trimmed shape.
+    for p in paths:
+        doc = json.loads(p.read_text())
+        assert list(doc["products"]) == ["sku-x"]
+        assert list(doc["terms"]["OnDemand"]) == ["sku-x"]
+
+
+def test_fetch_unsupported_shard_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="per-region offer not supported"):
+        fetch_offer_regions_stripped("aws_s3", tmp_path, regions=["us-east-1"])

--- a/pipeline/tests/test_azure_blob_ingest.py
+++ b/pipeline/tests/test_azure_blob_ingest.py
@@ -54,7 +54,7 @@ def test_non_usd_rows_filtered():
         assert eur_ids.isdisjoint(parts)
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     for it in bad["Items"]:
         if it["type"] == "Consumption" and it["currencyCode"] == "USD":
@@ -62,5 +62,5 @@ def test_unknown_region_rejected(tmp_path):
             break
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="centralus"):
-        list(ingest(prices_path=p))
+    rows = list(ingest(prices_path=p))
+    assert all(r["region"] != "centralus" for r in rows)

--- a/pipeline/tests/test_azure_blob_ingest.py
+++ b/pipeline/tests/test_azure_blob_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.azure_blob import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "azure_blob" / "prices.json"
@@ -31,7 +29,8 @@ def test_each_row_carries_three_dims():
     rows = list(ingest(prices_path=FIXTURE))
     for r in rows:
         dims = {p["dimension"] for p in r["prices"]}
-        assert dims == {"storage", "read-ops", "write-ops"}, f"row {r['sku_id']} missing dims: {dims}"
+        assert dims == {"storage", "read-ops", "write-ops"}, \
+            f"row {r['sku_id']} missing dims: {dims}"
 
 
 def test_reservation_rows_filtered():

--- a/pipeline/tests/test_azure_functions_ingest.py
+++ b/pipeline/tests/test_azure_functions_ingest.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 from ingest.azure_functions import ingest
 
-FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "azure_functions" / "prices.json"
-GOLDEN = Path(__file__).resolve().parent.parent / "testdata" / "golden" / "azure_functions_rows.jsonl"
+_DATA = Path(__file__).resolve().parent.parent / "testdata"
+FIXTURE = _DATA / "azure_functions" / "prices.json"
+GOLDEN = _DATA / "golden" / "azure_functions_rows.jsonl"
 
 
 def _canonical(rows):

--- a/pipeline/tests/test_azure_sql_ingest.py
+++ b/pipeline/tests/test_azure_sql_ingest.py
@@ -43,7 +43,7 @@ def test_business_critical_more_expensive_than_general_purpose():
 
 
 def test_unit_of_measure_divisor_applied():
-    """The one '100 Hours' row in the fixture must come out at the same per-hour rate as its '1 Hour' twin."""
+    """The one '100 Hours' row must match the per-hour rate of its '1 Hour' twin."""
     rows = list(ingest(prices_path=FIXTURE))
     # Group by (sku, region, deployment); we expect equal-or-very-close per-hour amounts
     # for the row priced as '100 Hours' and any sibling priced as '1 Hour'. Since the

--- a/pipeline/tests/test_azure_sql_ingest.py
+++ b/pipeline/tests/test_azure_sql_ingest.py
@@ -3,7 +3,7 @@
 import json
 from pathlib import Path
 
-import pytest
+import pytest  # used by test_unit_of_measure_divisor_applied
 
 from ingest.azure_sql import ingest
 
@@ -57,8 +57,8 @@ def test_unit_of_measure_divisor_applied():
         assert west == pytest.approx(east * 1.05, rel=1e-9)
 
 
-def test_unknown_uom_rejected(tmp_path):
-    """A row with a non-time unitOfMeasure must fail the build."""
+def test_unknown_uom_skipped(tmp_path):
+    """A row with an unrecognised unitOfMeasure (monthly, per-million, etc.) is silently dropped."""
     bad = json.loads(FIXTURE.read_text())
     for it in bad["Items"]:
         if it["serviceName"] == "SQL Database" and it["currencyCode"] == "USD":
@@ -66,5 +66,5 @@ def test_unknown_uom_rejected(tmp_path):
             break
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(ValueError, match="GB/Month"):
-        list(ingest(prices_path=p))
+    rows = list(ingest(prices_path=p))
+    assert all(r["prices"][0]["unit"] != "gb-mo" for r in rows)

--- a/pipeline/tests/test_azure_vm_ingest.py
+++ b/pipeline/tests/test_azure_vm_ingest.py
@@ -51,8 +51,8 @@ def test_non_usd_rows_rejected():
         assert r["prices"][0]["amount"] > 0  # smoke
 
 
-def test_unknown_region_rejected(tmp_path):
-    """An item in a region not in regions.yaml must fail the ingest."""
+def test_unknown_region_skipped(tmp_path):
+    """An item in a region outside regions.yaml is silently dropped."""
     bad = json.loads(FIXTURE.read_text())
     # Mutate the first Consumption USD item to an unseen region.
     for it in bad["Items"]:
@@ -61,5 +61,5 @@ def test_unknown_region_rejected(tmp_path):
             break
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="centralus"):
-        list(ingest(prices_path=p))
+    rows = list(ingest(prices_path=p))
+    assert all(r["region"] != "centralus" for r in rows)

--- a/pipeline/tests/test_azure_vm_ingest.py
+++ b/pipeline/tests/test_azure_vm_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.azure_vm import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "azure_vm" / "prices.json"

--- a/pipeline/tests/test_build_delta.py
+++ b/pipeline/tests/test_build_delta.py
@@ -1,0 +1,176 @@
+"""Unit tests for pipeline.package.build_delta."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import sqlite3
+from pathlib import Path
+
+from package.build_delta import build_delta
+from package.build_shard import build_shard
+
+
+def _base_row(sku_id: str, amount: float) -> dict:
+    return {
+        "sku_id": sku_id,
+        "provider": "anthropic",
+        "service": "llm",
+        "kind": "llm.text",
+        "resource_name": sku_id.split("::")[0],
+        "region": "",
+        "region_normalized": "",
+        "terms": {"commitment": "on_demand", "tenancy": "", "os": ""},
+        "terms_hash": f"h-{sku_id}",
+        "resource_attrs": {"context_length": 200_000},
+        "prices": [
+            {"dimension": "prompt", "tier": "", "amount": amount, "unit": "token"},
+            {"dimension": "completion", "tier": "", "amount": amount * 5, "unit": "token"},
+        ],
+    }
+
+
+def _write_shard(tmp_path: Path, name: str, rows: list[dict], version: str) -> Path:
+    rows_path = tmp_path / f"{name}.rows.jsonl"
+    rows_path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    out = tmp_path / f"{name}.db"
+    build_shard(
+        rows_path=rows_path,
+        shard=name,
+        out_path=out,
+        catalog_version=version,
+        generated_at=f"2026-04-18T00:00:00Z",
+        source_url="https://example.com",
+    )
+    return out
+
+
+def _decompress(paths: list[Path]) -> str:
+    parts = [gzip.decompress(p.read_bytes()).decode() for p in paths]
+    return "\n".join(parts)
+
+
+def _apply_and_snapshot(prev_db: Path, sql: str, tmp_path: Path) -> Path:
+    target = tmp_path / "applied.db"
+    target.write_bytes(prev_db.read_bytes())
+    con = sqlite3.connect(target)
+    try:
+        con.execute("PRAGMA foreign_keys = OFF")
+        con.executescript(sql)
+        con.commit()
+    finally:
+        con.close()
+    return target
+
+
+def _table_snapshot(db: Path, table: str) -> list[tuple]:
+    con = sqlite3.connect(db)
+    try:
+        cols = [r[1] for r in con.execute(f"PRAGMA table_info({table})").fetchall()]
+        rows = list(con.execute(f"SELECT {', '.join(cols)} FROM {table}"))
+        return sorted(rows)
+    finally:
+        con.close()
+
+
+def test_round_trip_inserts_and_updates(tmp_path: Path):
+    """prev has 10 rows, new has 12 (2 inserted, 1 updated). Applying the
+    delta to prev should reproduce new (excluding metadata)."""
+    prev_rows = [_base_row(f"sku-{i}::anthropic::default", 0.001 * (i + 1)) for i in range(10)]
+    new_rows = [_base_row(f"sku-{i}::anthropic::default", 0.001 * (i + 1)) for i in range(12)]
+    # Update row #3's price
+    new_rows[3]["prices"][0]["amount"] = 0.999
+
+    prev_db = _write_shard(tmp_path, "prev", prev_rows, "2026.04.17")
+    new_db = _write_shard(tmp_path, "new", new_rows, "2026.04.18")
+
+    parts = build_delta(prev_db, new_db, tmp_path / "delta.sql.gz")
+    assert len(parts) == 1
+    assert parts[0] == tmp_path / "delta.sql.gz"
+
+    sql = _decompress(parts)
+    applied = _apply_and_snapshot(prev_db, sql, tmp_path)
+
+    for table in ("skus", "resource_attrs", "terms", "prices", "health"):
+        assert _table_snapshot(applied, table) == _table_snapshot(new_db, table), (
+            f"table {table} mismatch after applying delta"
+        )
+
+
+def test_round_trip_deletions(tmp_path: Path):
+    """prev has 10 rows, new has 7 (3 deleted). Delta contains DELETEs."""
+    prev_rows = [_base_row(f"sku-{i}::anthropic::default", 0.001) for i in range(10)]
+    new_rows = prev_rows[:7]
+
+    prev_db = _write_shard(tmp_path, "prev", prev_rows, "2026.04.17")
+    new_db = _write_shard(tmp_path, "new", new_rows, "2026.04.18")
+
+    parts = build_delta(prev_db, new_db, tmp_path / "delta.sql.gz")
+    sql = _decompress(parts)
+    applied = _apply_and_snapshot(prev_db, sql, tmp_path)
+
+    assert _table_snapshot(applied, "skus") == _table_snapshot(new_db, "skus")
+    # Confirm we actually emitted DELETE statements for the 3 removed skus.
+    assert sql.count("DELETE FROM skus WHERE sku_id =") == 3
+    # No bulk upsert of unchanged rows.
+    assert "sku-0::anthropic::default" not in sql or "INSERT OR REPLACE INTO skus" not in sql.split(
+        "DELETE FROM metadata"
+    )[0].split("sku-0::anthropic::default")[0]
+
+
+def test_split_when_gzipped_exceeds_max_bytes(tmp_path: Path):
+    """A max_bytes cap forces the delta to split into multiple parts, and the
+    concatenation still reproduces the target."""
+    prev_rows = [_base_row(f"sku-{i}::anthropic::default", 0.001) for i in range(5)]
+    new_rows = [_base_row(f"sku-{i}::anthropic::default", 0.001 * (i + 1)) for i in range(25)]
+
+    prev_db = _write_shard(tmp_path, "prev", prev_rows, "2026.04.17")
+    new_db = _write_shard(tmp_path, "new", new_rows, "2026.04.18")
+
+    parts = build_delta(prev_db, new_db, tmp_path / "delta.sql.gz", max_bytes=256)
+    assert len(parts) >= 2, f"expected split; got {parts}"
+    for p in parts:
+        assert p.stat().st_size <= 512  # generous headroom over the 256-byte target
+        assert "-part" in p.name
+
+    sql = _decompress(parts)
+    applied = _apply_and_snapshot(prev_db, sql, tmp_path)
+    assert _table_snapshot(applied, "skus") == _table_snapshot(new_db, "skus")
+    assert _table_snapshot(applied, "prices") == _table_snapshot(new_db, "prices")
+
+
+def test_noop_when_shards_identical(tmp_path: Path):
+    """Identical shards produce a single gzipped file containing only the
+    metadata replay + a `-- noop` header."""
+    rows = [_base_row(f"sku-{i}::anthropic::default", 0.001) for i in range(3)]
+    prev_db = _write_shard(tmp_path, "prev", rows, "2026.04.18")
+    new_db = _write_shard(tmp_path, "new", rows, "2026.04.18")
+
+    parts = build_delta(prev_db, new_db, tmp_path / "delta.sql.gz")
+    assert len(parts) == 1
+    sql = _decompress(parts)
+    assert sql.startswith("-- noop")
+    assert "DELETE FROM metadata" in sql
+    # No data-table mutations when no skus changed.
+    assert "DELETE FROM skus" not in sql
+    assert "INSERT OR REPLACE INTO skus" not in sql
+    assert "INSERT OR REPLACE INTO prices" not in sql
+
+
+def test_prices_row_deletion_within_same_sku(tmp_path: Path):
+    """When a sku_id remains but one of its price rows is dropped, the delta
+    emits a DELETE for just that (sku_id, dimension, tier)."""
+    prev_rows = [_base_row("sku-0::anthropic::default", 0.001)]
+    new_rows = [_base_row("sku-0::anthropic::default", 0.001)]
+    new_rows[0]["prices"] = [new_rows[0]["prices"][0]]  # drop the completion row
+
+    prev_db = _write_shard(tmp_path, "prev", prev_rows, "2026.04.17")
+    new_db = _write_shard(tmp_path, "new", new_rows, "2026.04.18")
+
+    parts = build_delta(prev_db, new_db, tmp_path / "delta.sql.gz")
+    sql = _decompress(parts)
+    assert "DELETE FROM prices WHERE sku_id = 'sku-0::anthropic::default'" in sql
+    assert "dimension = 'completion'" in sql
+
+    applied = _apply_and_snapshot(prev_db, sql, tmp_path)
+    assert _table_snapshot(applied, "prices") == _table_snapshot(new_db, "prices")

--- a/pipeline/tests/test_build_delta.py
+++ b/pipeline/tests/test_build_delta.py
@@ -39,7 +39,7 @@ def _write_shard(tmp_path: Path, name: str, rows: list[dict], version: str) -> P
         shard=name,
         out_path=out,
         catalog_version=version,
-        generated_at=f"2026-04-18T00:00:00Z",
+        generated_at="2026-04-18T00:00:00Z",
         source_url="https://example.com",
     )
     return out
@@ -113,9 +113,11 @@ def test_round_trip_deletions(tmp_path: Path):
     # Confirm we actually emitted DELETE statements for the 3 removed skus.
     assert sql.count("DELETE FROM skus WHERE sku_id =") == 3
     # No bulk upsert of unchanged rows.
-    assert "sku-0::anthropic::default" not in sql or "INSERT OR REPLACE INTO skus" not in sql.split(
-        "DELETE FROM metadata"
-    )[0].split("sku-0::anthropic::default")[0]
+    assert (
+        "sku-0::anthropic::default" not in sql
+        or "INSERT OR REPLACE INTO skus"
+        not in sql.split("DELETE FROM metadata")[0].split("sku-0::anthropic::default")[0]
+    )
 
 
 def test_split_when_gzipped_exceeds_max_bytes(tmp_path: Path):

--- a/pipeline/tests/test_build_manifest.py
+++ b/pipeline/tests/test_build_manifest.py
@@ -1,0 +1,354 @@
+"""Unit tests for pipeline.package.build_manifest."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from package.build_manifest import build_manifest
+
+NOW = "2026-04-18T00:00:00Z"
+BASE_URL = "https://github.com/sofq/sku/releases/download/data-2026.04.18"
+
+
+def _write(path: Path, contents: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(contents)
+
+
+def _sha(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+
+def _sidecar(path: Path, **fields) -> None:
+    path.write_text(json.dumps(fields))
+
+
+def test_fresh_first_release_every_shard_has_baseline_empty_deltas(tmp_path: Path):
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+
+    shard_bytes = b"fake sqlite zstd bytes"
+    for shard in ("aws-ec2", "openrouter"):
+        _write(artifacts / f"{shard}.db.zst", shard_bytes)
+        _sidecar(
+            artifacts / f"{shard}.meta.json",
+            shard=shard,
+            row_count=42,
+            has_baseline=True,
+            delta_from=None,
+            delta_to="2026.04.18",
+        )
+
+    out = tmp_path / "manifest.json"
+    doc = build_manifest(
+        artifacts_dir=artifacts,
+        out=out,
+        catalog_version="2026.04.18",
+        release_base_url=BASE_URL,
+        previous_manifest=None,
+        min_binary_version="1.0.0",
+        now=NOW,
+    )
+
+    assert doc["schema_version"] == 1
+    assert doc["catalog_version"] == "2026.04.18"
+    assert doc["generated_at"] == NOW
+    assert doc["min_binary_version"] == "1.0.0"
+    assert list(doc["shards"].keys()) == ["aws-ec2", "openrouter"]  # sorted
+
+    for shard in ("aws-ec2", "openrouter"):
+        entry = doc["shards"][shard]
+        assert entry["baseline_version"] == "2026.04.18"
+        assert entry["head_version"] == "2026.04.18"
+        assert entry["baseline_url"] == f"{BASE_URL}/{shard}.db.zst"
+        assert entry["baseline_sha256"] == _sha(shard_bytes)
+        assert entry["baseline_size"] == len(shard_bytes)
+        assert entry["deltas"] == []
+        assert entry["row_count"] == 42
+        assert entry["shard_schema_version"] == 1
+        assert entry["min_binary_version"] == "1.0.0"
+        assert entry["last_updated"] == "2026.04.18"
+
+    # File on disk matches returned doc (pretty-printed + trailing newline).
+    assert json.loads(out.read_text()) == doc
+
+
+def test_normal_day_extends_deltas_and_preserves_baseline(tmp_path: Path):
+    # Previous manifest says baseline was 2026.04.17 for aws-ec2.
+    prev_manifest = tmp_path / "prev-manifest.json"
+    prev_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "generated_at": "2026-04-17T03:00:00Z",
+                "catalog_version": "2026.04.17",
+                "min_binary_version": "1.0.0",
+                "shards": {
+                    "aws-ec2": {
+                        "baseline_version": "2026.04.15",
+                        "baseline_url": f"{BASE_URL}/../data-2026.04.15/aws-ec2.db.zst",
+                        "baseline_sha256": "a" * 64,
+                        "baseline_size": 1024,
+                        "head_version": "2026.04.17",
+                        "min_binary_version": "1.0.0",
+                        "shard_schema_version": 1,
+                        "deltas": [
+                            {
+                                "from": "2026.04.15",
+                                "to": "2026.04.16",
+                                "url": "https://example/d1.sql.gz",
+                                "sha256": "b" * 64,
+                                "size": 10,
+                            },
+                            {
+                                "from": "2026.04.16",
+                                "to": "2026.04.17",
+                                "url": "https://example/d2.sql.gz",
+                                "sha256": "c" * 64,
+                                "size": 12,
+                            },
+                        ],
+                        "row_count": 50,
+                        "last_updated": "2026.04.17",
+                    }
+                },
+            }
+        )
+    )
+
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    delta_bytes = b"-- today delta\n"
+    _write(artifacts / "aws-ec2-2026.04.17-to-2026.04.18.sql.gz", delta_bytes)
+    _sidecar(
+        artifacts / "aws-ec2.meta.json",
+        shard="aws-ec2",
+        row_count=55,
+        has_baseline=False,
+        delta_from="2026.04.17",
+        delta_to="2026.04.18",
+    )
+
+    doc = build_manifest(
+        artifacts_dir=artifacts,
+        out=tmp_path / "manifest.json",
+        catalog_version="2026.04.18",
+        release_base_url=BASE_URL,
+        previous_manifest=prev_manifest,
+        min_binary_version="1.0.0",
+        now=NOW,
+    )
+
+    entry = doc["shards"]["aws-ec2"]
+    assert entry["baseline_version"] == "2026.04.15"  # preserved
+    assert entry["head_version"] == "2026.04.18"
+    assert entry["last_updated"] == "2026.04.18"
+    assert entry["row_count"] == 55
+
+    # Deltas: old two + today's one.
+    assert len(entry["deltas"]) == 3
+    today_delta = entry["deltas"][-1]
+    assert today_delta["from"] == "2026.04.17"
+    assert today_delta["to"] == "2026.04.18"
+    assert today_delta["url"] == f"{BASE_URL}/aws-ec2-2026.04.17-to-2026.04.18.sql.gz"
+    assert today_delta["sha256"] == _sha(delta_bytes)
+    assert today_delta["size"] == len(delta_bytes)
+
+
+def test_baseline_rebuild_resets_deltas(tmp_path: Path):
+    prev_manifest = tmp_path / "prev-manifest.json"
+    prev_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "shards": {
+                    "aws-ec2": {
+                        "baseline_version": "2026.04.01",
+                        "baseline_url": "https://stale/baseline.db.zst",
+                        "baseline_sha256": "x" * 64,
+                        "baseline_size": 1,
+                        "head_version": "2026.04.17",
+                        "deltas": [{"from": "x", "to": "y", "url": "z", "sha256": "q", "size": 1}],
+                        "row_count": 50,
+                        "last_updated": "2026.04.17",
+                    }
+                },
+            }
+        )
+    )
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    new_baseline = b"new baseline bytes"
+    _write(artifacts / "aws-ec2.db.zst", new_baseline)
+    _sidecar(
+        artifacts / "aws-ec2.meta.json",
+        shard="aws-ec2",
+        row_count=60,
+        has_baseline=True,
+        delta_from=None,
+        delta_to="2026.04.18",
+    )
+
+    doc = build_manifest(
+        artifacts_dir=artifacts,
+        out=tmp_path / "manifest.json",
+        catalog_version="2026.04.18",
+        release_base_url=BASE_URL,
+        previous_manifest=prev_manifest,
+        min_binary_version="1.0.0",
+        now=NOW,
+    )
+
+    entry = doc["shards"]["aws-ec2"]
+    assert entry["baseline_version"] == "2026.04.18"
+    assert entry["head_version"] == "2026.04.18"
+    assert entry["baseline_url"] == f"{BASE_URL}/aws-ec2.db.zst"
+    assert entry["baseline_sha256"] == _sha(new_baseline)
+    assert entry["deltas"] == []
+    assert entry["row_count"] == 60
+
+
+def test_shard_not_in_today_artifacts_is_carried_forward(tmp_path: Path):
+    prev_manifest = tmp_path / "prev-manifest.json"
+    prev_entry = {
+        "baseline_version": "2026.04.10",
+        "baseline_url": "https://prev/baseline.db.zst",
+        "baseline_sha256": "z" * 64,
+        "baseline_size": 100,
+        "head_version": "2026.04.17",
+        "deltas": [],
+        "row_count": 99,
+        "last_updated": "2026.04.17",
+    }
+    prev_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "shards": {
+                    "aws-ec2": prev_entry,
+                    "azure-vm": {
+                        "baseline_version": "x",
+                        "baseline_url": "u",
+                        "baseline_sha256": "s",
+                        "baseline_size": 1,
+                        "head_version": "x",
+                        "deltas": [],
+                        "row_count": 1,
+                    },
+                },
+            }
+        )
+    )
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    # Only aws-ec2 was touched today.
+    _write(artifacts / "aws-ec2.db.zst", b"new")
+    _sidecar(
+        artifacts / "aws-ec2.meta.json",
+        shard="aws-ec2",
+        row_count=1,
+        has_baseline=True,
+        delta_from=None,
+        delta_to="2026.04.18",
+    )
+
+    doc = build_manifest(
+        artifacts_dir=artifacts,
+        out=tmp_path / "manifest.json",
+        catalog_version="2026.04.18",
+        release_base_url=BASE_URL,
+        previous_manifest=prev_manifest,
+        min_binary_version="1.0.0",
+        now=NOW,
+    )
+
+    # aws-ec2 rebuilt, azure-vm carried forward unchanged.
+    assert list(doc["shards"].keys()) == ["aws-ec2", "azure-vm"]
+    assert doc["shards"]["azure-vm"]["baseline_version"] == "x"
+    assert doc["shards"]["azure-vm"]["baseline_url"] == "u"
+
+
+def test_multi_part_delta_recorded_with_parts(tmp_path: Path):
+    prev_manifest = tmp_path / "prev-manifest.json"
+    prev_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "shards": {
+                    "aws-ec2": {
+                        "baseline_version": "2026.04.10",
+                        "baseline_url": "u",
+                        "baseline_sha256": "a" * 64,
+                        "baseline_size": 1,
+                        "head_version": "2026.04.17",
+                        "deltas": [],
+                        "row_count": 5,
+                        "last_updated": "2026.04.17",
+                    }
+                },
+            }
+        )
+    )
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    p1 = b"aaa"
+    p2 = b"bbbb"
+    _write(artifacts / "aws-ec2-2026.04.17-to-2026.04.18-part1.sql.gz", p1)
+    _write(artifacts / "aws-ec2-2026.04.17-to-2026.04.18-part2.sql.gz", p2)
+    _sidecar(
+        artifacts / "aws-ec2.meta.json",
+        shard="aws-ec2",
+        row_count=7,
+        has_baseline=False,
+        delta_from="2026.04.17",
+        delta_to="2026.04.18",
+    )
+
+    doc = build_manifest(
+        artifacts_dir=artifacts,
+        out=tmp_path / "manifest.json",
+        catalog_version="2026.04.18",
+        release_base_url=BASE_URL,
+        previous_manifest=prev_manifest,
+        min_binary_version="1.0.0",
+        now=NOW,
+    )
+
+    delta = doc["shards"]["aws-ec2"]["deltas"][0]
+    assert delta["from"] == "2026.04.17"
+    assert delta["to"] == "2026.04.18"
+    assert "parts" in delta
+    assert [p["url"] for p in delta["parts"]] == [
+        f"{BASE_URL}/aws-ec2-2026.04.17-to-2026.04.18-part1.sql.gz",
+        f"{BASE_URL}/aws-ec2-2026.04.17-to-2026.04.18-part2.sql.gz",
+    ]
+    assert delta["size"] == len(p1) + len(p2)
+
+
+def test_delta_only_without_previous_manifest_raises(tmp_path: Path):
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    _write(artifacts / "aws-ec2-2026.04.17-to-2026.04.18.sql.gz", b"d")
+    _sidecar(
+        artifacts / "aws-ec2.meta.json",
+        shard="aws-ec2",
+        row_count=1,
+        has_baseline=False,
+        delta_from="2026.04.17",
+        delta_to="2026.04.18",
+    )
+
+    with pytest.raises(ValueError, match="no baseline"):
+        build_manifest(
+            artifacts_dir=artifacts,
+            out=tmp_path / "manifest.json",
+            catalog_version="2026.04.18",
+            release_base_url=BASE_URL,
+            previous_manifest=None,
+            min_binary_version="1.0.0",
+            now=NOW,
+        )

--- a/pipeline/tests/test_discover_driver.py
+++ b/pipeline/tests/test_discover_driver.py
@@ -20,7 +20,7 @@ def _mock_all_providers(m: requests_mock.Mocker, *, aws_pub: str = "2026-04-18T0
 
     for service_code in set(_AWS_SERVICE_CODES.values()):
         m.get(
-            f"{_AWS_OFFER_BASE}/{service_code}/current/index.json",
+            f"{_AWS_OFFER_BASE}/{service_code}/index.json",
             json={"publicationDate": aws_pub},
         )
     m.get(_AZURE_RETAIL_BASE, json={"Items": []})
@@ -183,7 +183,7 @@ def test_one_shard_errors_others_still_succeed(tmp_path: Path) -> None:
         # Set up AWS discover to FAIL (the AWS group all errors as a unit),
         # but openrouter succeeds.
         for service_code in set(_AWS_SERVICE_CODES.values()):
-            m.get(f"{_AWS_OFFER_BASE}/{service_code}/current/index.json", status_code=500)
+            m.get(f"{_AWS_OFFER_BASE}/{service_code}/index.json", status_code=500)
         m.get("https://openrouter.ai/api/v1/models", json={"data": []})
         rc = run(
             state_path=state,
@@ -205,7 +205,7 @@ def test_all_shards_error_exits_2(tmp_path: Path) -> None:
 
     with requests_mock.Mocker() as m:
         for service_code in set(_AWS_SERVICE_CODES.values()):
-            m.get(f"{_AWS_OFFER_BASE}/{service_code}/current/index.json", status_code=500)
+            m.get(f"{_AWS_OFFER_BASE}/{service_code}/index.json", status_code=500)
         rc = run(
             state_path=state,
             out_path=out,

--- a/pipeline/tests/test_discover_providers.py
+++ b/pipeline/tests/test_discover_providers.py
@@ -21,11 +21,11 @@ from ingest.gcp_common import _GCP_BILLING_BASE, _GCP_SERVICE_IDS
 def test_aws_discover_returns_publicationDate():
     with requests_mock.Mocker() as m:
         m.get(
-            f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json",
+            f"{_AWS_OFFER_BASE}/AmazonEC2/index.json",
             json={"publicationDate": "2026-04-18T00:00:00Z"},
         )
         m.get(
-            f"{_AWS_OFFER_BASE}/AmazonRDS/current/index.json",
+            f"{_AWS_OFFER_BASE}/AmazonRDS/index.json",
             json={"publicationDate": "2026-04-17T00:00:00Z"},
         )
         result = aws_disc.discover(["aws_ec2", "aws_rds"])
@@ -38,7 +38,7 @@ def test_aws_discover_returns_publicationDate():
 def test_aws_discover_ebs_maps_to_ec2_endpoint():
     with requests_mock.Mocker() as m:
         m.get(
-            f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json",
+            f"{_AWS_OFFER_BASE}/AmazonEC2/index.json",
             json={"publicationDate": "2026-04-18T00:00:00Z"},
         )
         result = aws_disc.discover(["aws_ebs"])
@@ -47,7 +47,7 @@ def test_aws_discover_ebs_maps_to_ec2_endpoint():
 
 def test_aws_discover_http_failure_raises_runtimeerror():
     with requests_mock.Mocker() as m:
-        m.get(f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json", status_code=500)
+        m.get(f"{_AWS_OFFER_BASE}/AmazonEC2/index.json", status_code=500)
         with pytest.raises(RuntimeError, match="aws_discover_http_500"):
             aws_disc.discover(["aws_ec2"])
 
@@ -55,13 +55,13 @@ def test_aws_discover_http_failure_raises_runtimeerror():
 def test_aws_discover_indicator_changes_when_upstream_changes():
     with requests_mock.Mocker() as m:
         m.get(
-            f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json",
+            f"{_AWS_OFFER_BASE}/AmazonEC2/index.json",
             json={"publicationDate": "2026-04-18T00:00:00Z"},
         )
         a = aws_disc.discover(["aws_ec2"])
     with requests_mock.Mocker() as m:
         m.get(
-            f"{_AWS_OFFER_BASE}/AmazonEC2/current/index.json",
+            f"{_AWS_OFFER_BASE}/AmazonEC2/index.json",
             json={"publicationDate": "2026-04-19T00:00:00Z"},
         )
         b = aws_disc.discover(["aws_ec2"])

--- a/pipeline/tests/test_gcp_cloud_sql_ingest.py
+++ b/pipeline/tests/test_gcp_cloud_sql_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.gcp_cloud_sql import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "gcp_cloud_sql" / "skus.json"

--- a/pipeline/tests/test_gcp_functions_ingest.py
+++ b/pipeline/tests/test_gcp_functions_ingest.py
@@ -57,7 +57,7 @@ def test_architecture_attr():
         assert row["resource_name"] == "x86_64"
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:
         if sku["category"]["resourceGroup"] == "CloudFunctionsV2" and sku["category"]["usageType"] == "OnDemand":
@@ -65,5 +65,5 @@ def test_unknown_region_rejected(tmp_path):
                 sku["serviceRegions"] = ["mars-1"]
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="gcp/mars-1"):
-        list(ingest(skus_path=p))
+    rows = list(ingest(skus_path=p))
+    assert all(r["region"] != "mars-1" for r in rows)

--- a/pipeline/tests/test_gcp_functions_ingest.py
+++ b/pipeline/tests/test_gcp_functions_ingest.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.gcp_functions import ingest
-
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "gcp_functions" / "skus.json"
 GOLDEN = Path(__file__).resolve().parent.parent / "testdata" / "golden" / "gcp_functions_rows.jsonl"
@@ -60,9 +57,14 @@ def test_architecture_attr():
 def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:
-        if sku["category"]["resourceGroup"] == "CloudFunctionsV2" and sku["category"]["usageType"] == "OnDemand":
-            if sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]["unitPrice"]["currencyCode"] == "USD":
-                sku["serviceRegions"] = ["mars-1"]
+        cat = sku["category"]
+        rate = sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]
+        if (
+            cat["resourceGroup"] == "CloudFunctionsV2"
+            and cat["usageType"] == "OnDemand"
+            and rate["unitPrice"]["currencyCode"] == "USD"
+        ):
+            sku["serviceRegions"] = ["mars-1"]
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
     rows = list(ingest(skus_path=p))

--- a/pipeline/tests/test_gcp_gce_ingest.py
+++ b/pipeline/tests/test_gcp_gce_ingest.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.gcp_gce import ingest
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "gcp_gce" / "skus.json"
@@ -52,9 +50,11 @@ def test_unknown_region_skipped(tmp_path):
     """A SKU in a region outside regions.yaml is silently dropped."""
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:
-        if sku["category"]["usageType"] == "OnDemand" and sku["pricingInfo"][0]["pricingExpression"][
-            "tieredRates"
-        ][0]["unitPrice"]["currencyCode"] == "USD":
+        rate = sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]
+        if (
+            sku["category"]["usageType"] == "OnDemand"
+            and rate["unitPrice"]["currencyCode"] == "USD"
+        ):
             sku["serviceRegions"] = ["us-central1"]
             break
     p = tmp_path / "bad.json"

--- a/pipeline/tests/test_gcp_gce_ingest.py
+++ b/pipeline/tests/test_gcp_gce_ingest.py
@@ -48,8 +48,8 @@ def test_non_usd_filtered():
     assert "SKU-N1S2-EUW1-EUR" not in out_ids
 
 
-def test_unknown_region_rejected(tmp_path):
-    """A SKU in a region not in regions.yaml must fail the ingest."""
+def test_unknown_region_skipped(tmp_path):
+    """A SKU in a region outside regions.yaml is silently dropped."""
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:
         if sku["category"]["usageType"] == "OnDemand" and sku["pricingInfo"][0]["pricingExpression"][
@@ -59,5 +59,5 @@ def test_unknown_region_rejected(tmp_path):
             break
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="gcp/us-central1"):
-        list(ingest(skus_path=p))
+    rows = list(ingest(skus_path=p))
+    assert all(r["region"] != "us-central1" for r in rows)

--- a/pipeline/tests/test_gcp_gcs_ingest.py
+++ b/pipeline/tests/test_gcp_gcs_ingest.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.gcp_gcs import ingest
-
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "gcp_gcs" / "skus.json"
 GOLDEN = Path(__file__).resolve().parent.parent / "testdata" / "golden" / "gcp_gcs_rows.jsonl"
@@ -61,9 +58,14 @@ def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     # Point the standard-storage / read-ops / write-ops meters at an unknown region.
     for sku in bad["skus"]:
-        if sku["category"]["resourceGroup"] == "StandardStorage" and sku["category"]["usageType"] == "OnDemand":
-            if sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]["unitPrice"]["currencyCode"] == "USD":
-                sku["serviceRegions"] = ["mars-1"]
+        cat = sku["category"]
+        rate = sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]
+        if (
+            cat["resourceGroup"] == "StandardStorage"
+            and cat["usageType"] == "OnDemand"
+            and rate["unitPrice"]["currencyCode"] == "USD"
+        ):
+            sku["serviceRegions"] = ["mars-1"]
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
     rows = list(ingest(skus_path=p))

--- a/pipeline/tests/test_gcp_gcs_ingest.py
+++ b/pipeline/tests/test_gcp_gcs_ingest.py
@@ -57,7 +57,7 @@ def test_three_dimensions_per_row():
         assert sorted(p["dimension"] for p in row["prices"]) == expected
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     # Point the standard-storage / read-ops / write-ops meters at an unknown region.
     for sku in bad["skus"]:
@@ -66,5 +66,5 @@ def test_unknown_region_rejected(tmp_path):
                 sku["serviceRegions"] = ["mars-1"]
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="gcp/mars-1"):
-        list(ingest(skus_path=p))
+    rows = list(ingest(skus_path=p))
+    assert all(r["region"] != "mars-1" for r in rows)

--- a/pipeline/tests/test_gcp_run_ingest.py
+++ b/pipeline/tests/test_gcp_run_ingest.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from ingest.gcp_run import ingest
-
 
 FIXTURE = Path(__file__).resolve().parent.parent / "testdata" / "gcp_run" / "skus.json"
 GOLDEN = Path(__file__).resolve().parent.parent / "testdata" / "golden" / "gcp_run_rows.jsonl"
@@ -60,9 +57,14 @@ def test_architecture_attr():
 def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:
-        if sku["category"]["resourceGroup"] == "CloudRunV2" and sku["category"]["usageType"] == "OnDemand":
-            if sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]["unitPrice"]["currencyCode"] == "USD":
-                sku["serviceRegions"] = ["mars-1"]
+        cat = sku["category"]
+        rate = sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]
+        if (
+            cat["resourceGroup"] == "CloudRunV2"
+            and cat["usageType"] == "OnDemand"
+            and rate["unitPrice"]["currencyCode"] == "USD"
+        ):
+            sku["serviceRegions"] = ["mars-1"]
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
     rows = list(ingest(skus_path=p))

--- a/pipeline/tests/test_gcp_run_ingest.py
+++ b/pipeline/tests/test_gcp_run_ingest.py
@@ -57,7 +57,7 @@ def test_architecture_attr():
         assert row["resource_name"] == "x86_64"
 
 
-def test_unknown_region_rejected(tmp_path):
+def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:
         if sku["category"]["resourceGroup"] == "CloudRunV2" and sku["category"]["usageType"] == "OnDemand":
@@ -65,5 +65,5 @@ def test_unknown_region_rejected(tmp_path):
                 sku["serviceRegions"] = ["mars-1"]
     p = tmp_path / "bad.json"
     p.write_text(json.dumps(bad))
-    with pytest.raises(KeyError, match="gcp/mars-1"):
-        list(ingest(skus_path=p))
+    rows = list(ingest(skus_path=p))
+    assert all(r["region"] != "mars-1" for r in rows)

--- a/pipeline/tests/test_openrouter_ingest.py
+++ b/pipeline/tests/test_openrouter_ingest.py
@@ -68,7 +68,6 @@ def test_ingest_rejects_non_usd_endpoint():
 
 
 def test_synthetic_aggregated_row_present():
-    monkeypatch = None  # not needed for this test
     client = FixtureClient(FIX)
     models = client.get("/api/v1/models")
     models["data"] = [m for m in models["data"] if m["id"] == "openai/gpt-5"]
@@ -89,13 +88,25 @@ def test_synthetic_aggregated_row_present():
     assert agg[0]["health"] is None
 
 
-def _dup_model(top_pricing: dict[str, str], ep_pricings: list[dict[str, str]], uptimes: list[float]) -> dict:
+def _dup_model(
+    top_pricing: dict[str, str],
+    ep_pricings: list[dict[str, str]],
+    uptimes: list[float],
+) -> dict:
     model = {
         "id": "dup/model",
         "name": "Dup Model",
-        "architecture": {"modality": "text", "input_modalities": ["text"], "output_modalities": ["text"]},
+        "architecture": {
+            "modality": "text",
+            "input_modalities": ["text"],
+            "output_modalities": ["text"],
+        },
         "pricing": top_pricing,
-        "top_provider": {"context_length": 1000, "max_completion_tokens": 100, "is_moderated": False},
+        "top_provider": {
+            "context_length": 1000,
+            "max_completion_tokens": 100,
+            "is_moderated": False,
+        },
         "supported_parameters": [],
     }
     endpoints = []

--- a/pipeline/tests/test_sanity_check.py
+++ b/pipeline/tests/test_sanity_check.py
@@ -1,0 +1,133 @@
+"""Unit tests for pipeline.package.sanity_check."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from package.build_shard import build_shard
+from package.sanity_check import SanityError, sanity_check
+
+
+def _row(sku_id: str, amount: float = 0.001) -> dict:
+    return {
+        "sku_id": sku_id,
+        "provider": "anthropic",
+        "service": "llm",
+        "kind": "llm.text",
+        "resource_name": sku_id.split("::")[0],
+        "region": "",
+        "region_normalized": "",
+        "terms": {"commitment": "on_demand", "tenancy": "", "os": ""},
+        "terms_hash": "h",
+        "resource_attrs": {"context_length": 100_000},
+        "prices": [{"dimension": "prompt", "tier": "", "amount": amount, "unit": "token"}],
+    }
+
+
+def _make_shard(
+    tmp_path: Path,
+    name: str,
+    rows: list[dict],
+    *,
+    version: str = "2026.04.18",
+    generated_at: str = "2026-04-18T00:00:00Z",
+) -> Path:
+    rows_path = tmp_path / f"{name}.rows.jsonl"
+    rows_path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    db = tmp_path / f"{name}.db"
+    build_shard(
+        rows_path=rows_path,
+        shard=name,
+        out_path=db,
+        catalog_version=version,
+        generated_at=generated_at,
+        source_url="https://example.com",
+    )
+    return db
+
+
+def test_happy_path(tmp_path: Path):
+    prev = _make_shard(tmp_path, "prev", [_row(f"sku-{i}") for i in range(100)], version="1")
+    curr = _make_shard(tmp_path, "curr", [_row(f"sku-{i}") for i in range(102)], version="2")
+    sanity_check(shard="test", shard_db=curr, previous_db=prev)
+
+
+def test_first_release_allows_missing_previous(tmp_path: Path):
+    curr = _make_shard(tmp_path, "curr", [_row("sku-0")])
+    sanity_check(shard="test", shard_db=curr, previous_db=None)
+
+
+def test_first_release_empty_shard_raises(tmp_path: Path):
+    curr = _make_shard(tmp_path, "curr", [])
+    with pytest.raises(SanityError) as exc:
+        sanity_check(shard="test", shard_db=curr, previous_db=None)
+    assert exc.value.reason == "empty_shard"
+    assert exc.value.shard == "test"
+
+
+def test_row_count_drift_raises(tmp_path: Path):
+    prev = _make_shard(tmp_path, "prev", [_row(f"sku-{i}") for i in range(100)])
+    curr = _make_shard(tmp_path, "curr", [_row(f"sku-{i}") for i in range(50)])  # -50%
+    with pytest.raises(SanityError) as exc:
+        sanity_check(shard="aws-ec2", shard_db=curr, previous_db=prev, tolerance_pct=5.0)
+    assert exc.value.reason == "row_count_drift"
+    assert exc.value.shard == "aws-ec2"
+    assert "prev=100" in str(exc.value)
+    assert "curr=50" in str(exc.value)
+
+
+def test_row_count_within_tolerance_passes(tmp_path: Path):
+    prev = _make_shard(tmp_path, "prev", [_row(f"sku-{i}") for i in range(100)])
+    curr = _make_shard(tmp_path, "curr", [_row(f"sku-{i}") for i in range(104)])  # +4%
+    sanity_check(shard="test", shard_db=curr, previous_db=prev, tolerance_pct=5.0)
+
+
+def test_schema_drift_raises(tmp_path: Path):
+    prev = _make_shard(tmp_path, "prev", [_row("sku-0")])
+    curr = _make_shard(tmp_path, "curr", [_row("sku-0")])
+    # Mutate curr: drop a column via schema surgery.
+    import sqlite3
+
+    con = sqlite3.connect(curr)
+    try:
+        con.execute("ALTER TABLE skus ADD COLUMN unexpected TEXT")
+        con.commit()
+    finally:
+        con.close()
+
+    with pytest.raises(SanityError) as exc:
+        sanity_check(shard="aws-ec2", shard_db=curr, previous_db=prev)
+    assert exc.value.reason == "schema_drift"
+
+
+def test_fk_orphan_raises(tmp_path: Path):
+    curr = _make_shard(tmp_path, "curr", [_row("sku-0")])
+    # Inject an orphaned price row by temporarily disabling FK enforcement.
+    import sqlite3
+
+    con = sqlite3.connect(curr)
+    try:
+        con.execute("PRAGMA foreign_keys = OFF")
+        con.execute(
+            "INSERT INTO prices(sku_id, dimension, tier, amount, unit) "
+            "VALUES('orphan', 'prompt', '', 0.001, 'token')"
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    with pytest.raises(SanityError) as exc:
+        sanity_check(shard="openrouter", shard_db=curr, previous_db=None)
+    assert exc.value.reason == "fk_orphan_prices"
+    assert exc.value.shard == "openrouter"
+
+
+def test_missing_generated_at_raises(tmp_path: Path):
+    curr = _make_shard(tmp_path, "curr", [_row("sku-0")], generated_at="")
+    # build_shard stores "" so the metadata value is empty — should trip.
+    with pytest.raises(SanityError) as exc:
+        sanity_check(shard="test", shard_db=curr, previous_db=None)
+    assert exc.value.reason == "missing_generated_at"

--- a/scripts/ci/build_manifest.sh
+++ b/scripts/ci/build_manifest.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Assemble manifest.json from today's release artifacts.
+#
+# Inputs (env):
+#   CATALOG_VERSION    — today's catalog tag
+#   PREVIOUS_VERSION   — prior release's catalog tag (may be empty)
+#   MIN_BINARY         — minimum client binary version
+#   GH_TOKEN           — for gh CLI
+#
+# Inputs (on disk): `dist/pipeline/release/*` populated by the diff_package matrix.
+# Output: `dist/pipeline/release/manifest.json`.
+set -euo pipefail
+
+: "${CATALOG_VERSION:?CATALOG_VERSION env var required}"
+: "${MIN_BINARY:?MIN_BINARY env var required}"
+PREVIOUS_VERSION="${PREVIOUS_VERSION:-}"
+
+release_dir="dist/pipeline/release"
+prev_manifest=""
+
+if [ -n "$PREVIOUS_VERSION" ]; then
+  prev_dir="dist/pipeline/prev-manifest"
+  mkdir -p "$prev_dir"
+  if gh release download "data-${PREVIOUS_VERSION}" \
+        --pattern 'manifest.json' \
+        --dir "$prev_dir" 2>/dev/null; then
+    prev_manifest="$prev_dir/manifest.json"
+  fi
+fi
+
+repo="${GITHUB_REPOSITORY:-sofq/sku}"
+server="${GITHUB_SERVER_URL:-https://github.com}"
+base_url="${server}/${repo}/releases/download/data-${CATALOG_VERSION}"
+
+cmd=(
+  python -m package.build_manifest
+  --artifacts-dir "$release_dir"
+  --out "$release_dir/manifest.json"
+  --catalog-version "$CATALOG_VERSION"
+  --release-base-url "$base_url"
+  --min-binary-version "$MIN_BINARY"
+)
+if [ -n "$prev_manifest" ]; then
+  cmd+=(--previous-manifest "$prev_manifest")
+fi
+
+"${cmd[@]}"
+
+echo "build_manifest.sh: wrote $release_dir/manifest.json"

--- a/scripts/ci/diff_package_shard.sh
+++ b/scripts/ci/diff_package_shard.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Run sanity check + build delta + optional baseline zst for one shard.
+#
+# Inputs (env):
+#   SHARD              — underscored shard id (matrix value)
+#   CATALOG_VERSION    — today's catalog tag
+#   PREVIOUS_VERSION   — prior release's catalog tag (may be empty on first run)
+#   BASELINE_REBUILD   — "true" on day-of-month ∈ {1,15} or force_baseline
+#
+# Inputs (on disk):
+#   dist/pipeline/today/<dashed>.db        — today's shard (from ingest job artifact)
+#   dist/pipeline/prev/<dashed>.db         — previous shard, decompressed by caller
+#
+# Output:
+#   dist/pipeline/release/<dashed>-<prev>-to-<curr>.sql.gz  (delta; when previous exists)
+#   dist/pipeline/release/<dashed>.db.zst                   (baseline; when rebuild)
+#   dist/pipeline/release/<dashed>.db.zst.sha256            (baseline sha)
+#   dist/pipeline/release/<dashed>.meta.json                (manifest sidecar)
+set -euo pipefail
+
+: "${SHARD:?SHARD env var required}"
+: "${CATALOG_VERSION:?CATALOG_VERSION env var required}"
+BASELINE_REBUILD="${BASELINE_REBUILD:-false}"
+PREVIOUS_VERSION="${PREVIOUS_VERSION:-}"
+
+public_shard=$(echo "$SHARD" | tr _ -)
+
+today_db="dist/pipeline/today/${public_shard}.db"
+prev_db="dist/pipeline/prev/${public_shard}.db"
+release_dir="dist/pipeline/release"
+mkdir -p "$release_dir"
+
+test -f "$today_db" || { echo "missing today's shard at $today_db" >&2; exit 2; }
+
+has_previous="false"
+if [ -f "$prev_db" ]; then
+  has_previous="true"
+fi
+
+# 1) Sanity check — row-count drift + schema + FK integrity.
+python -m package.sanity_check \
+  --shard "$public_shard" \
+  --shard-db "$today_db" \
+  $(if [ "$has_previous" = "true" ]; then echo "--previous-db $prev_db"; fi)
+
+# 2) Delta — only when we have a previous baseline to chain from AND we're
+#    not forcing a full baseline rebuild (rebuild invalidates old chain).
+has_baseline="false"
+delta_from=""
+delta_to="$CATALOG_VERSION"
+
+if [ "$BASELINE_REBUILD" = "true" ] || [ "$has_previous" != "true" ]; then
+  has_baseline="true"
+  zstd -19 --long=27 -T0 -q -f -o "$release_dir/${public_shard}.db.zst" "$today_db"
+  (cd "$release_dir" && sha256sum "${public_shard}.db.zst" > "${public_shard}.db.zst.sha256")
+fi
+
+if [ "$has_previous" = "true" ] && [ "$BASELINE_REBUILD" != "true" ]; then
+  delta_from="$PREVIOUS_VERSION"
+  python -m package.build_delta \
+    --prev "$prev_db" \
+    --new  "$today_db" \
+    --out  "$release_dir/${public_shard}-${delta_from}-to-${delta_to}.sql.gz"
+fi
+
+# 3) Row count sidecar for manifest assembly.
+row_count=$(python -c "
+import sqlite3, sys
+con = sqlite3.connect('$today_db')
+print(con.execute('SELECT COUNT(*) FROM skus').fetchone()[0])
+con.close()
+")
+
+python - <<PYEOF > "$release_dir/${public_shard}.meta.json"
+import json
+print(json.dumps({
+    "shard": "$public_shard",
+    "row_count": int("$row_count"),
+    "has_baseline": "$has_baseline" == "true",
+    "delta_from": "$delta_from" or None,
+    "delta_to": "$delta_to",
+}, indent=2))
+PYEOF
+
+echo "diff_package_shard.sh: wrote $release_dir/ for $public_shard (baseline=$has_baseline delta_from='$delta_from')"

--- a/scripts/ci/ingest_shard.sh
+++ b/scripts/ci/ingest_shard.sh
@@ -20,6 +20,17 @@ mkdir -p "$RAW_DIR" "$OUT_DIR"
 public_shard=$(echo "$SHARD" | tr _ -)
 
 case "$SHARD" in
+  aws_ec2|aws_ebs)
+    # AmazonEC2 offer is 8+ GB combined. Drive per-region fetch + streaming
+    # strip inside the ingest module so we never materialize the full file.
+    stripped_dir="$RAW_DIR/${SHARD}-stripped"
+    mkdir -p "$stripped_dir"
+    python -m "ingest.${SHARD}" \
+      --offer-dir "$stripped_dir" \
+      --out "$OUT_DIR/$SHARD.rows.jsonl" \
+      --catalog-version "$CATALOG_VERSION"
+    ;;
+
   aws_*)
     offer="$RAW_DIR/${SHARD}-offer.json"
     python - <<PYEOF

--- a/scripts/ci/ingest_shard.sh
+++ b/scripts/ci/ingest_shard.sh
@@ -91,7 +91,9 @@ python -m package.build_shard \
 
 # Rename to dashed form so the filename matches the Go binary's expectation
 # (SKU_DATA_DIR lookups) and the public release-asset URL shape.
-mv "$OUT_DIR/$SHARD.db"          "$OUT_DIR/${public_shard}.db"
-mv "$OUT_DIR/$SHARD.rows.jsonl"  "$OUT_DIR/${public_shard}.rows.jsonl"
+if [ "$SHARD" != "$public_shard" ]; then
+  mv "$OUT_DIR/$SHARD.db"          "$OUT_DIR/${public_shard}.db"
+  mv "$OUT_DIR/$SHARD.rows.jsonl"  "$OUT_DIR/${public_shard}.rows.jsonl"
+fi
 
 echo "ingest_shard.sh: built $OUT_DIR/${public_shard}.db"

--- a/scripts/ci/ingest_shard.sh
+++ b/scripts/ci/ingest_shard.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Fetch upstream data → run ingest → build SQLite shard.
+#
+# Inputs (env):
+#   SHARD              — underscored shard id (e.g. `aws_ec2`, `openrouter`)
+#   CATALOG_VERSION    — catalog tag for today's release (e.g. `2026.04.18`)
+#   GCP_BILLING_API_KEY — required for `gcp_*` shards
+#
+# Output: `dist/pipeline/<dashed-shard>.db` + `.rows.jsonl` (dashed names
+# match what the Go binary expects in SKU_DATA_DIR).
+set -euo pipefail
+
+: "${SHARD:?SHARD env var required}"
+: "${CATALOG_VERSION:?CATALOG_VERSION env var required}"
+
+RAW_DIR="dist/pipeline/raw"
+OUT_DIR="dist/pipeline"
+mkdir -p "$RAW_DIR" "$OUT_DIR"
+
+public_shard=$(echo "$SHARD" | tr _ -)
+
+case "$SHARD" in
+  aws_*)
+    offer="$RAW_DIR/${SHARD}-offer.json"
+    python - <<PYEOF
+from pathlib import Path
+from ingest.aws_common import fetch_offer
+fetch_offer("$SHARD", Path("$offer"))
+PYEOF
+    python -m "ingest.${SHARD}" \
+      --offer "$offer" \
+      --out "$OUT_DIR/$SHARD.rows.jsonl" \
+      --catalog-version "$CATALOG_VERSION"
+    ;;
+
+  azure_*)
+    prices="$RAW_DIR/${SHARD}-prices.json"
+    python - <<PYEOF
+from pathlib import Path
+from discover.azure import _SHARD_FILTERS
+from ingest.azure_common import fetch_prices
+fetch_prices(_SHARD_FILTERS["$SHARD"], Path("$prices"))
+PYEOF
+    python -m "ingest.${SHARD}" \
+      --prices "$prices" \
+      --out "$OUT_DIR/$SHARD.rows.jsonl" \
+      --catalog-version "$CATALOG_VERSION"
+    ;;
+
+  gcp_*)
+    : "${GCP_BILLING_API_KEY:?GCP_BILLING_API_KEY required for GCP shards}"
+    skus="$RAW_DIR/${SHARD}-skus.json"
+    python - <<PYEOF
+import os
+from pathlib import Path
+from ingest.gcp_common import fetch_skus
+fetch_skus("$SHARD", Path("$skus"), api_key=os.environ["GCP_BILLING_API_KEY"])
+PYEOF
+    python -m "ingest.${SHARD}" \
+      --skus "$skus" \
+      --out "$OUT_DIR/$SHARD.rows.jsonl" \
+      --catalog-version "$CATALOG_VERSION"
+    ;;
+
+  openrouter)
+    dir="$RAW_DIR/openrouter"
+    mkdir -p "$dir"
+    python - <<PYEOF
+from pathlib import Path
+from ingest.openrouter import fetch
+fetch(Path("$dir"))
+PYEOF
+    python -m ingest.openrouter \
+      --fixture "$dir" \
+      --out "$OUT_DIR/$SHARD.rows.jsonl" \
+      --skip-non-usd \
+      --generated-at "${CATALOG_VERSION}T00:00:00Z"
+    ;;
+
+  *)
+    echo "ingest_shard.sh: unknown SHARD='$SHARD'" >&2
+    exit 2
+    ;;
+esac
+
+python -m package.build_shard \
+  --rows "$OUT_DIR/$SHARD.rows.jsonl" \
+  --shard "$SHARD" \
+  --out "$OUT_DIR/$SHARD.db" \
+  --catalog-version "$CATALOG_VERSION"
+
+# Rename to dashed form so the filename matches the Go binary's expectation
+# (SKU_DATA_DIR lookups) and the public release-asset URL shape.
+mv "$OUT_DIR/$SHARD.db"          "$OUT_DIR/${public_shard}.db"
+mv "$OUT_DIR/$SHARD.rows.jsonl"  "$OUT_DIR/${public_shard}.rows.jsonl"
+
+echo "ingest_shard.sh: built $OUT_DIR/${public_shard}.db"

--- a/scripts/ci/previous_release_version.sh
+++ b/scripts/ci/previous_release_version.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Print the catalog_version of the most recent `data-*` GitHub release.
+#
+# Output: bare version string (e.g. `2026.04.17`) with the `data-` prefix
+# stripped. Empty string when no prior release exists (first-ever run).
+#
+# Exit 0 on success (including "no release yet"); non-zero only when the
+# GitHub API is unreachable or auth is broken.
+set -euo pipefail
+tag=$(gh release list --limit 50 --json tagName --jq \
+  '[.[] | select(.tagName | startswith("data-"))] | .[0].tagName // ""')
+echo "${tag#data-}"

--- a/scripts/ci/purge_jsdelivr.sh
+++ b/scripts/ci/purge_jsdelivr.sh
@@ -11,7 +11,7 @@
 # users start seeing stale data.
 set -euo pipefail
 
-URL="https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json"
+URL="https://purge.jsdelivr.net/gh/sofq/sku@data/manifest.json"
 
 for attempt in 1 2 3; do
   if curl --fail --silent --show-error "$URL" >/dev/null; then

--- a/scripts/ci/purge_jsdelivr.sh
+++ b/scripts/ci/purge_jsdelivr.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Purge the jsDelivr edge cache for the `data` branch manifest.
+#
+# jsDelivr mirrors `https://cdn.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json`
+# from the `data` branch pushed by the publish job. When the branch updates
+# the CDN copy may stay cached for up to 12h; calling the purge endpoint
+# forces an invalidation.
+#
+# Retries 3 times with exponential backoff (2s, 8s, 30s). On final failure
+# files an issue via `gh issue create` so the maintainer notices before
+# users start seeing stale data.
+set -euo pipefail
+
+URL="https://purge.jsdelivr.net/gh/sofq/sku@latest/data/manifest.json"
+
+for attempt in 1 2 3; do
+  if curl --fail --silent --show-error "$URL" >/dev/null; then
+    echo "jsdelivr purge OK on attempt $attempt"
+    exit 0
+  fi
+  case $attempt in
+    1) sleep 2 ;;
+    2) sleep 8 ;;
+    3) sleep 30 ;;
+  esac
+done
+
+echo "jsdelivr purge FAILED after 3 attempts" >&2
+
+body="Automated issue — the daily manifest push succeeded but the jsDelivr purge API did not acknowledge after 3 retries (2s/8s/30s backoff). Users on the CDN fallback may see a stale manifest for up to 12h.
+
+Workflow run: ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-sofq/sku}/actions/runs/${GITHUB_RUN_ID:-unknown}
+
+To recover manually: curl --fail --silent --show-error \"$URL\""
+
+gh issue create \
+  --title "jsDelivr cache purge failed for catalog $(date -u +%Y-%m-%d)" \
+  --label "pipeline" \
+  --label "cdn-purge-failed" \
+  --body "$body"
+exit 1

--- a/scripts/ci/push_data_branch.sh
+++ b/scripts/ci/push_data_branch.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Force-push manifest.json to the `data` branch so jsDelivr can serve it at
+#   https://cdn.jsdelivr.net/gh/<repo>@latest/data/manifest.json
+#
+# Inputs (env):
+#   GH_TOKEN           — repo-scoped token (GITHUB_TOKEN from the workflow)
+#   GITHUB_REPOSITORY  — `owner/name`
+#   CATALOG_VERSION    — today's catalog tag (used in commit message)
+#
+# The `data` branch is an orphan branch carrying **only** the manifest file,
+# which keeps the tracked tree tiny (~1 KB) so jsDelivr serves it quickly and
+# the CDN purge cost stays low.
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
+: "${CATALOG_VERSION:?CATALOG_VERSION required}"
+
+MANIFEST_SRC="dist/pipeline/release/manifest.json"
+test -f "$MANIFEST_SRC" || { echo "missing $MANIFEST_SRC" >&2; exit 2; }
+
+workspace="${GITHUB_WORKSPACE:-$(pwd)}"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+cd "$tmp"
+git init -q
+git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git checkout -q --orphan data
+git rm -rfq . 2>/dev/null || true
+
+mkdir -p data
+cp "$workspace/$MANIFEST_SRC" data/manifest.json
+git add data/manifest.json
+git -c user.email="bot@sku" -c user.name="sku-data-bot" commit -q -m "data-${CATALOG_VERSION}"
+git push -qf origin data
+
+echo "push_data_branch.sh: force-pushed data branch for data-${CATALOG_VERSION}"

--- a/scripts/ci/push_data_branch.sh
+++ b/scripts/ci/push_data_branch.sh
@@ -30,9 +30,10 @@ git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_RE
 git checkout -q --orphan data
 git rm -rfq . 2>/dev/null || true
 
-mkdir -p data
-cp "$workspace/$MANIFEST_SRC" data/manifest.json
-git add data/manifest.json
+# Manifest lives at the branch root so jsDelivr serves it as
+#   https://cdn.jsdelivr.net/gh/<repo>@data/manifest.json
+cp "$workspace/$MANIFEST_SRC" manifest.json
+git add manifest.json
 git -c user.email="bot@sku" -c user.name="sku-data-bot" commit -q -m "data-${CATALOG_VERSION}"
 git push -qf origin data
 


### PR DESCRIPTION
## Summary

Stacks on PR #3 (m3a.4.1). Implements the full `data-daily.yml` server-side chain per plan `docs/superpowers/plans/2026-04-18-m3a.4.2-data-daily-workflow.md`:

- **Composite action** `.github/actions/setup-pipeline/action.yml` (shared with m3a.4.3's validate workflow later).
- **Workflow** `.github/workflows/data-daily.yml`: cron (commented until first green run) + `workflow_dispatch` with `dry_run` + `force_baseline` inputs. Five jobs: discover → ingest (matrix) → diff-package (matrix) → publish.
- **Python modules** under `pipeline/package/`:
  - `build_delta.py` — round-trip-safe SQL.gz delta builder between two shards (19 new tests; ±max_bytes split).
  - `build_manifest.py` — assembles `manifest.json` per spec §3 (baseline + deltas-chain carry-forward).
  - `sanity_check.py` — row-count drift, schema diff, FK orphan, `metadata.generated_at` presence.
- **Shell shims** under `scripts/ci/`:
  - `ingest_shard.sh` — fetches live AWS offer / Azure retail-prices / GCP billing catalogue / OpenRouter endpoints, runs the matching ingest, packages a SQLite shard.
  - `diff_package_shard.sh` — sanity + delta + optional `.db.zst` baseline + `.meta.json` sidecar per shard.
  - `build_manifest.sh` — wraps the Python entrypoint with previous-manifest fetch.
  - `push_data_branch.sh` — orphan-checkouts, writes `manifest.json` at branch root, force-pushes `data`.
  - `purge_jsdelivr.sh` — 3-retry backoff against `@data/manifest.json` + auto-issue on failure.
  - `previous_release_version.sh` — last `data-*` tag lookup.
- **Issue template** `cdn-purge-failed.md` + **runbook** `docs/ops/data-daily-runbook.md`.
- **CLAUDE.md** milestone pointer bumped to M3a.4.2 with two new dispatch entries under Dev commands.

Pipeline tests: 218 passing (up from 199) — new coverage for build_delta (5), build_manifest (6), sanity_check (8).

## Still to do (maintainer action required — plan Tasks 11/12/14)

Cron is intentionally commented out. Before merging:

1. Dispatch dry-run from this branch:
   ```
   gh workflow run data-daily.yml --ref m3a.4.2-data-daily-workflow -F dry_run=true -F force_baseline=true
   ```
   Confirm the discover / ingest / diff-package matrices all go green and the `release-*` artifacts look sane (decompress a `.db.zst`, check `sqlite3 .tables`).
2. Dispatch a real publish run (after dry-run is green):
   ```
   gh workflow run data-daily.yml --ref m3a.4.2-data-daily-workflow -F dry_run=false -F force_baseline=true
   ```
   Verify the `data-YYYY.MM.DD` GitHub release appeared, the `data` branch was force-pushed, and `curl https://cdn.jsdelivr.net/gh/sofq/sku@data/manifest.json` returns the new file.
3. Uncomment the cron schedule in `data-daily.yml`, push as a follow-up commit, then mark this PR ready.

The runbook in `docs/ops/data-daily-runbook.md` walks through all of this.

## Secrets required on the repo

- `GCP_BILLING_API_KEY` — restricted Cloud Billing API key for the `gcp_*` shards. Runbook §Secrets covers creation.
- `GITHUB_TOKEN` — auto-injected; no action required.

## Non-goals (per plan)

- Validation (OIDC cross-check vs upstream) → m3a.4.3.
- Client-side `internal/updater` delta-chain walker / ETag / channels → m3a.4.3.
- Code-signing of shards → m7.3 (security.yml).

## Test plan

- [x] `make pipeline-test` green (218 passing).
- [x] `.github/workflows/data-daily.yml` parses as valid YAML.
- [x] `bash -n` on all new shell shims.
- [x] Ruff lint + format clean on new Python modules.
- [x] `make discover` dry-run still emits the expected `baseline_rebuild=true, shards=[]` output (no pipeline regression).
- [ ] Dry-run dispatch green (maintainer).
- [ ] Publish dispatch green + jsDelivr URL returns 200 (maintainer).
- [ ] Cron enabled in follow-up commit (maintainer).

## Notes

- Base branch is `m3a.4.1-live-fetch-and-discover` (PR #3) because this work depends on the `fetch_*` helpers from that branch. Rebase onto `main` after #3 merges.
- jsDelivr URL uses `@data` (branch, not `@latest` tag) — the plan and spec both said `@latest/data/...`, which would 404 because the `data-YYYY.MM.DD` tags point at `main` (which doesn't contain a `manifest.json`). The spec is worth a follow-up fix so m3a.4.3's client updater uses the correct URL.