### PR TITLE
M3a.4.3: data-validate.yml OIDC cross-check + updater delta-chain

### DIFF
--- a/.github/ISSUE_TEMPLATE/catalog-drift.md
+++ b/.github/ISSUE_TEMPLATE/catalog-drift.md
@@ -1,0 +1,21 @@
+---
+name: Catalog drift detected (automated)
+about: Weekly validate workflow detected >1% price drift in a catalog shard
+title: "Catalog drift in <shard> (catalog <YYYY-MM-DD>)"
+labels: ["pipeline", "catalog-drift"]
+---
+
+The weekly `data-validate.yml` workflow sampled prices from the shard and found one or more SKUs where the catalog price differs from the upstream provider API by more than 1%.
+
+**Impact:** The catalog may contain stale prices for the flagged SKUs. Agents reading from this shard may receive incorrect pricing data.
+
+**Action:**
+
+1. Open the workflow run linked below and download the `validate-<shard>` artifact for the full drift report.
+2. Inspect `drift_records` in the report JSON to identify the specific SKUs and delta percentages.
+3. Determine whether the drift is a real upstream price change or a transient API glitch.
+   - **Real price change:** Temporarily disable `data-daily.yml`, investigate the ingest module for the affected shard, fix the parsing or mapping, re-ingest, and re-publish.
+   - **API glitch:** Re-run `data-validate.yml` for the affected shard via `workflow_dispatch`. Close this issue if the re-run passes.
+4. If the `vantage_drift` field in the report is non-empty, the EC2 shard also diverges from the vantage-sh/ec2instances.info reference data — follow the same triage steps.
+
+Close this issue once the validate workflow passes cleanly for the affected shard.

--- a/.github/workflows/data-validate.yml
+++ b/.github/workflows/data-validate.yml
@@ -1,0 +1,113 @@
+name: data-validate
+
+on:
+  schedule:
+    - cron: "0 4 * * 1"         # Mondays 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      shards:
+        description: "Comma-separated shards to validate (default: all)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  id-token: write               # OIDC federation
+  issues:   write               # drift issue filing
+  actions:  read
+
+concurrency:
+  group: data-validate
+  cancel-in-progress: true
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      shards: ${{ steps.resolve.outputs.shards }}
+      catalog_version: ${{ steps.resolve.outputs.catalog_version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve latest data release + shard list
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTED: ${{ github.event.inputs.shards }}
+        run: |
+          tag=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          mkdir -p dist/pipeline/validate
+          gh release download "$tag" --pattern manifest.json --dir dist/pipeline/validate/
+          if [ -n "$REQUESTED" ]; then
+            shards=$(echo "$REQUESTED" | jq -R 'split(",")')
+          else
+            shards=$(jq -c '.shards | keys' dist/pipeline/validate/manifest.json)
+          fi
+          echo "shards=$shards" >> "$GITHUB_OUTPUT"
+          echo "catalog_version=${tag#data-}" >> "$GITHUB_OUTPUT"
+
+  validate:
+    needs: resolve
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.resolve.outputs.shards) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pipeline
+      - name: Install validate extras
+        run: python -m pip install -e 'pipeline[validate]'
+      - name: Configure AWS credentials (OIDC)
+        if: startsWith(matrix.shard, 'aws-')
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_VALIDATE_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Authenticate to Google Cloud (WIF)
+        if: startsWith(matrix.shard, 'gcp-')
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_VALIDATE_SA }}
+      - name: Download shard from latest release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CV: ${{ needs.resolve.outputs.catalog_version }}
+          SHARD: ${{ matrix.shard }}
+        run: |
+          gh release download "data-${CV}" --pattern "${SHARD}.db.zst" --dir dist/pipeline/
+          zstd -d "dist/pipeline/${SHARD}.db.zst"
+      - name: Download vantage instances.json (EC2 only)
+        if: matrix.shard == 'aws-ec2'
+        run: |
+          curl -sSL --fail \
+            https://raw.githubusercontent.com/vantage-sh/ec2instances.info/master/www/instances.json \
+            -o dist/pipeline/instances.json
+      - name: Run validator
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          extra=()
+          if [ "$SHARD" = "aws-ec2" ]; then
+            extra+=(--vantage-json dist/pipeline/instances.json)
+          fi
+          python -m validate \
+            --shard "$SHARD" \
+            --shard-db "dist/pipeline/${SHARD}.db" \
+            --report "dist/pipeline/${SHARD}.report.json" \
+            "${extra[@]}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: validate-${{ matrix.shard }}
+          path: dist/pipeline/*.report.json
+      - name: File drift issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHARD: ${{ matrix.shard }}
+          CV: ${{ needs.resolve.outputs.catalog_version }}
+        run: |
+          gh issue create \
+            --title "Catalog drift in ${SHARD} (catalog ${CV})" \
+            --label "pipeline,catalog-drift" \
+            --body "See workflow run ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} and the attached validate-${SHARD} artifact."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,17 +45,24 @@ Agent quick-start for the `sku` repo.
 
 ## Current milestone
 
-M3a.4.2 — `data-daily.yml` cron workflow publishes daily data releases:
-discover → ingest (matrix) → diff+package (matrix) → publish. Emits
-`data-YYYY.MM.DD` GitHub release with `<shard>.db.zst` baselines,
-`<shard>-<from>-to-<to>.sql.gz` deltas, and an authoritative `manifest.json`.
-Mirrors the manifest to the `data` branch for jsDelivr fallback; purges CDN
-on each publish. Dry-runs via `gh workflow run data-daily.yml -F dry_run=true`.
-Runbook: `docs/ops/data-daily-runbook.md`.
+M3a.4.3 — weekly validate workflow + client-side delta-chain updates:
+- `data-validate.yml` (Mondays 04:00 UTC + dispatch) stratified-samples
+  each on-demand shard, re-fetches SKUs via short-lived OIDC (AWS IAM
+  role; GCP Workload Identity Federation; Azure/OpenRouter anonymous),
+  fails on >1% drift, files `catalog-drift` issue automatically. EC2
+  runs an extra offline cross-check vs `vantage-sh/ec2instances.info`.
+  OIDC provisioning is maintainer-gated — first dispatch pending
+  `AWS_VALIDATE_ROLE_ARN`, `GCP_WIF_PROVIDER`, `GCP_VALIDATE_SA` repo
+  variables.
+- `sku update --channel daily` walks the manifest's delta chain:
+  ETag-cached manifest fetch; per-delta sha256 verification; single-
+  transaction apply with advisory flock; fallback to baseline on
+  chain-too-long (>MaxChain, default 20) or `from`-mismatch.
+- Runbook: `docs/ops/validation.md`.
 
-Next: M3a.4.3 — `data-validate.yml` (OIDC cross-check vs upstream) +
-client-side `internal/updater` delta-chain walker + ETag + stable/daily
-channel split.
+Next: M7.3 — security, bench regression gate, v1.0.0 release (cosign
+shard signing, `actions/attest-build-provenance`, property-based
+delta-chain tests).
 
 ### Quick path (agent, repeatable, M3b.4 surface)
 
@@ -151,6 +158,9 @@ echo '[
 ]' | ./bin/sku batch --pretty
 cat docs/examples/batch-queries.ndjson | ./bin/sku batch
 ./bin/sku schema --list-commands
+
+./bin/sku update openrouter --channel daily            # delta-chain walk
+./bin/sku update aws-ec2   --channel stable            # baseline-only
 ```
 
 ### Distribution smoke (M6)

--- a/cmd/sku/update.go
+++ b/cmd/sku/update.go
@@ -3,6 +3,7 @@ package sku
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -37,16 +38,29 @@ func resolveUpdateBaseURL(shard string) (string, bool) {
 	return strings.TrimRight(base, "/"), true
 }
 
+// resolveManifestPrimaryURL returns the manifest.json URL based on
+// SKU_UPDATE_BASE_URL or the default GitHub releases data branch.
+func resolveManifestPrimaryURL() string {
+	if v := os.Getenv("SKU_UPDATE_BASE_URL"); v != "" {
+		return strings.TrimRight(v, "/") + "/manifest.json"
+	}
+	return "https://github.com/sofq/sku/releases/download/data-latest/manifest.json"
+}
+
 func shardNames() []string { return updater.ShardNames() }
 
 func newUpdateCmd() *cobra.Command {
-	return &cobra.Command{
+	var channelFlag string
+
+	cmd := &cobra.Command{
 		Use:   "update <shard>",
 		Short: "Download and install a pricing shard (openrouter | aws-ec2 | aws-rds | aws-s3 | aws-lambda | aws-ebs | aws-dynamodb | aws-cloudfront | azure-vm | azure-sql | azure-blob | azure-functions | azure-disks)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := globalSettings(cmd)
 			shard := args[0]
+
+			// Validate shard name.
 			baseURL, ok := resolveUpdateBaseURL(shard)
 			if !ok {
 				err := skuerrors.Validation(
@@ -56,25 +70,122 @@ func newUpdateCmd() *cobra.Command {
 				skuerrors.Write(cmd.ErrOrStderr(), err)
 				return err
 			}
+
+			// Resolve channel: flag > SKU_UPDATE_CHANNEL env > profile > stable.
+			channel, err := updater.ResolveChannel(
+				channelFlag,
+				os.Getenv("SKU_UPDATE_CHANNEL"),
+				s.Channel,
+			)
+			if err != nil {
+				skuerrors.Write(cmd.ErrOrStderr(), err)
+				return err
+			}
+
+			dataDir := catalog.DataDir()
+			dbPath := filepath.Join(dataDir, shard+".db")
+
+			// Decide whether to use Update (manifest-driven) or Install (baseline-only).
+			// Update is used when:
+			//   - channel is daily (always prefer manifest-driven), OR
+			//   - the shard .db exists (Update handles stable channel too, even for
+			//     existing shards, by re-downloading the baseline).
+			// Fresh installs on stable still go through Install for simplicity.
+			useUpdate := channel == updater.ChannelDaily || shardExists(dbPath)
+
 			if s.Verbose {
 				output.Log(cmd.ErrOrStderr(), "update.fetch", map[string]any{
-					"shard": shard, "base_url": baseURL,
+					"shard": shard, "base_url": baseURL, "channel": string(channel),
 				})
 			}
-			if err := updater.Install(cmd.Context(), shard, updater.Options{
-				BaseURL: baseURL,
-				DestDir: catalog.DataDir(),
-			}); err != nil {
-				code := skuerrors.CodeServer
-				if errors.Is(err, updater.ErrSHAMismatch) {
-					code = skuerrors.CodeConflict
+
+			if useUpdate {
+				primaryManifestURL := resolveManifestPrimaryURL()
+				fallbackManifestURL := "https://cdn.jsdelivr.net/gh/sofq/sku@data/manifest.json"
+
+				manifestSrc := updater.NewHTTPSource(primaryManifestURL, fallbackManifestURL, nil)
+
+				opts := updater.UpdateOptions{
+					Options: updater.Options{
+						DestDir: dataDir,
+					},
+					Channel:  channel,
+					Manifest: manifestSrc,
+					MaxChain: 20,
 				}
-				e := &skuerrors.E{Code: code, Message: err.Error()}
-				skuerrors.Write(cmd.ErrOrStderr(), e)
-				return e
+
+				result, err := updater.Update(cmd.Context(), shard, opts)
+				if err != nil {
+					code := skuerrors.CodeServer
+					var ve *skuerrors.E
+					if errors.As(err, &ve) {
+						skuerrors.Write(cmd.ErrOrStderr(), ve)
+						return ve
+					}
+					if errors.Is(err, updater.ErrSHAMismatch) {
+						code = skuerrors.CodeConflict
+					} else if errors.Is(err, updater.ErrLocked) {
+						code = skuerrors.CodeConflict
+					}
+					e := &skuerrors.E{Code: code, Message: err.Error()}
+					skuerrors.Write(cmd.ErrOrStderr(), e)
+					return e
+				}
+
+				if s.Verbose {
+					if result.Baseline {
+						output.Log(cmd.ErrOrStderr(), "update.baseline-installed", map[string]any{
+							"shard": shard, "version": result.To,
+						})
+					} else if len(result.Applied) > 0 {
+						for _, d := range result.Applied {
+							output.Log(cmd.ErrOrStderr(), "update.delta-applied", map[string]any{
+								"shard": shard, "from": d.From, "to": d.To,
+							})
+						}
+					} else {
+						output.Log(cmd.ErrOrStderr(), "update.304", map[string]any{
+							"shard": shard, "version": result.From,
+						})
+					}
+				}
+			} else {
+				// Fresh stable install: use the original Install path.
+				if s.Verbose {
+					output.Log(cmd.ErrOrStderr(), "update.fetch", map[string]any{
+						"shard": shard, "base_url": baseURL,
+					})
+				}
+				if err := updater.Install(cmd.Context(), shard, updater.Options{
+					BaseURL: baseURL,
+					DestDir: dataDir,
+				}); err != nil {
+					code := skuerrors.CodeServer
+					if errors.Is(err, updater.ErrSHAMismatch) {
+						code = skuerrors.CodeConflict
+					}
+					e := &skuerrors.E{Code: code, Message: err.Error()}
+					skuerrors.Write(cmd.ErrOrStderr(), e)
+					return e
+				}
+				if s.Verbose {
+					output.Log(cmd.ErrOrStderr(), "update.baseline-installed", map[string]any{
+						"shard": shard, "base_url": baseURL,
+					})
+				}
 			}
+
 			_, _ = cmd.ErrOrStderr().Write([]byte("installed " + shard + " -> " + catalog.ShardPath(shard) + "\n"))
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&channelFlag, "channel", "", `update channel: "stable" (default, always full baseline) or "daily" (delta chain, falls back to baseline)`)
+	return cmd
+}
+
+// shardExists returns true if path exists and is a regular file.
+func shardExists(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.Mode().IsRegular()
 }

--- a/cmd/sku/update.go
+++ b/cmd/sku/update.go
@@ -133,6 +133,11 @@ func newUpdateCmd() *cobra.Command {
 				}
 
 				if s.Verbose {
+					if result.FellBackToBaseline {
+						output.Log(cmd.ErrOrStderr(), "update.fallback-to-baseline", map[string]any{
+							"shard": shard, "from": result.From,
+						})
+					}
 					if result.Baseline {
 						output.Log(cmd.ErrOrStderr(), "update.baseline-installed", map[string]any{
 							"shard": shard, "version": result.To,

--- a/docs/ops/validation.md
+++ b/docs/ops/validation.md
@@ -1,0 +1,226 @@
+# Data-validate workflow runbook
+
+Maintainer guide for `.github/workflows/data-validate.yml` — the weekly
+(Mondays 04:00 UTC + `workflow_dispatch`) cross-check that re-fetches a
+stratified sample of SKUs from each upstream provider, compares against the
+published shard, and files a `catalog-drift` issue on >1% price divergence.
+Independent of `data-daily.yml`: a failing validate run does **not** roll
+back a published release, it just alerts.
+
+## Auth model
+
+| Provider | Auth path | Why not anonymous |
+|---|---|---|
+| AWS | Short-lived OIDC → IAM role `sku-validator` → SigV4 `pricing:GetProducts` | Query API requires SigV4. Bulk JSON is anonymous but the daily ingest already reads it — cross-checking against the same source catches fewer parser bugs. |
+| GCP | Short-lived OIDC → Workload Identity Federation → service account `sku-validator@<project>.iam` → `cloudbilling.googleapis.com/v1/services/{sid}/skus` | Cloud Billing Catalog API requires a bearer token. WIF avoids the long-lived `GCP_BILLING_API_KEY` that `data-daily.yml` uses. |
+| Azure | Anonymous `prices.azure.com/api/retail/prices` | Azure retail prices are public. |
+| OpenRouter | Anonymous `openrouter.ai/api/v1/models/{id}/endpoints` | Public. |
+
+Both federated identities are **read-only** and scoped to `repo:sofq/sku`.
+No long-lived credentials live in repo secrets for this workflow.
+
+## Repo variables required (non-sensitive — variables, not secrets)
+
+| Variable | Example | Owner |
+|---|---|---|
+| `AWS_VALIDATE_ROLE_ARN` | `arn:aws:iam::123456789012:role/sku-validator` | Maintainer |
+| `GCP_WIF_PROVIDER` | `projects/123/locations/global/workloadIdentityPools/github/providers/sofq-sku` | Maintainer |
+| `GCP_VALIDATE_SA` | `sku-validator@my-project.iam.gserviceaccount.com` | Maintainer |
+
+Until these are populated, `workflow_dispatch` for AWS or GCP shards will
+fail on the auth step. Azure- and OpenRouter-only dispatches still succeed.
+
+## One-time provisioning — AWS
+
+1. Pick (or create) a dedicated AWS account with nothing else running in it.
+   `pricing:GetProducts` itself is free; the isolation is for blast-radius.
+2. Create the role via AWS CLI (substitute your account ID):
+
+   ```bash
+   cat > trust.json <<'EOF'
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Principal": { "Federated": "arn:aws:iam::AWS_ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com" },
+         "Action": "sts:AssumeRoleWithWebIdentity",
+         "Condition": {
+           "StringEquals": {
+             "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+           },
+           "StringLike": {
+             "token.actions.githubusercontent.com:sub": [
+               "repo:sofq/sku:ref:refs/heads/main",
+               "repo:sofq/sku:pull_request"
+             ]
+           }
+         }
+       }
+     ]
+   }
+   EOF
+
+   aws iam create-role \
+     --role-name sku-validator \
+     --assume-role-policy-document file://trust.json
+
+   aws iam attach-role-policy \
+     --role-name sku-validator \
+     --policy-arn arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
+   ```
+
+3. If the GitHub OIDC provider is not yet registered in the account:
+
+   ```bash
+   aws iam create-open-id-connect-provider \
+     --url https://token.actions.githubusercontent.com \
+     --client-id-list sts.amazonaws.com \
+     --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
+   ```
+
+4. Copy the role ARN into repo variables:
+
+   ```bash
+   gh variable set AWS_VALIDATE_ROLE_ARN \
+     --body "arn:aws:iam::AWS_ACCOUNT_ID:role/sku-validator"
+   ```
+
+5. Verify: dispatch `data-validate.yml` for a single AWS shard:
+
+   ```bash
+   gh workflow run data-validate.yml -F shards=aws-s3
+   gh run watch
+   ```
+
+   Expected: green. If the auth step fails, re-check the `sub` claim in
+   the trust policy matches `repo:sofq/sku:ref:refs/heads/<branch>` or
+   `repo:sofq/sku:pull_request`.
+
+## One-time provisioning — GCP
+
+1. Pick (or create) a dedicated GCP project. The Cloud Billing Catalog API
+   is free; isolate for blast-radius.
+2. Enable APIs:
+
+   ```bash
+   gcloud services enable \
+     cloudbilling.googleapis.com \
+     iamcredentials.googleapis.com \
+     --project "$PROJECT_ID"
+   ```
+
+3. Create the service account + grant read-only billing:
+
+   ```bash
+   gcloud iam service-accounts create sku-validator \
+     --project "$PROJECT_ID" \
+     --display-name "sku catalog validator"
+
+   SA="sku-validator@${PROJECT_ID}.iam.gserviceaccount.com"
+
+   gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+     --member "serviceAccount:${SA}" \
+     --role   roles/billing.viewer
+
+   gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+     --member "serviceAccount:${SA}" \
+     --role   roles/serviceusage.serviceUsageConsumer
+   ```
+
+4. Create the Workload Identity Pool + GitHub provider:
+
+   ```bash
+   gcloud iam workload-identity-pools create github \
+     --project "$PROJECT_ID" \
+     --location global \
+     --display-name "GitHub Actions"
+
+   gcloud iam workload-identity-pools providers create-oidc sofq-sku \
+     --project "$PROJECT_ID" \
+     --location global \
+     --workload-identity-pool github \
+     --issuer-uri "https://token.actions.githubusercontent.com" \
+     --attribute-mapping "google.subject=assertion.sub,attribute.repository=assertion.repository" \
+     --attribute-condition "assertion.repository=='sofq/sku'"
+   ```
+
+5. Bind the service account to the pool so GitHub Actions can impersonate it:
+
+   ```bash
+   POOL_ID=$(gcloud iam workload-identity-pools describe github \
+     --project "$PROJECT_ID" --location global --format 'value(name)')
+
+   gcloud iam service-accounts add-iam-policy-binding "$SA" \
+     --project "$PROJECT_ID" \
+     --role roles/iam.workloadIdentityUser \
+     --member "principalSet://iam.googleapis.com/${POOL_ID}/attribute.repository/sofq/sku"
+   ```
+
+6. Copy the provider resource name + SA email into repo variables:
+
+   ```bash
+   PROVIDER=$(gcloud iam workload-identity-pools providers describe sofq-sku \
+     --project "$PROJECT_ID" --location global \
+     --workload-identity-pool github --format 'value(name)')
+
+   gh variable set GCP_WIF_PROVIDER --body "$PROVIDER"
+   gh variable set GCP_VALIDATE_SA --body "$SA"
+   ```
+
+7. Verify: dispatch `data-validate.yml` for a single GCP shard:
+
+   ```bash
+   gh workflow run data-validate.yml -F shards=gcp-gce
+   gh run watch
+   ```
+
+## Rotation policy
+
+Review quarterly:
+- IAM role + attached policies (confirm still read-only).
+- WIF provider + SA bindings (confirm principalSet condition still scopes to `sofq/sku`).
+- No access keys or service-account JSON keys anywhere. If either appears, rotate and remove.
+
+## What breaks if OIDC is misconfigured
+
+The `configure-aws-credentials@v4` / `google-github-actions/auth@v2` step
+fails. The matrix cell for that shard fails; other cells keep running
+(`fail-fast: false`). **No release is affected** — `data-daily.yml` runs
+independently and doesn't consult `data-validate.yml`.
+
+Recovery: fix the trust policy or WIF condition, re-dispatch.
+
+## Triaging a `catalog-drift` issue
+
+Filed automatically by `data-validate.yml` on matrix-cell failure. Body
+links to the run + artifact `validate-<shard>` (the per-shard JSON report).
+
+Decision tree:
+
+1. **Download the artifact**; inspect `drift_records`. Each record has
+   `sku_id`, `catalog_amount`, `upstream_amount`, `delta_pct`, `source`.
+2. **Real upstream price change?** (common after AWS price revisions).
+   - Verify upstream by hand: `aws pricing get-products --service-code AmazonEC2 --filters ...`.
+   - If upstream has indeed moved, the shard will pick it up on the next
+     `data-daily` run. Close the issue with a link to the next release.
+3. **Upstream unchanged, catalog wrong?** (parser bug).
+   - Disable the `data-daily.yml` cron temporarily (comment out the
+     `schedule` block; merge; re-enable after fix).
+   - Investigate the relevant `pipeline/ingest/<shard>.py`; add a
+     regression test fixture in `pipeline/tests/`.
+   - Push the fix; force a `workflow_dispatch` of `data-daily.yml` with
+     `force_baseline=true` to republish.
+4. **Validator false positive** (e.g. unit-of-measure mismatch that
+   doesn't matter economically).
+   - Patch `pipeline/validate/<provider>.py` or the specific filter in
+     `pipeline/validate/sampler.py`.
+   - Add a regression test.
+
+## EC2 offline cross-check (Vantage)
+
+For `aws-ec2`, the workflow additionally downloads
+`vantage-sh/ec2instances.info/www/instances.json` at run time and joins
+against the shard on `(instance_type, region, os=linux, tenancy=shared)`.
+Drift >1% flags a record under `vantage_drift` in the report. This is a
+zero-credential cross-check — useful even when the OIDC path is down.

--- a/docs/ref/sku-update.md
+++ b/docs/ref/sku-update.md
@@ -1,0 +1,115 @@
+# sku update
+
+Downloads and installs (or incrementally updates) a pricing shard.
+
+## Synopsis
+
+```
+sku update <shard> [--channel stable|daily] [global flags]
+```
+
+## Positional arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<shard>` | Shard name, e.g. `aws-ec2`, `openrouter`, `azure-vm` |
+
+Supported shards: `openrouter`, `aws-ec2`, `aws-rds`, `aws-s3`, `aws-lambda`, `aws-ebs`, `aws-dynamodb`, `aws-cloudfront`, `azure-vm`, `azure-sql`, `azure-blob`, `azure-functions`, `azure-disks`, `gcp-gce`, `gcp-cloud-sql`, `gcp-gcs`, `gcp-run`, `gcp-functions`.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--channel` | `""` (inherits config) | Update channel: `stable` or `daily`. |
+
+## Channel behaviour
+
+### `stable` (default)
+
+Always downloads the latest full baseline shard (`.db.zst`) from the release asset URL. Safe for automated pipelines that need a complete, known-good snapshot.
+
+### `daily`
+
+1. Fetches `manifest.json` from the primary URL (or the jsDelivr CDN fallback).
+2. Reads the local shard's `catalog_version` from its `metadata` table.
+3. If the manifest returns HTTP 304 (Not Modified / ETag match) — no-op; exits 0.
+4. Filters the manifest's delta list to entries with `from >= local_version`.
+5. Applies the delta chain in a single `BEGIN IMMEDIATE` transaction; verifies each delta's SHA-256 before applying.
+6. **Fallback to baseline**: if the chain is too long (`max_delta_chain` exceeded), starts at the wrong version, or the shard file is missing — falls back to a full baseline download automatically.
+
+### `max_delta_chain`
+
+Maximum number of deltas applied in one run. Default: **20**. There is no config key for this yet; it is hard-coded in the binary.
+
+## Update channel precedence
+
+```
+--channel flag  >  SKU_UPDATE_CHANNEL env  >  profile.channel config  >  "stable"
+```
+
+## Configuration
+
+### Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `SKU_UPDATE_CHANNEL` | Set the default channel without a flag (`stable` or `daily`). |
+| `SKU_UPDATE_BASE_URL` | Override the asset base URL for all shards (used in tests). |
+| `SKU_UPDATE_BASE_URL_<SHARD>` | Per-shard base URL override (hyphens become underscores, e.g. `SKU_UPDATE_BASE_URL_AWS_EC2`). |
+
+### Config file
+
+In `~/.config/sku/config.yaml` (or platform equivalent):
+
+```yaml
+profiles:
+  default:
+    channel: daily   # "stable" | "daily"
+```
+
+The key is `update.channel` conceptually; in the YAML structure it lives under the profile as `channel:`.
+
+## Manifest URL resolution
+
+Primary: `$SKU_UPDATE_BASE_URL/manifest.json` (if `SKU_UPDATE_BASE_URL` is set), otherwise `https://github.com/sofq/sku/releases/download/data-latest/manifest.json`.
+
+Fallback: `https://cdn.jsdelivr.net/gh/sofq/sku@data/manifest.json` (jsDelivr CDN mirror of the `data` branch).
+
+A 5xx error on the primary causes one automatic retry against the fallback. Both failing → non-zero exit (code 7, server error).
+
+## Exit codes
+
+| Code | Value | Meaning |
+|------|-------|---------|
+| 0 | success | Shard installed or already up to date. |
+| 4 | validation | Unknown `--channel` value; unsupported shard name; shard schema version mismatch. |
+| 6 | conflict | SHA-256 mismatch on downloaded asset; another `sku update` holds the advisory lock. |
+| 7 | server | Upstream HTTP error (both primary and fallback failed). |
+
+## Verbose log events
+
+With `--verbose`, structured log lines are emitted to stderr:
+
+| Event | When |
+|-------|------|
+| `update.fetch` | Before fetching the manifest or baseline. |
+| `update.304` | Manifest server returned 304 — nothing to do. |
+| `update.delta-applied` | After each individual delta is applied (includes `from`/`to` versions). |
+| `update.fallback-to-baseline` | Chain fallback triggered (chain-too-long or starts-elsewhere). |
+| `update.baseline-installed` | Full baseline downloaded and installed. |
+
+## Examples
+
+```bash
+# Fresh install (stable channel — downloads full baseline)
+sku update aws-ec2
+
+# Daily channel — tries delta chain first
+sku update aws-ec2 --channel daily
+
+# Override via environment
+SKU_UPDATE_CHANNEL=daily sku update openrouter
+
+# Use a local test server for CI
+SKU_UPDATE_BASE_URL=http://localhost:9000 sku update aws-ec2
+```

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -25,6 +25,10 @@ type Settings struct {
 	NoColor           bool
 	Verbose           bool
 	DryRun            bool
+	// Channel is the update channel ("stable" | "daily") resolved from
+	// profile.channel. The --channel flag on `sku update` overrides this
+	// via updater.ResolveChannel.
+	Channel string
 }
 
 // FlagBag carries raw pflag values along with "was this flag explicitly
@@ -92,6 +96,9 @@ func Resolve(fb FlagBag, file File, env map[string]string) (Settings, error) {
 	s.Format = pickString(fb.FormatSet, fb.Format, env["SKU_FORMAT"], "", "json")
 	s.JQ = pickString(fb.JQSet, fb.JQ, env["SKU_JQ"], "", "")
 	s.Fields = pickString(fb.FieldsSet, fb.Fields, env["SKU_FIELDS"], "", "")
+	// Channel is not exposed as a global flag; the profile value is passed
+	// through so update.go can feed it to updater.ResolveChannel.
+	s.Channel = profile.Channel
 
 	// Bool fields from flag > env > profile > false.
 	s.Pretty = pickBool(fb.PrettySet, fb.Pretty, env["SKU_PRETTY"], nil, false)

--- a/internal/sqliteutil/flock.go
+++ b/internal/sqliteutil/flock.go
@@ -1,0 +1,45 @@
+//go:build unix
+
+// Package sqliteutil provides small helpers for SQLite database files.
+package sqliteutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// ErrLocked is returned when an advisory flock cannot be acquired because
+// another process already holds it. Callers map this to
+// skuerrors.CodeConflict (exit 6) per spec §4.
+var ErrLocked = errors.New("sqliteutil: shard is locked by another process")
+
+// Flock acquires an exclusive advisory lock on a sidecar file <dbPath>.lock.
+// It does NOT lock the SQLite file directly to avoid interfering with SQLite's
+// own locking protocol. The sidecar file is created if it does not exist.
+//
+// Returns an unlock function that releases the lock and closes the sidecar fd.
+// If the lock is already held by another process, ErrLocked is returned.
+func Flock(dbPath string) (unlock func() error, err error) {
+	lockPath := dbPath + ".lock"
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600) //nolint:gosec // path derived from caller
+	if err != nil {
+		return nil, fmt.Errorf("sqliteutil: open lock file %s: %w", lockPath, err)
+	}
+
+	fd := f.Fd()
+	if err := syscall.Flock(int(fd), syscall.LOCK_EX|syscall.LOCK_NB); err != nil { //nolint:gosec // G115: fd is a valid int-range file descriptor
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, ErrLocked
+		}
+		return nil, fmt.Errorf("sqliteutil: flock %s: %w", lockPath, err)
+	}
+
+	unlock = func() error {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) //nolint:gosec // G115: fd is a valid int-range file descriptor
+		return f.Close()
+	}
+	return unlock, nil
+}

--- a/internal/sqliteutil/flock_test.go
+++ b/internal/sqliteutil/flock_test.go
@@ -1,0 +1,80 @@
+//go:build unix
+
+package sqliteutil_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sofq/sku/internal/sqliteutil"
+)
+
+func TestFlock_AcquireRelease(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+	// Create the file so flock has something to open.
+	if err := os.WriteFile(path, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unlock, err := sqliteutil.Flock(path)
+	if err != nil {
+		t.Fatalf("first Flock: %v", err)
+	}
+	// Release.
+	if err := unlock(); err != nil {
+		t.Fatalf("unlock: %v", err)
+	}
+
+	// Can acquire again after release.
+	unlock2, err := sqliteutil.Flock(path)
+	if err != nil {
+		t.Fatalf("second Flock after release: %v", err)
+	}
+	_ = unlock2()
+}
+
+func TestFlock_Conflict(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+	if err := os.WriteFile(path, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unlock, err := sqliteutil.Flock(path)
+	if err != nil {
+		t.Fatalf("first Flock: %v", err)
+	}
+	defer unlock() //nolint:errcheck
+
+	// Second attempt on same sidecar file → conflict.
+	_, err2 := sqliteutil.Flock(path)
+	if err2 == nil {
+		t.Fatal("want conflict error, got nil")
+	}
+	if !errors.Is(err2, sqliteutil.ErrLocked) {
+		t.Fatalf("want ErrLocked, got %v", err2)
+	}
+}
+
+func TestFlock_CreatesLockSidecar(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+	if err := os.WriteFile(path, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unlock, err := sqliteutil.Flock(path)
+	if err != nil {
+		t.Fatalf("Flock: %v", err)
+	}
+	defer unlock() //nolint:errcheck
+
+	// Sidecar lock file should exist.
+	lockPath := path + ".lock"
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("expected sidecar lock file at %s: %v", lockPath, statErr)
+	}
+}

--- a/internal/sqliteutil/flock_windows.go
+++ b/internal/sqliteutil/flock_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+// Package sqliteutil provides small helpers for SQLite database files.
+package sqliteutil
+
+import "errors"
+
+// ErrLocked is returned when an advisory flock cannot be acquired.
+var ErrLocked = errors.New("sqliteutil: shard is locked by another process")
+
+// Flock is a no-op stub on Windows. Advisory file locking via syscall.Flock
+// is not available on this platform. Callers should treat the returned unlock
+// func as valid — it does nothing.
+//
+// TODO: implement using LockFileEx on Windows if concurrent-update protection
+// is needed on that platform.
+func Flock(dbPath string) (unlock func() error, err error) {
+	return func() error { return nil }, nil
+}

--- a/internal/updater/chain.go
+++ b/internal/updater/chain.go
@@ -1,0 +1,205 @@
+package updater
+
+import (
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	_ "modernc.org/sqlite" // register "sqlite" driver
+
+	"github.com/sofq/sku/internal/sqliteutil"
+)
+
+// ErrChainStartsElsewhere is returned when the first delta in the chain has a
+// From version that does not match the provided from argument. The caller
+// should fall back to a full baseline download.
+var ErrChainStartsElsewhere = errors.New("updater: delta chain starts at a different version than the local shard")
+
+// ErrChainTooLong is returned when len(chain) > Applier.MaxChain. The caller
+// should fall back to a full baseline download.
+var ErrChainTooLong = errors.New("updater: delta chain exceeds MaxChain limit")
+
+// ErrLocked is re-exported from sqliteutil so callers only need to import
+// this package. It signals that another process holds the shard advisory lock.
+// Callers map this to skuerrors.CodeConflict (exit 6) per spec §4.
+var ErrLocked = sqliteutil.ErrLocked
+
+// Applier applies a delta chain to an existing SQLite shard file in a single
+// all-or-nothing transaction. It takes an advisory flock on the shard before
+// opening SQLite to prevent concurrent modification.
+type Applier struct {
+	// HTTPClient is the client used to fetch delta files. If nil, http.DefaultClient is used.
+	HTTPClient *http.Client
+	// DBPath is the absolute path to the shard .db file.
+	DBPath string
+	// MaxChain is the maximum number of deltas allowed in one Apply call.
+	// Defaults to 20 if zero.
+	MaxChain int
+	// OnProgress is called after each delta is successfully applied.
+	// It may be nil.
+	OnProgress func(event string, delta Delta)
+}
+
+func (a *Applier) maxChain() int {
+	if a.MaxChain > 0 {
+		return a.MaxChain
+	}
+	return 20
+}
+
+func (a *Applier) client() *http.Client {
+	if a.HTTPClient != nil {
+		return a.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+// Apply applies chain to the shard at a.DBPath. All deltas are applied in a
+// single BEGIN IMMEDIATE transaction; any failure causes a ROLLBACK so the
+// database is left unchanged.
+//
+// Pre-conditions checked before opening the database:
+//   - len(chain) == 0 || from != chain[0].From → ErrChainStartsElsewhere
+//   - len(chain) > MaxChain → ErrChainTooLong
+func (a *Applier) Apply(ctx context.Context, from, to string, chain []Delta) error {
+	if len(chain) == 0 || from != chain[0].From {
+		return ErrChainStartsElsewhere
+	}
+	if len(chain) > a.maxChain() {
+		return ErrChainTooLong
+	}
+
+	// Take advisory flock before opening SQLite.
+	unlock, err := sqliteutil.Flock(a.DBPath)
+	if err != nil {
+		return err // ErrLocked or I/O error
+	}
+	defer func() { _ = unlock() }()
+
+	db, err := sql.Open("sqlite", a.DBPath)
+	if err != nil {
+		return fmt.Errorf("updater: open shard %s: %w", a.DBPath, err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Use a raw connection so we can issue BEGIN IMMEDIATE (not available via
+	// db.BeginTx) on the same connection object. SQLite requires IMMEDIATE on
+	// the connection that will do writes to avoid "database is locked" during
+	// COMMIT on a busy WAL file.
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("updater: acquire conn: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return fmt.Errorf("updater: BEGIN IMMEDIATE: %w", err)
+	}
+
+	rollback := func() {
+		_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+	}
+
+	for _, d := range chain {
+		sqlBody, err := a.fetchDelta(ctx, d)
+		if err != nil {
+			rollback()
+			return fmt.Errorf("updater: fetch delta %s->%s: %w", d.From, d.To, err)
+		}
+		if _, err := conn.ExecContext(ctx, sqlBody); err != nil {
+			rollback()
+			return fmt.Errorf("updater: exec delta %s->%s: %w", d.From, d.To, err)
+		}
+		if a.OnProgress != nil {
+			a.OnProgress("delta-applied", d)
+		}
+	}
+
+	// Update metadata to reflect the applied head version.
+	_, err = conn.ExecContext(ctx,
+		"UPDATE metadata SET catalog_version=?, generated_at=datetime('now')",
+		to,
+	)
+	if err != nil {
+		rollback()
+		return fmt.Errorf("updater: update metadata: %w", err)
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		rollback()
+		return fmt.Errorf("updater: COMMIT: %w", err)
+	}
+	return nil
+}
+
+// fetchDelta downloads a delta file, verifies its SHA256, gunzips it, and
+// returns the SQL body as a string.
+func (a *Applier) fetchDelta(ctx context.Context, d Delta) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, d.URL, http.NoBody)
+	if err != nil {
+		return "", err
+	}
+	resp, err := a.client().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("GET %s: %w", d.URL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("GET %s: HTTP %d", d.URL, resp.StatusCode)
+	}
+
+	gzBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read body %s: %w", d.URL, err)
+	}
+
+	// Verify SHA256 over the compressed bytes (per spec instructions).
+	if d.SHA256 != "" {
+		h := sha256.Sum256(gzBytes)
+		got := hex.EncodeToString(h[:])
+		if got != d.SHA256 {
+			return "", fmt.Errorf("%w for delta %s->%s: got %s want %s",
+				ErrSHAMismatch, d.From, d.To, got, d.SHA256)
+		}
+	}
+
+	// Gunzip the SQL body.
+	gr, err := gzip.NewReader(io.LimitReader(bytesReader(gzBytes), 64<<20)) // 64 MiB limit
+	if err != nil {
+		return "", fmt.Errorf("gzip open %s: %w", d.URL, err)
+	}
+	defer func() { _ = gr.Close() }()
+
+	sqlBytes, err := io.ReadAll(gr)
+	if err != nil {
+		return "", fmt.Errorf("gzip read %s: %w", d.URL, err)
+	}
+	return string(sqlBytes), nil
+}
+
+// bytesReader wraps a byte slice as an io.Reader without importing "bytes".
+// (We'd normally just use bytes.NewReader, which is fine — using it directly.)
+func bytesReader(b []byte) io.Reader {
+	return &bytesReaderImpl{b: b}
+}
+
+type bytesReaderImpl struct {
+	b   []byte
+	off int
+}
+
+func (r *bytesReaderImpl) Read(p []byte) (n int, err error) {
+	if r.off >= len(r.b) {
+		return 0, io.EOF
+	}
+	n = copy(p, r.b[r.off:])
+	r.off += n
+	return n, nil
+}

--- a/internal/updater/chain_test.go
+++ b/internal/updater/chain_test.go
@@ -1,0 +1,356 @@
+package updater_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/sofq/sku/internal/sqliteutil"
+	"github.com/sofq/sku/internal/updater"
+)
+
+// buildChainDB creates a SQLite fixture with a metadata table and a rows table
+// pre-populated with n rows. Returns the path to the .db file.
+func buildChainDB(t *testing.T, dir, version string, n int) string {
+	t.Helper()
+	path := filepath.Join(dir, "shard.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS metadata (
+			catalog_version TEXT NOT NULL,
+			generated_at    TEXT NOT NULL
+		);
+		INSERT INTO metadata VALUES (?, ?);
+		CREATE TABLE IF NOT EXISTS rows (id INTEGER PRIMARY KEY, val TEXT);
+	`, version, "2026-04-18T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		_, err = db.ExecContext(ctx, "INSERT INTO rows (val) VALUES (?)", fmt.Sprintf("row-%d", i))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return path
+}
+
+// gzipSQL compresses sql text and returns the bytes.
+func gzipSQL(t *testing.T, sql string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write([]byte(sql)); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func sha256HexBytes(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// buildDeltaResponse returns a fakeRT body map entry for one delta.
+func buildDeltaResponse(t *testing.T, sqlBody string) (body []byte, sha string) {
+	t.Helper()
+	body = gzipSQL(t, sqlBody)
+	sha = sha256HexBytes(body)
+	return body, sha
+}
+
+func countRows(t *testing.T, dbPath string) int {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var n int
+	if err := db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM rows").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+func getVersion(t *testing.T, dbPath string) string {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var v string
+	if err := db.QueryRowContext(context.Background(), "SELECT catalog_version FROM metadata LIMIT 1").Scan(&v); err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+func TestApplier_HappyPath1Delta(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := buildChainDB(t, dir, "2026.04.18", 10)
+
+	deltaSQL := "INSERT INTO rows (val) VALUES ('d1'); INSERT INTO rows (val) VALUES ('d2');"
+	body, sha := buildDeltaResponse(t, deltaSQL)
+
+	delta := updater.Delta{
+		From:   "2026.04.18",
+		To:     "2026.04.19",
+		URL:    "https://delta.example.com/d1.sql.gz",
+		SHA256: sha,
+	}
+
+	rt := &fakeRT{body: map[string][]byte{delta.URL: body}}
+	applier := &updater.Applier{
+		HTTPClient: &http.Client{Transport: rt},
+		DBPath:     dbPath,
+		MaxChain:   20,
+	}
+
+	err := applier.Apply(context.Background(), "2026.04.18", "2026.04.19", []updater.Delta{delta})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if n := countRows(t, dbPath); n != 12 {
+		t.Errorf("row count: got %d, want 12", n)
+	}
+	if v := getVersion(t, dbPath); v != "2026.04.19" {
+		t.Errorf("catalog_version: got %q, want 2026.04.19", v)
+	}
+}
+
+func TestApplier_HappyPath3Deltas(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := buildChainDB(t, dir, "2026.04.18", 10)
+
+	type deltaSpec struct {
+		from, to string
+		rowsSQL  string
+	}
+	specs := []deltaSpec{
+		{"2026.04.18", "2026.04.19", "INSERT INTO rows (val) VALUES ('a');"},
+		{"2026.04.19", "2026.04.20", "INSERT INTO rows (val) VALUES ('b');"},
+		{"2026.04.20", "2026.04.21", "INSERT INTO rows (val) VALUES ('c');"},
+	}
+
+	bodyMap := map[string][]byte{}
+	var chain []updater.Delta
+	for i, s := range specs {
+		body, sha := buildDeltaResponse(t, s.rowsSQL)
+		url := fmt.Sprintf("https://delta.example.com/d%d.sql.gz", i)
+		bodyMap[url] = body
+		chain = append(chain, updater.Delta{From: s.from, To: s.to, URL: url, SHA256: sha})
+	}
+
+	rt := &fakeRT{body: bodyMap}
+	applier := &updater.Applier{
+		HTTPClient: &http.Client{Transport: rt},
+		DBPath:     dbPath,
+		MaxChain:   20,
+	}
+
+	err := applier.Apply(context.Background(), "2026.04.18", "2026.04.21", chain)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if n := countRows(t, dbPath); n != 13 {
+		t.Errorf("row count: got %d, want 13", n)
+	}
+	if v := getVersion(t, dbPath); v != "2026.04.21" {
+		t.Errorf("catalog_version: got %q, want 2026.04.21", v)
+	}
+}
+
+func TestApplier_ChainTooLong(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := buildChainDB(t, dir, "2026.04.18", 5)
+
+	var chain []updater.Delta
+	for i := 0; i < 3; i++ {
+		chain = append(chain, updater.Delta{
+			From: fmt.Sprintf("2026.04.%02d", 18+i),
+			To:   fmt.Sprintf("2026.04.%02d", 19+i),
+			URL:  fmt.Sprintf("https://delta.example.com/d%d.sql.gz", i),
+		})
+	}
+
+	applier := &updater.Applier{
+		HTTPClient: http.DefaultClient,
+		DBPath:     dbPath,
+		MaxChain:   2,
+	}
+	err := applier.Apply(context.Background(), "2026.04.18", "2026.04.21", chain)
+	if !errors.Is(err, updater.ErrChainTooLong) {
+		t.Fatalf("want ErrChainTooLong, got %v", err)
+	}
+}
+
+func TestApplier_FromMismatch(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := buildChainDB(t, dir, "2026.04.18", 5)
+
+	chain := []updater.Delta{{
+		From: "2026.04.17", // does not match from="2026.04.18"
+		To:   "2026.04.18",
+		URL:  "https://delta.example.com/d.sql.gz",
+	}}
+
+	applier := &updater.Applier{
+		HTTPClient: http.DefaultClient,
+		DBPath:     dbPath,
+		MaxChain:   20,
+	}
+	err := applier.Apply(context.Background(), "2026.04.18", "2026.04.18", chain)
+	if !errors.Is(err, updater.ErrChainStartsElsewhere) {
+		t.Fatalf("want ErrChainStartsElsewhere, got %v", err)
+	}
+}
+
+func TestApplier_SHAMismatchMidChain_Rollback(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := buildChainDB(t, dir, "2026.04.18", 10)
+
+	body1, sha1 := buildDeltaResponse(t, "INSERT INTO rows (val) VALUES ('d1');")
+	body2, _ := buildDeltaResponse(t, "INSERT INTO rows (val) VALUES ('d2');")
+	// corrupt body2's SHA so second delta fails
+	badSHA2 := strings.Repeat("0", 64)
+
+	chain := []updater.Delta{
+		{From: "2026.04.18", To: "2026.04.19", URL: "https://delta.example.com/d1.sql.gz", SHA256: sha1},
+		{From: "2026.04.19", To: "2026.04.20", URL: "https://delta.example.com/d2.sql.gz", SHA256: badSHA2},
+	}
+	rt := &fakeRT{body: map[string][]byte{
+		chain[0].URL: body1,
+		chain[1].URL: body2,
+	}}
+
+	applier := &updater.Applier{
+		HTTPClient: &http.Client{Transport: rt},
+		DBPath:     dbPath,
+		MaxChain:   20,
+	}
+	err := applier.Apply(context.Background(), "2026.04.18", "2026.04.20", chain)
+	if err == nil {
+		t.Fatal("want SHA mismatch error, got nil")
+	}
+	// Row count must be unchanged — rollback worked
+	if n := countRows(t, dbPath); n != 10 {
+		t.Errorf("row count after rollback: got %d, want 10 (rollback failed)", n)
+	}
+	if v := getVersion(t, dbPath); v != "2026.04.18" {
+		t.Errorf("version after rollback: got %q, want 2026.04.18", v)
+	}
+}
+
+func TestApplier_NetworkFailureMidChain_Rollback(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := buildChainDB(t, dir, "2026.04.18", 10)
+
+	body1, sha1 := buildDeltaResponse(t, "INSERT INTO rows (val) VALUES ('d1');")
+
+	chain := []updater.Delta{
+		{From: "2026.04.18", To: "2026.04.19", URL: "https://delta.example.com/d1.sql.gz", SHA256: sha1},
+		{From: "2026.04.19", To: "2026.04.20", URL: "https://delta.example.com/d2.sql.gz", SHA256: strings.Repeat("0", 64)},
+	}
+	// Only d1 is in the map; d2 returns 404
+	rt := &fakeRT{body: map[string][]byte{chain[0].URL: body1}}
+
+	applier := &updater.Applier{
+		HTTPClient: &http.Client{Transport: rt},
+		DBPath:     dbPath,
+		MaxChain:   20,
+	}
+	err := applier.Apply(context.Background(), "2026.04.18", "2026.04.20", chain)
+	if err == nil {
+		t.Fatal("want error for missing second delta")
+	}
+	if n := countRows(t, dbPath); n != 10 {
+		t.Errorf("row count after network failure: got %d, want 10 (rollback failed)", n)
+	}
+	if v := getVersion(t, dbPath); v != "2026.04.18" {
+		t.Errorf("version after rollback: got %q, want 2026.04.18", v)
+	}
+}
+
+func TestApplier_ConcurrentCallGetsLockConflict(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := buildChainDB(t, dir, "2026.04.18", 5)
+
+	// Acquire the lock externally to simulate a concurrent Apply.
+	unlock, err := sqliteutil.Flock(dbPath)
+	if err != nil {
+		t.Fatalf("pre-lock: %v", err)
+	}
+	defer unlock() //nolint:errcheck
+
+	applier := &updater.Applier{
+		HTTPClient: http.DefaultClient,
+		DBPath:     dbPath,
+		MaxChain:   20,
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var applyErr error
+	go func() {
+		defer wg.Done()
+		applyErr = applier.Apply(context.Background(), "2026.04.18", "2026.04.19", []updater.Delta{
+			{From: "2026.04.18", To: "2026.04.19", URL: "https://delta.example.com/d.sql.gz"},
+		})
+	}()
+	wg.Wait()
+
+	if !errors.Is(applyErr, updater.ErrLocked) {
+		t.Fatalf("want ErrLocked on second concurrent call, got %v", applyErr)
+	}
+}
+
+func TestApplier_OnProgressCallback(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := buildChainDB(t, dir, "2026.04.18", 5)
+
+	body, sha := buildDeltaResponse(t, "INSERT INTO rows (val) VALUES ('p1');")
+	delta := updater.Delta{From: "2026.04.18", To: "2026.04.19", URL: "https://delta.example.com/d.sql.gz", SHA256: sha}
+
+	rt := &fakeRT{body: map[string][]byte{delta.URL: body}}
+
+	var events []string
+	applier := &updater.Applier{
+		HTTPClient: &http.Client{Transport: rt},
+		DBPath:     dbPath,
+		MaxChain:   20,
+		OnProgress: func(event string, d updater.Delta) {
+			events = append(events, event+":"+d.From+"->"+d.To)
+		},
+	}
+
+	if err := applier.Apply(context.Background(), "2026.04.18", "2026.04.19", []updater.Delta{delta}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if len(events) != 1 || events[0] != "delta-applied:2026.04.18->2026.04.19" {
+		t.Errorf("progress events: %v", events)
+	}
+}

--- a/internal/updater/chain_test.go
+++ b/internal/updater/chain_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -296,6 +297,10 @@ func TestApplier_NetworkFailureMidChain_Rollback(t *testing.T) {
 }
 
 func TestApplier_ConcurrentCallGetsLockConflict(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("advisory flock is a no-op on Windows (sqliteutil/flock_windows.go); " +
+			"concurrent-apply protection is unix-only for now")
+	}
 	dir := t.TempDir()
 	dbPath := buildChainDB(t, dir, "2026.04.18", 5)
 

--- a/internal/updater/channel.go
+++ b/internal/updater/channel.go
@@ -1,0 +1,59 @@
+package updater
+
+import (
+	"fmt"
+
+	skuerrors "github.com/sofq/sku/internal/errors"
+)
+
+// Channel controls whether sku update uses the delta chain or always
+// re-downloads the full baseline.
+type Channel string
+
+const (
+	// ChannelStable always downloads the latest baseline shard. Safe for
+	// automated pipelines that need a known-good, complete snapshot.
+	ChannelStable Channel = "stable"
+
+	// ChannelDaily walks the manifest delta chain first and falls back to the
+	// baseline only when the chain is too long, starts elsewhere, or the shard
+	// file is missing. Best for daily/frequent operator updates.
+	ChannelDaily Channel = "daily"
+)
+
+var validChannels = []Channel{ChannelStable, ChannelDaily}
+
+func isValidChannel(v string) bool {
+	for _, c := range validChannels {
+		if string(c) == v {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveChannel returns the effective Channel from the precedence chain:
+// flag > env (SKU_UPDATE_CHANNEL) > configValue > ChannelStable.
+// Any non-empty value that is not "stable" or "daily" produces a
+// skuerrors.CodeValidation error with reason "flag_invalid".
+func ResolveChannel(flag, env, configValue string) (Channel, error) {
+	for _, src := range []struct{ name, value string }{
+		{"flag", flag},
+		{"env", env},
+		{"config", configValue},
+	} {
+		if src.value == "" {
+			continue
+		}
+		if !isValidChannel(src.value) {
+			return "", skuerrors.Validation(
+				"flag_invalid",
+				"channel",
+				src.value,
+				fmt.Sprintf("valid values: stable, daily (got %q from %s)", src.value, src.name),
+			)
+		}
+		return Channel(src.value), nil
+	}
+	return ChannelStable, nil
+}

--- a/internal/updater/channel_test.go
+++ b/internal/updater/channel_test.go
@@ -1,0 +1,65 @@
+package updater_test
+
+import (
+	"errors"
+	"testing"
+
+	skuerrors "github.com/sofq/sku/internal/errors"
+	"github.com/sofq/sku/internal/updater"
+)
+
+func TestResolveChannel(t *testing.T) {
+	tests := []struct {
+		name        string
+		flag        string
+		env         string
+		configValue string
+		want        updater.Channel
+		wantErr     bool
+	}{
+		// Defaults
+		{name: "all_empty_defaults_to_stable", flag: "", env: "", configValue: "", want: updater.ChannelStable},
+
+		// Flag wins over everything
+		{name: "flag_stable_wins", flag: "stable", env: "daily", configValue: "daily", want: updater.ChannelStable},
+		{name: "flag_daily_wins", flag: "daily", env: "stable", configValue: "stable", want: updater.ChannelDaily},
+
+		// Env wins over config
+		{name: "env_daily_beats_config", flag: "", env: "daily", configValue: "stable", want: updater.ChannelDaily},
+		{name: "env_stable_beats_config", flag: "", env: "stable", configValue: "daily", want: updater.ChannelStable},
+
+		// Config wins over default
+		{name: "config_daily_beats_default", flag: "", env: "", configValue: "daily", want: updater.ChannelDaily},
+		{name: "config_stable_explicit", flag: "", env: "", configValue: "stable", want: updater.ChannelStable},
+
+		// Invalid values
+		{name: "flag_invalid", flag: "weekly", env: "", configValue: "", wantErr: true},
+		{name: "env_invalid", flag: "", env: "nightly", configValue: "", wantErr: true},
+		{name: "config_invalid", flag: "", env: "", configValue: "beta", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := updater.ResolveChannel(tc.flag, tc.env, tc.configValue)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("want error, got nil")
+				}
+				var e *skuerrors.E
+				if !errors.As(err, &e) {
+					t.Fatalf("want *skuerrors.E, got %T: %v", err, err)
+				}
+				if e.Code != skuerrors.CodeValidation {
+					t.Errorf("want CodeValidation, got %v", e.Code)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/updater/manifest.go
+++ b/internal/updater/manifest.go
@@ -1,0 +1,135 @@
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Manifest is the top-level structure of the daily-published manifest.json.
+// It describes all available shards, their current baseline, and any available
+// delta files that allow incremental updates.
+type Manifest struct {
+	SchemaVersion  int                   `json:"schema_version"`
+	GeneratedAt    time.Time             `json:"generated_at"`
+	CatalogVersion string                `json:"catalog_version"`
+	Shards         map[string]ShardEntry `json:"shards"`
+}
+
+// ShardEntry describes a single shard's current state in the manifest.
+type ShardEntry struct {
+	BaselineVersion    string    `json:"baseline_version"`
+	BaselineURL        string    `json:"baseline_url"`
+	BaselineSHA256     string    `json:"baseline_sha256"`
+	BaselineSize       int64     `json:"baseline_size"`
+	HeadVersion        string    `json:"head_version"`
+	MinBinaryVersion   string    `json:"min_binary_version"`
+	ShardSchemaVersion int       `json:"shard_schema_version"`
+	Deltas             []Delta   `json:"deltas"`
+	RowCount           int64     `json:"row_count"`
+	LastUpdated        time.Time `json:"last_updated"`
+}
+
+// Delta describes one incremental SQL patch between two catalog versions.
+type Delta struct {
+	From   string `json:"from"`
+	To     string `json:"to"`
+	URL    string `json:"url"`
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+
+// ManifestSource is the interface for fetching the manifest. The ETag string
+// is passed as If-None-Match so the source can return notModified=true when
+// the manifest has not changed since the last fetch.
+type ManifestSource interface {
+	// Fetch retrieves the manifest. If the server returns 304, notModified is
+	// true and m is nil. On success, newETag holds the server's ETag header
+	// value (empty if the server did not send one).
+	Fetch(ctx context.Context, etag string) (m *Manifest, newETag string, notModified bool, err error)
+}
+
+// httpSource implements ManifestSource over HTTP with a primary/fallback URL
+// pair. A 5xx response on the primary causes a single retry on the fallback.
+type httpSource struct {
+	primary  string
+	fallback string
+	client   *http.Client
+}
+
+// NewHTTPSource returns a ManifestSource that GETs from primary, falling back
+// to fallback on 5xx. rt may be nil (uses http.DefaultTransport).
+func NewHTTPSource(primary, fallback string, rt http.RoundTripper) ManifestSource {
+	c := &http.Client{}
+	if rt != nil {
+		c.Transport = rt
+	}
+	return &httpSource{
+		primary:  strings.TrimRight(primary, "/"),
+		fallback: strings.TrimRight(fallback, "/"),
+		client:   c,
+	}
+}
+
+// Fetch implements ManifestSource.
+func (s *httpSource) Fetch(ctx context.Context, etag string) (*Manifest, string, bool, error) {
+	m, newETag, notModified, primaryErr := s.fetchURL(ctx, s.primary, etag)
+	if primaryErr == nil {
+		return m, newETag, notModified, nil
+	}
+
+	// Fall back to secondary URL.
+	m2, newETag2, notModified2, fallbackErr := s.fetchURL(ctx, s.fallback, etag)
+	if fallbackErr == nil {
+		return m2, newETag2, notModified2, nil
+	}
+
+	return nil, "", false, fmt.Errorf("updater: manifest fetch failed — primary (%s): %w; fallback (%s): %v",
+		s.primary, primaryErr, s.fallback, fallbackErr)
+}
+
+func (s *httpSource) fetchURL(ctx context.Context, url, etag string) (*Manifest, string, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("updater: build request for %s: %w", url, err)
+	}
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("updater: GET %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, "", true, nil
+	}
+
+	if resp.StatusCode >= 500 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, "", false, fmt.Errorf("updater: GET %s: HTTP %d: %s", url, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, "", false, fmt.Errorf("updater: GET %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("updater: read body from %s: %w", url, err)
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, "", false, fmt.Errorf("updater: parse manifest from %s: %w", url, err)
+	}
+
+	newETag := resp.Header.Get("ETag")
+	return &m, newETag, false, nil
+}

--- a/internal/updater/manifest_test.go
+++ b/internal/updater/manifest_test.go
@@ -1,0 +1,205 @@
+package updater_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sofq/sku/internal/updater"
+)
+
+// roundTripperFunc wraps a function as an http.RoundTripper.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func loadManifestFixture(t *testing.T) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", "manifest.v1.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestHTTPSource_200WithETag(t *testing.T) {
+	fixture := loadManifestFixture(t)
+	const serverETag = `"abc123"`
+
+	rt := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		h := make(http.Header)
+		h.Set("ETag", serverETag)
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(string(fixture))),
+			Header:     h,
+		}, nil
+	})
+
+	src := updater.NewHTTPSource(
+		"https://primary.example.com/manifest.json",
+		"https://fallback.example.com/manifest.json",
+		rt,
+	)
+
+	m, newETag, notModified, err := src.Fetch(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if notModified {
+		t.Fatal("want notModified=false on 200")
+	}
+	if newETag != serverETag {
+		t.Errorf("ETag: got %q, want %q", newETag, serverETag)
+	}
+	if m == nil {
+		t.Fatal("want non-nil Manifest")
+	}
+	if m.SchemaVersion != 1 {
+		t.Errorf("SchemaVersion: got %d, want 1", m.SchemaVersion)
+	}
+	if len(m.Shards) != 3 {
+		t.Errorf("Shards count: got %d, want 3", len(m.Shards))
+	}
+	ec2 := m.Shards["aws-ec2"]
+	if len(ec2.Deltas) != 2 {
+		t.Errorf("aws-ec2 delta count: got %d, want 2", len(ec2.Deltas))
+	}
+	openrouter := m.Shards["openrouter"]
+	if len(openrouter.Deltas) != 0 {
+		t.Errorf("openrouter delta count: got %d, want 0", len(openrouter.Deltas))
+	}
+	azureVM := m.Shards["azure-vm"]
+	if len(azureVM.Deltas) != 1 {
+		t.Errorf("azure-vm delta count: got %d, want 1", len(azureVM.Deltas))
+	}
+}
+
+func TestHTTPSource_304NotModified(t *testing.T) {
+	const cachedETag = `"stale-etag"`
+	var capturedIfNoneMatch string
+
+	rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		capturedIfNoneMatch = req.Header.Get("If-None-Match")
+		return &http.Response{
+			StatusCode: 304,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	src := updater.NewHTTPSource(
+		"https://primary.example.com/manifest.json",
+		"https://fallback.example.com/manifest.json",
+		rt,
+	)
+
+	m, newETag, notModified, err := src.Fetch(context.Background(), cachedETag)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !notModified {
+		t.Fatal("want notModified=true on 304")
+	}
+	if m != nil {
+		t.Fatal("want nil Manifest on 304")
+	}
+	if newETag != "" {
+		t.Errorf("want empty newETag on 304, got %q", newETag)
+	}
+	if capturedIfNoneMatch != cachedETag {
+		t.Errorf("If-None-Match: got %q, want %q", capturedIfNoneMatch, cachedETag)
+	}
+}
+
+func TestHTTPSource_500PrimaryFallsBackToSecondary(t *testing.T) {
+	fixture := loadManifestFixture(t)
+	var callCount int
+
+	rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		if strings.Contains(req.URL.Host, "primary") {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(strings.NewReader("internal server error")),
+				Header:     make(http.Header),
+			}, nil
+		}
+		// fallback
+		h := make(http.Header)
+		h.Set("ETag", `"fallback-etag"`)
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(string(fixture))),
+			Header:     h,
+		}, nil
+	})
+
+	src := updater.NewHTTPSource(
+		"https://primary.example.com/manifest.json",
+		"https://fallback.example.com/manifest.json",
+		rt,
+	)
+
+	m, _, notModified, err := src.Fetch(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if notModified {
+		t.Fatal("want notModified=false")
+	}
+	if m == nil {
+		t.Fatal("want non-nil Manifest from fallback")
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 HTTP calls (primary + fallback), got %d", callCount)
+	}
+}
+
+func TestHTTPSource_BothFail_ErrorContainsBothURLs(t *testing.T) {
+	primaryURL := "https://primary.example.com/manifest.json"
+	fallbackURL := "https://fallback.example.com/manifest.json"
+
+	rt := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 503,
+			Body:       io.NopCloser(strings.NewReader("unavailable")),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	src := updater.NewHTTPSource(primaryURL, fallbackURL, rt)
+	_, _, _, err := src.Fetch(context.Background(), "")
+	if err == nil {
+		t.Fatal("want error when both URLs fail")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "primary.example.com") {
+		t.Errorf("error missing primary URL; got: %s", msg)
+	}
+	if !strings.Contains(msg, "fallback.example.com") {
+		t.Errorf("error missing fallback URL; got: %s", msg)
+	}
+}
+
+func TestManifestStructure(t *testing.T) {
+	fixture := loadManifestFixture(t)
+	var m updater.Manifest
+	if err := json.Unmarshal(fixture, &m); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	wantGenerated := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	if !m.GeneratedAt.Equal(wantGenerated) {
+		t.Errorf("GeneratedAt: got %v, want %v", m.GeneratedAt, wantGenerated)
+	}
+	if m.CatalogVersion != "2026.04.20" {
+		t.Errorf("CatalogVersion: got %q", m.CatalogVersion)
+	}
+}

--- a/internal/updater/testdata/manifest.v1.json
+++ b/internal/updater/testdata/manifest.v1.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-04-20T12:00:00Z",
+  "catalog_version": "2026.04.20",
+  "shards": {
+    "openrouter": {
+      "baseline_version": "2026.04.20",
+      "baseline_url": "https://cdn.example.com/data-2026.04.20/openrouter.db.zst",
+      "baseline_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "baseline_size": 1048576,
+      "head_version": "2026.04.20",
+      "min_binary_version": "0.1.0",
+      "shard_schema_version": 1,
+      "deltas": [],
+      "row_count": 500,
+      "last_updated": "2026-04-20T12:00:00Z"
+    },
+    "azure-vm": {
+      "baseline_version": "2026.04.18",
+      "baseline_url": "https://cdn.example.com/data-2026.04.18/azure-vm.db.zst",
+      "baseline_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "baseline_size": 2097152,
+      "head_version": "2026.04.19",
+      "min_binary_version": "0.1.0",
+      "shard_schema_version": 1,
+      "deltas": [
+        {
+          "from": "2026.04.18",
+          "to": "2026.04.19",
+          "url": "https://cdn.example.com/deltas/azure-vm-2026.04.18-to-2026.04.19.sql.gz",
+          "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "size": 4096
+        }
+      ],
+      "row_count": 1200,
+      "last_updated": "2026-04-19T12:00:00Z"
+    },
+    "aws-ec2": {
+      "baseline_version": "2026.04.18",
+      "baseline_url": "https://cdn.example.com/data-2026.04.18/aws-ec2.db.zst",
+      "baseline_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "baseline_size": 5242880,
+      "head_version": "2026.04.20",
+      "min_binary_version": "0.1.0",
+      "shard_schema_version": 1,
+      "deltas": [
+        {
+          "from": "2026.04.18",
+          "to": "2026.04.19",
+          "url": "https://cdn.example.com/deltas/aws-ec2-2026.04.18-to-2026.04.19.sql.gz",
+          "sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "size": 8192
+        },
+        {
+          "from": "2026.04.19",
+          "to": "2026.04.20",
+          "url": "https://cdn.example.com/deltas/aws-ec2-2026.04.19-to-2026.04.20.sql.gz",
+          "sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "size": 6144
+        }
+      ],
+      "row_count": 3000,
+      "last_updated": "2026-04-20T12:00:00Z"
+    }
+  }
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -178,6 +178,9 @@ type Result struct {
 	Applied []Delta
 	// Baseline is true when the shard was installed from the full baseline.
 	Baseline bool
+	// FellBackToBaseline is true when the daily delta chain was attempted but
+	// fell back to baseline due to ErrChainTooLong or ErrChainStartsElsewhere.
+	FellBackToBaseline bool
 	// NewETag is the ETag returned by the manifest server for future caching.
 	NewETag string
 }
@@ -283,7 +286,9 @@ func Update(ctx context.Context, shard string, opts UpdateOptions) (Result, erro
 
 	// Fall back to baseline on recoverable chain errors.
 	if errors.Is(applyErr, ErrChainTooLong) || errors.Is(applyErr, ErrChainStartsElsewhere) {
-		return installBaseline(ctx, shard, localVersion, entry, opts, newETag)
+		r, err := installBaseline(ctx, shard, localVersion, entry, opts, newETag)
+		r.FellBackToBaseline = true
+		return r, err
 	}
 
 	return Result{}, applyErr

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -2,13 +2,14 @@
 //
 // M3a.3 scope: extract the one-shot baseline download flow from
 // cmd/sku/update.go so it can be unit-tested behind an http.RoundTripper
-// fake. Delta-chain + manifest walking + ETag arrive in m3a.4.
+// fake. M3a.4.3 adds delta-chain + manifest walking + ETag support.
 package updater
 
 import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -19,6 +20,10 @@ import (
 	"strings"
 
 	"github.com/klauspost/compress/zstd"
+
+	_ "modernc.org/sqlite" // register "sqlite" driver (idempotent; also in chain.go)
+
+	skuerrors "github.com/sofq/sku/internal/errors"
 )
 
 // ErrSHAMismatch is returned when the downloaded .zst's sha256 does not
@@ -135,6 +140,207 @@ func httpGet(ctx context.Context, client *http.Client, url string) ([]byte, erro
 		return nil, fmt.Errorf("updater: GET %s: HTTP %d", url, resp.StatusCode)
 	}
 	return io.ReadAll(resp.Body)
+}
+
+// MinSupportedShardSchema is the minimum shard schema version this binary
+// understands. Shards with a lower value are rejected as shard_too_old.
+const MinSupportedShardSchema = 1
+
+// MaxSupportedShardSchema is the maximum shard schema version this binary
+// understands. Shards with a higher value are rejected as shard_too_new.
+const MaxSupportedShardSchema = 1
+
+// UpdateOptions controls a single Update call.
+type UpdateOptions struct {
+	// Options embeds the base Install options (DestDir, HTTPClient, BaseURL).
+	Options
+	// Channel controls whether to walk deltas or always use the baseline.
+	Channel Channel
+	// Manifest is the source for the manifest.json.
+	Manifest ManifestSource
+	// ETag is the cached ETag from the previous manifest fetch.
+	// A 304 response causes Update to return a no-op Result.
+	ETag string
+	// MaxChain limits the number of deltas applied in one Update.
+	// Zero uses the default (20).
+	MaxChain int
+}
+
+// Result describes the outcome of a single Update call.
+type Result struct {
+	// From is the catalog_version the shard was at before Update ran.
+	// Empty when the shard file did not exist before (fresh install).
+	From string
+	// To is the catalog_version the shard is at after Update ran.
+	To string
+	// Applied contains the deltas that were successfully applied.
+	// Empty when the update used a baseline download or was a no-op.
+	Applied []Delta
+	// Baseline is true when the shard was installed from the full baseline.
+	Baseline bool
+	// NewETag is the ETag returned by the manifest server for future caching.
+	NewETag string
+}
+
+// Update either applies a delta chain or re-downloads the full baseline for
+// shard, depending on opts.Channel, the local shard state, and the manifest.
+//
+// Flow:
+//  1. Read local catalog_version from <DestDir>/<shard>.db metadata table.
+//     If the file does not exist, treat it as "need baseline".
+//  2. Fetch the manifest. On 304, return a noop Result (nothing to do).
+//  3. Validate shard schema version — reject with CodeValidation on mismatch.
+//  4. If channel==Stable OR local is missing OR local < entry.BaselineVersion:
+//     call Install with the baseline URL.
+//  5. Else (Daily): filter deltas with d.From >= local; if empty → noop;
+//     else call Applier.Apply. On ErrChainTooLong / ErrChainStartsElsewhere /
+//     ErrLocked (actually just first two — locks propagate), fall back to Install.
+//  6. Return Result.
+func Update(ctx context.Context, shard string, opts UpdateOptions) (Result, error) {
+	dbPath := filepath.Join(opts.DestDir, shard+".db")
+
+	// Step 1: read local version.
+	localVersion, err := readLocalVersion(dbPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("updater: read local version: %w", err)
+	}
+	hasShard := localVersion != ""
+
+	// Step 2: fetch manifest.
+	m, newETag, notModified, err := opts.Manifest.Fetch(ctx, opts.ETag)
+	if err != nil {
+		return Result{}, fmt.Errorf("updater: fetch manifest: %w", err)
+	}
+	if notModified {
+		return Result{From: localVersion, To: localVersion, NewETag: ""}, nil
+	}
+
+	// Step 3: validate shard entry.
+	entry, ok := m.Shards[shard]
+	if !ok {
+		return Result{}, fmt.Errorf("updater: shard %q not found in manifest", shard)
+	}
+	if entry.ShardSchemaVersion > MaxSupportedShardSchema {
+		return Result{}, skuerrors.Validation(
+			"shard_too_new", "shard", shard,
+			fmt.Sprintf("shard schema version %d exceeds max supported %d; upgrade sku binary",
+				entry.ShardSchemaVersion, MaxSupportedShardSchema),
+		)
+	}
+	if entry.ShardSchemaVersion < MinSupportedShardSchema {
+		return Result{}, skuerrors.Validation(
+			"shard_too_old", "shard", shard,
+			fmt.Sprintf("shard schema version %d below min supported %d",
+				entry.ShardSchemaVersion, MinSupportedShardSchema),
+		)
+	}
+
+	// Step 4: decide whether to use a baseline or delta chain.
+	useBaseline := opts.Channel == ChannelStable ||
+		!hasShard ||
+		localVersion < entry.BaselineVersion
+
+	if useBaseline {
+		return installBaseline(ctx, shard, localVersion, entry, opts, newETag)
+	}
+
+	// Step 5: daily channel — try delta chain.
+	var chain []Delta
+	for _, d := range entry.Deltas {
+		if d.From >= localVersion {
+			chain = append(chain, d)
+		}
+	}
+	if len(chain) == 0 {
+		// Already up to date.
+		return Result{From: localVersion, To: localVersion, NewETag: newETag}, nil
+	}
+
+	maxChain := opts.MaxChain
+	if maxChain == 0 {
+		maxChain = 20
+	}
+	applier := &Applier{
+		HTTPClient: opts.HTTPClient,
+		DBPath:     dbPath,
+		MaxChain:   maxChain,
+	}
+
+	var applied []Delta
+	applier.OnProgress = func(_ string, d Delta) {
+		applied = append(applied, d)
+	}
+
+	applyErr := applier.Apply(ctx, localVersion, entry.HeadVersion, chain)
+	if applyErr == nil {
+		return Result{
+			From:    localVersion,
+			To:      entry.HeadVersion,
+			Applied: applied,
+			NewETag: newETag,
+		}, nil
+	}
+
+	// Fall back to baseline on recoverable chain errors.
+	if errors.Is(applyErr, ErrChainTooLong) || errors.Is(applyErr, ErrChainStartsElsewhere) {
+		return installBaseline(ctx, shard, localVersion, entry, opts, newETag)
+	}
+
+	return Result{}, applyErr
+}
+
+// installBaseline downloads the full baseline for shard and returns a Result.
+func installBaseline(ctx context.Context, shard, localVersion string, entry ShardEntry, opts UpdateOptions, newETag string) (Result, error) {
+	// Build an Install Options from the entry.
+	baseURL := trimToDir(entry.BaselineURL)
+	installOpts := Options{
+		BaseURL:    baseURL,
+		HTTPClient: opts.HTTPClient,
+		DestDir:    opts.DestDir,
+	}
+	if err := Install(ctx, shard, installOpts); err != nil {
+		return Result{}, err
+	}
+	return Result{
+		From:     localVersion,
+		To:       entry.HeadVersion,
+		Baseline: true,
+		NewETag:  newETag,
+	}, nil
+}
+
+// trimToDir strips the filename component from a URL to produce a base URL
+// suitable for Install (which appends /<shard>.db.zst).
+// e.g. "https://example.com/data/aws-ec2.db.zst" → "https://example.com/data"
+func trimToDir(url string) string {
+	if i := strings.LastIndex(url, "/"); i > 0 {
+		return url[:i]
+	}
+	return url
+}
+
+// readLocalVersion reads the catalog_version from the metadata table of a
+// SQLite shard. Returns ("", nil) if the file does not exist.
+func readLocalVersion(dbPath string) (string, error) {
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return "", nil
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = db.Close() }()
+
+	var v string
+	err = db.QueryRowContext(context.Background(),
+		"SELECT catalog_version FROM metadata LIMIT 1").Scan(&v)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return v, nil
 }
 
 func decompressZstd(zstData []byte, destPath string) error {

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -415,6 +415,9 @@ func TestUpdate_DailyChainTooLong_FallsBackToBaseline(t *testing.T) {
 	if !result.Baseline {
 		t.Error("want Baseline=true after chain-too-long fallback")
 	}
+	if !result.FellBackToBaseline {
+		t.Error("want FellBackToBaseline=true after chain-too-long fallback")
+	}
 }
 
 func TestUpdate_ShardSchemaVersionTooNew(t *testing.T) {

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -2,9 +2,12 @@ package updater_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -12,9 +15,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/klauspost/compress/zstd"
 
+	skuerrors "github.com/sofq/sku/internal/errors"
 	"github.com/sofq/sku/internal/updater"
 )
 
@@ -162,3 +167,334 @@ func TestDefaultSources_Contains(t *testing.T) {
 		}
 	}
 }
+
+// ---- Update() tests ----
+
+// fakeManifestSource is a ManifestSource backed by a static manifest.
+type fakeManifestSource struct {
+	m           *updater.Manifest
+	returnETag  string
+	notModified bool
+	err         error
+}
+
+func (f *fakeManifestSource) Fetch(_ context.Context, _ string) (*updater.Manifest, string, bool, error) {
+	return f.m, f.returnETag, f.notModified, f.err
+}
+
+// seedShardDB creates a minimal SQLite shard with the given catalog_version.
+func seedShardDB(t *testing.T, path, version string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	_, err = db.ExecContext(context.Background(), `
+		CREATE TABLE metadata (catalog_version TEXT NOT NULL, generated_at TEXT NOT NULL);
+		INSERT INTO metadata VALUES (?, ?);
+		CREATE TABLE rows (id INTEGER PRIMARY KEY, val TEXT);
+	`, version, "2026-04-18T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// gzipBytes compresses b with gzip.
+func gzipBytes(t *testing.T, b []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(b); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// buildFakeManifest returns a Manifest with the given shard entry.
+func buildFakeManifest(shard string, entry updater.ShardEntry) *updater.Manifest {
+	return &updater.Manifest{
+		SchemaVersion:  1,
+		GeneratedAt:    time.Now(),
+		CatalogVersion: entry.HeadVersion,
+		Shards:         map[string]updater.ShardEntry{shard: entry},
+	}
+}
+
+// makeZstdShard builds a zstd-compressed minimal SQLite database with
+// catalog_version set to version for use as a fake baseline download.
+func makeZstdShard(t *testing.T, version string) []byte {
+	t.Helper()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "shard.db")
+	seedShardDB(t, dbPath, version)
+	raw, err := os.ReadFile(dbPath) //nolint:gosec // G304: test helper reads from t.TempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Compress with zstd using klauspost/compress.
+	var buf bytes.Buffer
+	w, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(raw); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestUpdate_StableChannelAlwaysBaseline(t *testing.T) {
+	dir := t.TempDir()
+	const shard = "aws-ec2"
+
+	// Shard exists locally at an older version.
+	dbPath := filepath.Join(dir, shard+".db")
+	seedShardDB(t, dbPath, "2026.04.18")
+
+	zstBytes := makeZstdShard(t, "2026.04.20")
+	shaHex := sha256Hex(zstBytes)
+	shaFile := shaHex + "  " + shard + ".db.zst\n"
+
+	baselineURL := "https://baseline.example.com/data-2026.04.20/" + shard + ".db.zst"
+	shaURL := "https://baseline.example.com/data-2026.04.20/" + shard + ".db.zst.sha256"
+
+	rt := &fakeRT{body: map[string][]byte{
+		baselineURL: zstBytes,
+		shaURL:      []byte(shaFile),
+	}}
+
+	entry := updater.ShardEntry{
+		BaselineVersion:    "2026.04.18",
+		BaselineURL:        "https://baseline.example.com/data-2026.04.20/" + shard + ".db.zst",
+		BaselineSHA256:     shaHex,
+		HeadVersion:        "2026.04.20",
+		ShardSchemaVersion: 1,
+	}
+	m := buildFakeManifest(shard, entry)
+
+	opts := updater.UpdateOptions{
+		Options:  updater.Options{DestDir: dir, HTTPClient: &http.Client{Transport: rt}},
+		Channel:  updater.ChannelStable,
+		Manifest: &fakeManifestSource{m: m, returnETag: `"new-etag"`},
+	}
+
+	result, err := updater.Update(context.Background(), shard, opts)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !result.Baseline {
+		t.Error("want Baseline=true for stable channel")
+	}
+	if result.To != "2026.04.20" {
+		t.Errorf("To: got %q, want 2026.04.20", result.To)
+	}
+}
+
+func TestUpdate_NotModified304_Noop(t *testing.T) {
+	dir := t.TempDir()
+	const shard = "aws-ec2"
+
+	dbPath := filepath.Join(dir, shard+".db")
+	seedShardDB(t, dbPath, "2026.04.20")
+
+	opts := updater.UpdateOptions{
+		Options:  updater.Options{DestDir: dir},
+		Channel:  updater.ChannelDaily,
+		Manifest: &fakeManifestSource{notModified: true},
+	}
+
+	result, err := updater.Update(context.Background(), shard, opts)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if result.From != "2026.04.20" {
+		t.Errorf("From: got %q, want 2026.04.20", result.From)
+	}
+	if result.To != "2026.04.20" {
+		t.Errorf("To: got %q, want 2026.04.20", result.To)
+	}
+	if result.Baseline {
+		t.Error("want Baseline=false on noop")
+	}
+}
+
+func TestUpdate_DailyChannelAppliesDeltas(t *testing.T) {
+	dir := t.TempDir()
+	const shard = "aws-ec2"
+
+	dbPath := filepath.Join(dir, shard+".db")
+	seedShardDB(t, dbPath, "2026.04.18")
+
+	// Build a delta that adds 2 rows.
+	deltaSQL := "INSERT INTO rows (val) VALUES ('upd1'); INSERT INTO rows (val) VALUES ('upd2');"
+	deltaBody := gzipBytes(t, []byte(deltaSQL))
+	deltaSHA := sha256Hex(deltaBody)
+	deltaURL := "https://delta.example.com/aws-ec2-d1.sql.gz"
+
+	entry := updater.ShardEntry{
+		BaselineVersion:    "2026.04.18",
+		HeadVersion:        "2026.04.19",
+		ShardSchemaVersion: 1,
+		Deltas: []updater.Delta{
+			{From: "2026.04.18", To: "2026.04.19", URL: deltaURL, SHA256: deltaSHA},
+		},
+	}
+	m := buildFakeManifest(shard, entry)
+
+	rt := &fakeRT{body: map[string][]byte{deltaURL: deltaBody}}
+	opts := updater.UpdateOptions{
+		Options:  updater.Options{DestDir: dir, HTTPClient: &http.Client{Transport: rt}},
+		Channel:  updater.ChannelDaily,
+		MaxChain: 20,
+		Manifest: &fakeManifestSource{m: m, returnETag: `"etag2"`},
+	}
+
+	result, err := updater.Update(context.Background(), shard, opts)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if result.Baseline {
+		t.Error("want Baseline=false on delta apply")
+	}
+	if len(result.Applied) != 1 {
+		t.Errorf("Applied count: got %d, want 1", len(result.Applied))
+	}
+	if result.To != "2026.04.19" {
+		t.Errorf("To: got %q, want 2026.04.19", result.To)
+	}
+}
+
+func TestUpdate_DailyChainTooLong_FallsBackToBaseline(t *testing.T) {
+	dir := t.TempDir()
+	const shard = "aws-ec2"
+
+	dbPath := filepath.Join(dir, shard+".db")
+	seedShardDB(t, dbPath, "2026.04.18")
+
+	// 3 deltas but MaxChain=2 → fallback to baseline.
+	entry := updater.ShardEntry{
+		BaselineVersion:    "2026.04.18",
+		BaselineURL:        "https://baseline.example.com/data/" + shard + ".db.zst",
+		HeadVersion:        "2026.04.21",
+		ShardSchemaVersion: 1,
+		Deltas: []updater.Delta{
+			{From: "2026.04.18", To: "2026.04.19"},
+			{From: "2026.04.19", To: "2026.04.20"},
+			{From: "2026.04.20", To: "2026.04.21"},
+		},
+	}
+
+	zstBytes := makeZstdShard(t, "2026.04.21")
+	shaHex := sha256Hex(zstBytes)
+	entry.BaselineSHA256 = shaHex
+	shaURL := entry.BaselineURL + ".sha256"
+	rt := &fakeRT{body: map[string][]byte{
+		entry.BaselineURL: zstBytes,
+		shaURL:            []byte(shaHex + "  x\n"),
+	}}
+
+	m := buildFakeManifest(shard, entry)
+	opts := updater.UpdateOptions{
+		Options:  updater.Options{DestDir: dir, HTTPClient: &http.Client{Transport: rt}},
+		Channel:  updater.ChannelDaily,
+		MaxChain: 2,
+		Manifest: &fakeManifestSource{m: m},
+	}
+
+	result, err := updater.Update(context.Background(), shard, opts)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !result.Baseline {
+		t.Error("want Baseline=true after chain-too-long fallback")
+	}
+}
+
+func TestUpdate_ShardSchemaVersionTooNew(t *testing.T) {
+	dir := t.TempDir()
+	const shard = "aws-ec2"
+
+	dbPath := filepath.Join(dir, shard+".db")
+	seedShardDB(t, dbPath, "2026.04.18")
+
+	entry := updater.ShardEntry{
+		HeadVersion:        "2026.04.20",
+		ShardSchemaVersion: 99, // way above MaxSupportedShardSchema=1
+	}
+	m := buildFakeManifest(shard, entry)
+	opts := updater.UpdateOptions{
+		Options:  updater.Options{DestDir: dir},
+		Channel:  updater.ChannelDaily,
+		Manifest: &fakeManifestSource{m: m},
+	}
+
+	_, err := updater.Update(context.Background(), shard, opts)
+	if err == nil {
+		t.Fatal("want error for shard_too_new, got nil")
+	}
+	var e *skuerrors.E
+	if !errors.As(err, &e) {
+		t.Fatalf("want *skuerrors.E, got %T: %v", err, err)
+	}
+	if e.Code != skuerrors.CodeValidation {
+		t.Errorf("want CodeValidation, got %v", e.Code)
+	}
+	if reason, _ := e.Details["reason"].(string); reason != "shard_too_new" {
+		t.Errorf("want reason=shard_too_new, got %q", reason)
+	}
+}
+
+func TestUpdate_NoLocalShard_InstallsBaseline(t *testing.T) {
+	dir := t.TempDir()
+	const shard = "openrouter"
+	// No .db file exists — should trigger a baseline install.
+
+	zstBytes := makeZstdShard(t, "2026.04.20")
+	shaHex := sha256Hex(zstBytes)
+	baselineURL := "https://baseline.example.com/data/" + shard + ".db.zst"
+	shaURL := baselineURL + ".sha256"
+
+	entry := updater.ShardEntry{
+		BaselineVersion:    "2026.04.20",
+		BaselineURL:        baselineURL,
+		BaselineSHA256:     shaHex,
+		HeadVersion:        "2026.04.20",
+		ShardSchemaVersion: 1,
+	}
+	m := buildFakeManifest(shard, entry)
+
+	rt := &fakeRT{body: map[string][]byte{
+		baselineURL: zstBytes,
+		shaURL:      []byte(shaHex + "  x\n"),
+	}}
+
+	opts := updater.UpdateOptions{
+		Options:  updater.Options{DestDir: dir, HTTPClient: &http.Client{Transport: rt}},
+		Channel:  updater.ChannelDaily,
+		Manifest: &fakeManifestSource{m: m},
+	}
+
+	result, err := updater.Update(context.Background(), shard, opts)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !result.Baseline {
+		t.Error("want Baseline=true for fresh install")
+	}
+
+	// File should exist now.
+	if _, statErr := os.Stat(filepath.Join(dir, shard+".db")); statErr != nil {
+		t.Errorf("expected shard .db to exist after install: %v", statErr)
+	}
+}
+
+// Ensure json/time imports are used (via buildFakeManifest + time.Now).
+var _ = json.Marshal
+var _ = time.Now

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -40,3 +40,5 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 # strings; ruff counts the string content as source lines. Splitting the SQL
 # to stay under 100 cols hurts readability more than it helps.
 "ingest/*.py" = ["E501"]
+# Validate tests embed inline fixture dicts; splitting them hurts readability.
+"tests/test_validate_*.py" = ["E501"]

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -18,10 +18,15 @@ dev = [
   "pytest>=8.0",
   "ruff>=0.5",
   "requests-mock>=1.12",
+  "moto[pricing]>=5.0",
+]
+validate = [
+  "boto3>=1.34",
+  "google-auth>=2.30",
 ]
 
 [tool.setuptools]
-packages = ["ingest", "normalize", "package", "discover"]
+packages = ["ingest", "normalize", "package", "discover", "validate"]
 
 [tool.ruff]
 line-length = 100

--- a/pipeline/tests/test_validate_aws.py
+++ b/pipeline/tests/test_validate_aws.py
@@ -1,0 +1,245 @@
+"""Tests for pipeline.validate.aws — AWS Pricing API revalidator."""
+
+from __future__ import annotations
+
+import json
+
+import boto3
+import pytest
+from botocore.stub import Stubber
+
+from validate.aws import DriftRecord, revalidate
+from validate.sampler import Sample
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE = Sample(
+    sku_id="aws-ec2/m5.large/us-east-1",
+    region="us-east-1",
+    resource_name="m5.large",
+    price_amount=0.096,
+    price_currency="USD",
+    dimension="on-demand",
+)
+
+_EC2_FILTERS = [
+    {"Type": "TERM_MATCH", "Field": "instanceType", "Value": "m5.large"},
+    {"Type": "TERM_MATCH", "Field": "regionCode", "Value": "us-east-1"},
+]
+
+
+def _price_list_item(amount: str) -> str:
+    """Return a JSON-encoded PriceList item string as returned by Pricing API."""
+    return json.dumps(
+        {
+            "product": {
+                "attributes": {
+                    "instanceType": "m5.large",
+                    "location": "US East (N. Virginia)",
+                    "operatingSystem": "Linux",
+                    "tenancy": "Shared",
+                }
+            },
+            "terms": {
+                "OnDemand": {
+                    "term1": {
+                        "priceDimensions": {
+                            "pd1": {
+                                "pricePerUnit": {"USD": amount},
+                                "unit": "Hrs",
+                                "description": "Linux m5.large",
+                            }
+                        }
+                    }
+                }
+            },
+        }
+    )
+
+
+def _make_stubbed_client(responses: list[dict]) -> boto3.client:
+    """Return a pricing client with queued stub responses."""
+    client = boto3.client("pricing", region_name="us-east-1")
+    stubber = Stubber(client)
+    for resp in responses:
+        stubber.add_response(
+            "get_products",
+            resp,
+            expected_params=resp.pop("_expected", None),
+        )
+    stubber.activate()
+    return client, stubber
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_revalidate_no_drift_within_tolerance() -> None:
+    """Catalog price within 1% of upstream -> no drift record."""
+    client = boto3.client("pricing", region_name="us-east-1")
+    stubber = Stubber(client)
+    stubber.add_response(
+        "get_products",
+        {
+            "PriceList": [_price_list_item("0.096")],
+            "NextToken": "",
+            "FormatVersion": "aws_v1",
+        },
+        expected_params={
+            "ServiceCode": "AmazonEC2",
+            "Filters": _EC2_FILTERS,
+            "FormatVersion": "aws_v1",
+            "MaxResults": 1,
+        },
+    )
+    with stubber:
+        drift, missing = revalidate([_SAMPLE], client=client)
+    assert drift == []
+    assert missing == []
+
+
+def test_revalidate_drift_detected() -> None:
+    """Catalog price differs by >1% from upstream -> drift record returned."""
+    client = boto3.client("pricing", region_name="us-east-1")
+    stubber = Stubber(client)
+    # Upstream price is 5% higher.
+    upstream_amount = 0.096 * 1.05
+    stubber.add_response(
+        "get_products",
+        {
+            "PriceList": [_price_list_item(f"{upstream_amount:.6f}")],
+            "NextToken": "",
+            "FormatVersion": "aws_v1",
+        },
+        expected_params={
+            "ServiceCode": "AmazonEC2",
+            "Filters": _EC2_FILTERS,
+            "FormatVersion": "aws_v1",
+            "MaxResults": 1,
+        },
+    )
+    with stubber:
+        drift, missing = revalidate(samples=[_SAMPLE], client=client)
+    assert len(drift) == 1
+    rec = drift[0]
+    assert isinstance(rec, DriftRecord)
+    assert rec.sku_id == _SAMPLE.sku_id
+    assert rec.catalog_amount == pytest.approx(0.096)
+    assert rec.upstream_amount == pytest.approx(upstream_amount)
+    assert rec.delta_pct == pytest.approx(abs(upstream_amount - 0.096) / upstream_amount * 100)
+    assert rec.source == "aws"
+
+
+def test_revalidate_missing_upstream() -> None:
+    """SKU not found upstream -> no drift record, but entry in missing list."""
+    client = boto3.client("pricing", region_name="us-east-1")
+    stubber = Stubber(client)
+    stubber.add_response(
+        "get_products",
+        {
+            "PriceList": [],
+            "NextToken": "",
+            "FormatVersion": "aws_v1",
+        },
+        expected_params={
+            "ServiceCode": "AmazonEC2",
+            "Filters": _EC2_FILTERS,
+            "FormatVersion": "aws_v1",
+            "MaxResults": 1,
+        },
+    )
+    with stubber:
+        drift, missing = revalidate(samples=[_SAMPLE], client=client)
+    assert drift == []
+    assert len(missing) == 1
+    assert missing[0] == _SAMPLE.sku_id
+
+
+def test_revalidate_multiple_samples() -> None:
+    """Multiple samples processed: one match, one drift, one missing."""
+    client = boto3.client("pricing", region_name="us-east-1")
+    stubber = Stubber(client)
+
+    s1 = Sample(
+        sku_id="aws-ec2/m5.large/us-east-1",
+        region="us-east-1",
+        resource_name="m5.large",
+        price_amount=0.096,
+        price_currency="USD",
+        dimension="on-demand",
+    )
+    s2 = Sample(
+        sku_id="aws-ec2/c5.large/eu-west-1",
+        region="eu-west-1",
+        resource_name="c5.large",
+        price_amount=0.085,
+        price_currency="USD",
+        dimension="on-demand",
+    )
+    s3 = Sample(
+        sku_id="aws-ec2/r5.large/ap-southeast-1",
+        region="ap-southeast-1",
+        resource_name="r5.large",
+        price_amount=0.126,
+        price_currency="USD",
+        dimension="on-demand",
+    )
+
+    # s1: exact match
+    stubber.add_response(
+        "get_products",
+        {"PriceList": [_price_list_item("0.096")], "NextToken": "", "FormatVersion": "aws_v1"},
+        expected_params={
+            "ServiceCode": "AmazonEC2",
+            "Filters": [
+                {"Type": "TERM_MATCH", "Field": "instanceType", "Value": "m5.large"},
+                {"Type": "TERM_MATCH", "Field": "regionCode", "Value": "us-east-1"},
+            ],
+            "FormatVersion": "aws_v1",
+            "MaxResults": 1,
+        },
+    )
+    # s2: ~10% drift
+    stubber.add_response(
+        "get_products",
+        {
+            "PriceList": [_price_list_item("0.0935")],
+            "NextToken": "",
+            "FormatVersion": "aws_v1",
+        },
+        expected_params={
+            "ServiceCode": "AmazonEC2",
+            "Filters": [
+                {"Type": "TERM_MATCH", "Field": "instanceType", "Value": "c5.large"},
+                {"Type": "TERM_MATCH", "Field": "regionCode", "Value": "eu-west-1"},
+            ],
+            "FormatVersion": "aws_v1",
+            "MaxResults": 1,
+        },
+    )
+    # s3: missing
+    stubber.add_response(
+        "get_products",
+        {"PriceList": [], "NextToken": "", "FormatVersion": "aws_v1"},
+        expected_params={
+            "ServiceCode": "AmazonEC2",
+            "Filters": [
+                {"Type": "TERM_MATCH", "Field": "instanceType", "Value": "r5.large"},
+                {"Type": "TERM_MATCH", "Field": "regionCode", "Value": "ap-southeast-1"},
+            ],
+            "FormatVersion": "aws_v1",
+            "MaxResults": 1,
+        },
+    )
+
+    with stubber:
+        drift, missing = revalidate(samples=[s1, s2, s3], client=client)
+
+    assert len(drift) == 1
+    assert drift[0].sku_id == s2.sku_id
+    assert len(missing) == 1
+    assert missing[0] == s3.sku_id

--- a/pipeline/tests/test_validate_azure.py
+++ b/pipeline/tests/test_validate_azure.py
@@ -1,0 +1,106 @@
+"""Tests for pipeline.validate.azure — Azure retail pricing revalidator."""
+
+from __future__ import annotations
+
+import pytest
+import requests_mock as requests_mock_module
+
+from validate.azure import revalidate
+from validate.sampler import Sample
+
+_AZURE_PRICES_URL = "https://prices.azure.com/api/retail/prices"
+
+_SAMPLE = Sample(
+    sku_id="azure-vm/Standard_D2_v3/eastus",
+    region="eastus",
+    resource_name="Standard_D2_v3",
+    price_amount=0.096,
+    price_currency="USD",
+    dimension="on-demand",
+)
+
+
+def _api_response(unit_price: float) -> dict:
+    return {
+        "Items": [
+            {
+                "meterName": "Standard_D2_v3",
+                "armRegionName": "eastus",
+                "unitPrice": unit_price,
+                "currencyCode": "USD",
+                "retailPrice": unit_price,
+                "skuName": "D2 v3",
+                "productName": "Virtual Machines Dv3 Series",
+                "type": "Consumption",
+            }
+        ],
+        "NextPageLink": None,
+        "Count": 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_azure_no_drift(requests_mock: requests_mock_module.Mocker) -> None:
+    """Catalog within 1% -> no drift record."""
+    requests_mock.get(_AZURE_PRICES_URL, json=_api_response(0.096))
+    drift, missing = revalidate([_SAMPLE])
+    assert drift == []
+    assert missing == []
+
+
+def test_azure_drift_detected(requests_mock: requests_mock_module.Mocker) -> None:
+    """5% upstream price higher -> drift record."""
+    upstream = 0.096 * 1.05
+    requests_mock.get(_AZURE_PRICES_URL, json=_api_response(upstream))
+    drift, missing = revalidate([_SAMPLE])
+    assert len(drift) == 1
+    rec = drift[0]
+    assert rec.sku_id == _SAMPLE.sku_id
+    assert rec.catalog_amount == pytest.approx(0.096)
+    assert rec.upstream_amount == pytest.approx(upstream)
+    assert rec.source == "azure"
+
+
+def test_azure_missing_upstream(requests_mock: requests_mock_module.Mocker) -> None:
+    """Empty Items response -> missing list."""
+    requests_mock.get(_AZURE_PRICES_URL, json={"Items": [], "NextPageLink": None, "Count": 0})
+    drift, missing = revalidate([_SAMPLE])
+    assert drift == []
+    assert len(missing) == 1
+    assert missing[0] == _SAMPLE.sku_id
+
+
+def test_azure_multiple_samples(requests_mock: requests_mock_module.Mocker) -> None:
+    """Two samples: one match, one drift."""
+    s1 = Sample(
+        sku_id="azure-vm/Standard_D2_v3/eastus",
+        region="eastus",
+        resource_name="Standard_D2_v3",
+        price_amount=0.096,
+        price_currency="USD",
+        dimension="on-demand",
+    )
+    s2 = Sample(
+        sku_id="azure-vm/Standard_F4s_v2/westus",
+        region="westus",
+        resource_name="Standard_F4s_v2",
+        price_amount=0.200,
+        price_currency="USD",
+        dimension="on-demand",
+    )
+    # Respond in call order (two separate GET calls)
+    requests_mock.get(
+        _AZURE_PRICES_URL,
+        [
+            {"json": _api_response(0.096)},   # s1: match
+            {"json": _api_response(0.230)},   # s2: drift ~15%
+        ],
+    )
+    drift, missing = revalidate([s1, s2])
+    assert len(drift) == 1
+    assert drift[0].sku_id == s2.sku_id
+    assert missing == []

--- a/pipeline/tests/test_validate_driver.py
+++ b/pipeline/tests/test_validate_driver.py
@@ -1,0 +1,224 @@
+"""Tests for pipeline.validate.driver — orchestration and CLI."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from validate.driver import run_validation
+from validate.sampler import Sample
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_shard(tmp_path: Path) -> Path:
+    """Create a minimal shard with 2 SKUs, one per region."""
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(db_path)
+    try:
+        con.executescript(
+            """
+            PRAGMA foreign_keys = ON;
+            CREATE TABLE skus (
+                sku_id TEXT NOT NULL PRIMARY KEY, provider TEXT NOT NULL,
+                service TEXT NOT NULL, kind TEXT NOT NULL,
+                resource_name TEXT NOT NULL, region TEXT NOT NULL,
+                region_normalized TEXT NOT NULL, terms_hash TEXT NOT NULL
+            ) WITHOUT ROWID;
+            CREATE TABLE prices (
+                sku_id TEXT NOT NULL REFERENCES skus(sku_id),
+                dimension TEXT NOT NULL, tier TEXT NOT NULL DEFAULT '',
+                amount REAL NOT NULL, unit TEXT NOT NULL,
+                PRIMARY KEY (sku_id, dimension, tier)
+            ) WITHOUT ROWID;
+            CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT);
+            INSERT INTO metadata VALUES ('currency', 'USD');
+            INSERT INTO skus VALUES ('sku-1', 'aws', 'ec2', 'compute.vm',
+                'm5.large', 'us-east-1', 'us-east-1', 'h1');
+            INSERT INTO skus VALUES ('sku-2', 'aws', 'ec2', 'compute.vm',
+                'c5.large', 'eu-west-1', 'eu-west-1', 'h2');
+            INSERT INTO prices VALUES ('sku-1', 'on-demand', '', 0.096, 'USD');
+            INSERT INTO prices VALUES ('sku-2', 'on-demand', '', 0.085, 'USD');
+            """
+        )
+        con.commit()
+    finally:
+        con.close()
+    return db_path
+
+
+def _no_drift_revalidator(
+    samples: list[Sample],
+    **kwargs,
+) -> tuple[list, list]:
+    return [], []
+
+
+def _drift_revalidator(
+    samples: list[Sample],
+    **kwargs,
+) -> tuple[list, list]:
+    from validate.aws import DriftRecord
+
+    drift = [
+        DriftRecord(
+            sku_id=samples[0].sku_id,
+            catalog_amount=samples[0].price_amount,
+            upstream_amount=samples[0].price_amount * 1.05,
+            delta_pct=5.0,
+            source="aws",
+        )
+    ]
+    return drift, []
+
+
+def _missing_revalidator(
+    samples: list[Sample],
+    **kwargs,
+) -> tuple[list, list]:
+    return [], [samples[0].sku_id]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_driver_pass_no_drift(tmp_path: Path) -> None:
+    """All samples within tolerance -> report.exit == 'pass', exit code 0."""
+    db = _make_minimal_shard(tmp_path)
+    report_path = tmp_path / "report.json"
+
+    result = run_validation(
+        shard="aws-ec2",
+        shard_db=db,
+        budget=5,
+        report=report_path,
+        revalidator=_no_drift_revalidator,
+        seed=42,
+    )
+    assert result == 0
+    assert report_path.exists()
+    data = json.loads(report_path.read_text())
+    assert data["shard"] == "aws-ec2"
+    assert data["exit"] == "pass"
+    assert data["drift_records"] == []
+    assert "generated_at" in data
+    assert "sample_size" in data
+
+
+def test_driver_fail_on_drift(tmp_path: Path) -> None:
+    """Drift detected -> report.exit == 'fail', exit code 1."""
+    db = _make_minimal_shard(tmp_path)
+    report_path = tmp_path / "report.json"
+
+    result = run_validation(
+        shard="aws-ec2",
+        shard_db=db,
+        budget=5,
+        report=report_path,
+        revalidator=_drift_revalidator,
+        seed=42,
+    )
+    assert result == 1
+    data = json.loads(report_path.read_text())
+    assert data["exit"] == "fail"
+    assert len(data["drift_records"]) == 1
+    assert data["drift_records"][0]["source"] == "aws"
+
+
+def test_driver_missing_not_fail(tmp_path: Path) -> None:
+    """Missing upstream entries do not cause a failure."""
+    db = _make_minimal_shard(tmp_path)
+    report_path = tmp_path / "report.json"
+
+    result = run_validation(
+        shard="aws-ec2",
+        shard_db=db,
+        budget=5,
+        report=report_path,
+        revalidator=_missing_revalidator,
+        seed=42,
+    )
+    assert result == 0
+    data = json.loads(report_path.read_text())
+    assert data["exit"] == "pass"
+    assert len(data["missing_upstream"]) >= 1
+
+
+def test_driver_report_schema(tmp_path: Path) -> None:
+    """Verify all required keys appear in the JSON report."""
+    db = _make_minimal_shard(tmp_path)
+    report_path = tmp_path / "report.json"
+    run_validation(
+        shard="openrouter",
+        shard_db=db,
+        budget=5,
+        report=report_path,
+        revalidator=_no_drift_revalidator,
+        seed=42,
+    )
+    data = json.loads(report_path.read_text())
+    for key in ("shard", "generated_at", "sample_size", "drift_records",
+                "missing_upstream", "vantage_drift", "exit"):
+        assert key in data, f"Missing key: {key}"
+
+
+def test_driver_vantage_drift_in_report(tmp_path: Path) -> None:
+    """Vantage drift records appear in report and cause fail."""
+    db = _make_minimal_shard(tmp_path)
+    report_path = tmp_path / "report.json"
+    from validate.vantage import DriftRecord as VDriftRecord
+    vantage_drift = [
+        VDriftRecord(
+            sku_id="sku-1",
+            catalog_amount=0.096,
+            upstream_amount=0.110,
+            delta_pct=14.5,
+        )
+    ]
+
+    result = run_validation(
+        shard="aws-ec2",
+        shard_db=db,
+        budget=5,
+        report=report_path,
+        revalidator=_no_drift_revalidator,
+        vantage_drift=vantage_drift,
+        seed=42,
+    )
+    assert result == 1
+    data = json.loads(report_path.read_text())
+    assert data["exit"] == "fail"
+    assert len(data["vantage_drift"]) == 1
+
+
+def test_driver_aggregates_multiple_drift_records(tmp_path: Path) -> None:
+    """Multiple drift records from revalidator are all captured."""
+    from validate.aws import DriftRecord
+
+    db = _make_minimal_shard(tmp_path)
+    report_path = tmp_path / "report.json"
+
+    def multi_drift(samples, **kwargs):
+        return [
+            DriftRecord(sku_id=s.sku_id, catalog_amount=s.price_amount,
+                        upstream_amount=s.price_amount * 1.10, delta_pct=10.0,
+                        source="aws")
+            for s in samples
+        ], []
+
+    result = run_validation(
+        shard="aws-ec2",
+        shard_db=db,
+        budget=5,
+        report=report_path,
+        revalidator=multi_drift,
+        seed=42,
+    )
+    data = json.loads(report_path.read_text())
+    assert result == 1
+    assert len(data["drift_records"]) == data["sample_size"]

--- a/pipeline/tests/test_validate_gcp.py
+++ b/pipeline/tests/test_validate_gcp.py
@@ -1,0 +1,113 @@
+"""Tests for pipeline.validate.gcp — GCP Cloud Billing revalidator."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests_mock as requests_mock_module
+
+from validate.gcp import revalidate
+from validate.sampler import Sample
+
+_BASE_URL = "https://cloudbilling.googleapis.com/v1/services"
+
+_SAMPLE = Sample(
+    sku_id="gcp-gce/n1-standard-2/us-east1",
+    region="us-east1",
+    resource_name="n1-standard-2",
+    price_amount=0.095,
+    price_currency="USD",
+    dimension="on-demand",
+)
+
+
+def _billing_response(nanos: int, units: int = 0) -> dict:
+    """Return a Cloud Billing SKU list response with one item."""
+    return {
+        "skus": [
+            {
+                "skuId": "some-sku-id",
+                "description": "N1 Standard Instance Core running in Americas",
+                "serviceRegions": ["us-east1"],
+                "pricingInfo": [
+                    {
+                        "pricingExpression": {
+                            "tieredRates": [
+                                {
+                                    "startUsageAmount": 0,
+                                    "unitPrice": {
+                                        "currencyCode": "USD",
+                                        "units": str(units),
+                                        "nanos": nanos,
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ],
+            }
+        ],
+        "nextPageToken": "",
+    }
+
+
+def _mock_auth() -> tuple[MagicMock, MagicMock]:
+    """Return mock (credentials, project) for google.auth.default."""
+    creds = MagicMock()
+    creds.token = "mock-token"
+    creds.valid = True
+    creds.refresh = MagicMock()
+    return creds, "mock-project"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_gcp_no_drift(requests_mock: requests_mock_module.Mocker) -> None:
+    """Catalog within 1% -> no drift record."""
+    # 95_000_000 nanos = $0.095
+    service_id = "6F81-5844-456A"  # GCE compute service
+    requests_mock.get(
+        f"{_BASE_URL}/{service_id}/skus",
+        json=_billing_response(nanos=95_000_000),
+    )
+    with patch("google.auth.default", return_value=_mock_auth()):
+        drift, missing = revalidate([_SAMPLE], service_id=service_id)
+    assert drift == []
+    assert missing == []
+
+
+def test_gcp_drift_detected(requests_mock: requests_mock_module.Mocker) -> None:
+    """Upstream 10% higher -> drift record."""
+    service_id = "6F81-5844-456A"
+    # 0.095 * 1.10 = 0.1045 -> 104_500_000 nanos
+    upstream_nanos = 104_500_000
+    requests_mock.get(
+        f"{_BASE_URL}/{service_id}/skus",
+        json=_billing_response(nanos=upstream_nanos),
+    )
+    with patch("google.auth.default", return_value=_mock_auth()):
+        drift, missing = revalidate([_SAMPLE], service_id=service_id)
+    assert len(drift) == 1
+    rec = drift[0]
+    assert rec.sku_id == _SAMPLE.sku_id
+    assert rec.source == "gcp"
+    upstream_expected = upstream_nanos / 1e9
+    assert rec.upstream_amount == pytest.approx(upstream_expected)
+
+
+def test_gcp_missing_upstream(requests_mock: requests_mock_module.Mocker) -> None:
+    """Empty skus list -> missing."""
+    service_id = "6F81-5844-456A"
+    requests_mock.get(
+        f"{_BASE_URL}/{service_id}/skus",
+        json={"skus": [], "nextPageToken": ""},
+    )
+    with patch("google.auth.default", return_value=_mock_auth()):
+        drift, missing = revalidate([_SAMPLE], service_id=service_id)
+    assert drift == []
+    assert len(missing) == 1
+    assert missing[0] == _SAMPLE.sku_id

--- a/pipeline/tests/test_validate_openrouter.py
+++ b/pipeline/tests/test_validate_openrouter.py
@@ -1,0 +1,103 @@
+"""Tests for pipeline.validate.openrouter — OpenRouter endpoint revalidator."""
+
+from __future__ import annotations
+
+import pytest
+import requests_mock as requests_mock_module
+
+from validate.openrouter import revalidate
+from validate.sampler import Sample
+
+_BASE_URL = "https://openrouter.ai/api/v1/models"
+
+_SAMPLE_PROMPT = Sample(
+    sku_id="openrouter/anthropic/claude-opus-4.6/anthropic",
+    region="",
+    resource_name="anthropic/claude-opus-4.6",
+    price_amount=15e-6,   # $15 per 1M tokens -> $0.000015 per token
+    price_currency="USD",
+    dimension="prompt",
+)
+
+_SAMPLE_COMPLETION = Sample(
+    sku_id="openrouter/anthropic/claude-opus-4.6/anthropic",
+    region="",
+    resource_name="anthropic/claude-opus-4.6",
+    price_amount=75e-6,
+    price_currency="USD",
+    dimension="completion",
+)
+
+
+def _endpoint_response(prompt_price: float, completion_price: float) -> dict:
+    return {
+        "data": [
+            {
+                "id": "anthropic/claude-opus-4.6",
+                "name": "Claude Opus 4.6",
+                "pricing": {
+                    "prompt": str(prompt_price),
+                    "completion": str(completion_price),
+                },
+                "provider": "anthropic",
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_openrouter_no_drift(requests_mock: requests_mock_module.Mocker) -> None:
+    """Exact match -> no drift."""
+    requests_mock.get(
+        f"{_BASE_URL}/anthropic/claude-opus-4.6/endpoints",
+        json=_endpoint_response(15e-6, 75e-6),
+    )
+    drift, missing = revalidate([_SAMPLE_PROMPT])
+    assert drift == []
+    assert missing == []
+
+
+def test_openrouter_drift_detected(requests_mock: requests_mock_module.Mocker) -> None:
+    """Upstream prompt price 10% higher -> drift record."""
+    upstream_prompt = 15e-6 * 1.10
+    requests_mock.get(
+        f"{_BASE_URL}/anthropic/claude-opus-4.6/endpoints",
+        json=_endpoint_response(upstream_prompt, 75e-6),
+    )
+    drift, missing = revalidate([_SAMPLE_PROMPT])
+    assert len(drift) == 1
+    rec = drift[0]
+    assert rec.sku_id == _SAMPLE_PROMPT.sku_id
+    assert rec.source == "openrouter"
+    assert rec.upstream_amount == pytest.approx(upstream_prompt)
+
+
+def test_openrouter_missing_upstream(requests_mock: requests_mock_module.Mocker) -> None:
+    """404 or empty response -> missing."""
+    requests_mock.get(
+        f"{_BASE_URL}/anthropic/claude-opus-4.6/endpoints",
+        json={"data": []},
+    )
+    drift, missing = revalidate([_SAMPLE_PROMPT])
+    assert drift == []
+    assert len(missing) == 1
+
+
+def test_openrouter_both_dimensions(requests_mock: requests_mock_module.Mocker) -> None:
+    """Prompt in-tolerance, completion drifted -> 1 drift record."""
+    upstream_completion = 75e-6 * 1.20
+    requests_mock.get(
+        f"{_BASE_URL}/anthropic/claude-opus-4.6/endpoints",
+        [
+            {"json": _endpoint_response(15e-6, 75e-6)},         # for prompt sample
+            {"json": _endpoint_response(15e-6, upstream_completion)},  # for completion sample
+        ],
+    )
+    drift, missing = revalidate([_SAMPLE_PROMPT, _SAMPLE_COMPLETION])
+    assert len(drift) == 1
+    assert drift[0].sku_id == _SAMPLE_COMPLETION.sku_id
+    assert missing == []

--- a/pipeline/tests/test_validate_sampler.py
+++ b/pipeline/tests/test_validate_sampler.py
@@ -1,0 +1,233 @@
+"""Tests for pipeline.validate.sampler — stratified sampling from a shard."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from validate.sampler import Sample, sample
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_shard(tmp_path: Path, rows: list[dict]) -> Path:
+    """Create a minimal SQLite shard with the sku schema and given rows."""
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(db_path)
+    try:
+        con.executescript(
+            """
+            PRAGMA foreign_keys = ON;
+            CREATE TABLE skus (
+                sku_id            TEXT NOT NULL PRIMARY KEY,
+                provider          TEXT NOT NULL,
+                service           TEXT NOT NULL,
+                kind              TEXT NOT NULL,
+                resource_name     TEXT NOT NULL,
+                region            TEXT NOT NULL,
+                region_normalized TEXT NOT NULL,
+                terms_hash        TEXT NOT NULL
+            ) WITHOUT ROWID;
+            CREATE TABLE prices (
+                sku_id     TEXT NOT NULL REFERENCES skus(sku_id) ON DELETE CASCADE,
+                dimension  TEXT NOT NULL,
+                tier       TEXT NOT NULL DEFAULT '',
+                amount     REAL NOT NULL,
+                unit       TEXT NOT NULL,
+                PRIMARY KEY (sku_id, dimension, tier)
+            ) WITHOUT ROWID;
+            CREATE TABLE metadata (
+                key   TEXT PRIMARY KEY,
+                value TEXT
+            );
+            INSERT INTO metadata VALUES ('currency', 'USD');
+            """
+        )
+        for r in rows:
+            con.execute(
+                "INSERT INTO skus VALUES (?,?,?,?,?,?,?,?)",
+                (
+                    r["sku_id"],
+                    r.get("provider", "aws"),
+                    r.get("service", "ec2"),
+                    r.get("kind", "compute.vm"),
+                    r["resource_name"],
+                    r["region"],
+                    r["region"],
+                    r.get("terms_hash", "hash1"),
+                ),
+            )
+            con.execute(
+                "INSERT INTO prices VALUES (?,?,?,?,?)",
+                (r["sku_id"], r.get("dimension", "on-demand"), "", r["amount"], "USD"),
+            )
+        con.commit()
+    finally:
+        con.close()
+    return db_path
+
+
+def _make_rows(
+    regions: list[tuple[str, int]],
+    families: list[str],
+) -> list[dict]:
+    """Generate rows: each (region, count) pair × families evenly distributed."""
+    rows = []
+    for region, count in regions:
+        for i in range(count):
+            family = families[i % len(families)]
+            sku_id = f"{region}/{family}/sku-{i}"
+            rows.append(
+                {
+                    "sku_id": sku_id,
+                    "resource_name": f"{family}.large",
+                    "region": region,
+                    "amount": 0.10 + i * 0.001,
+                }
+            )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_sample_returns_correct_type(tmp_path: Path) -> None:
+    """sample() returns a list of Sample dataclass instances."""
+    families = ["m5", "c5", "r5", "t3"]
+    rows = _make_rows(
+        [("us-east-1", 100), ("eu-west-1", 50), ("ap-southeast-1", 5)],
+        families,
+    )
+    db = _make_shard(tmp_path, rows)
+    result = sample(db, budget=20, seed=42)
+    assert isinstance(result, list)
+    assert len(result) > 0
+    s = result[0]
+    assert isinstance(s, Sample)
+    # Required fields
+    assert s.sku_id
+    assert s.region
+    assert s.resource_name
+    assert s.price_amount >= 0
+    assert s.price_currency == "USD"
+    assert s.dimension
+
+
+def test_sample_budget_respected(tmp_path: Path) -> None:
+    """sample() returns at most `budget` items."""
+    families = ["m5", "c5", "r5", "t3"]
+    rows = _make_rows(
+        [("us-east-1", 100), ("eu-west-1", 50), ("ap-southeast-1", 5)],
+        families,
+    )
+    db = _make_shard(tmp_path, rows)
+    result = sample(db, budget=20, seed=42)
+    assert len(result) <= 20
+
+
+def test_sample_stratification_top_regions(tmp_path: Path) -> None:
+    """At least 70% of budget comes from top-3 regions."""
+    families = ["m5", "c5", "r5", "t3"]
+    rows = _make_rows(
+        [("us-east-1", 100), ("eu-west-1", 50), ("ap-southeast-1", 5)],
+        families,
+    )
+    db = _make_shard(tmp_path, rows)
+    budget = 20
+    result = sample(db, budget=budget, seed=42)
+    top_regions = {"us-east-1", "eu-west-1", "ap-southeast-1"}
+    top_count = sum(1 for s in result if s.region in top_regions)
+    # With only 3 regions total, all should qualify as "top regions"
+    assert top_count >= int(budget * 0.70), (
+        f"Expected >= {int(budget * 0.70)} from top regions, got {top_count}"
+    )
+
+
+def test_sample_long_tail_present(tmp_path: Path) -> None:
+    """At least 1 sample from a long-tail region when budget allows."""
+    families = ["m5", "c5"]
+    rows = _make_rows(
+        [
+            ("us-east-1", 100),
+            ("eu-west-1", 50),
+            ("ap-southeast-1", 40),
+            ("sa-east-1", 5),   # long tail
+        ],
+        families,
+    )
+    db = _make_shard(tmp_path, rows)
+    result = sample(db, budget=20, seed=42)
+    long_tail_regions = {"sa-east-1"}
+    lt_count = sum(1 for s in result if s.region in long_tail_regions)
+    assert lt_count >= 1, f"Expected >= 1 from long-tail regions, got {lt_count}"
+
+
+def test_sample_family_diversity(tmp_path: Path) -> None:
+    """At least 3 distinct resource families in the result."""
+    families = ["m5", "c5", "r5", "t3"]
+    rows = _make_rows(
+        [("us-east-1", 100), ("eu-west-1", 50), ("ap-southeast-1", 5)],
+        families,
+    )
+    db = _make_shard(tmp_path, rows)
+    result = sample(db, budget=20, seed=42)
+    # resource_name is like "m5.large", "c5.large" etc.
+    families_seen = {s.resource_name.split(".")[0] for s in result}
+    assert len(families_seen) >= 3, (
+        f"Expected >= 3 distinct families, got {families_seen}"
+    )
+
+
+def test_sample_deterministic(tmp_path: Path) -> None:
+    """Same seed produces same results; different seed may differ."""
+    families = ["m5", "c5", "r5", "t3"]
+    rows = _make_rows(
+        [("us-east-1", 100), ("eu-west-1", 50), ("ap-southeast-1", 5)],
+        families,
+    )
+    db = _make_shard(tmp_path, rows)
+    r1 = sample(db, budget=20, seed=42)
+    r2 = sample(db, budget=20, seed=42)
+    assert r1 == r2, "Same seed must produce identical results"
+
+
+def test_sample_different_seeds_differ(tmp_path: Path) -> None:
+    """Different seeds should (almost always) produce different orderings."""
+    families = ["m5", "c5", "r5", "t3"]
+    rows = _make_rows(
+        [("us-east-1", 100), ("eu-west-1", 50), ("ap-southeast-1", 20)],
+        families,
+    )
+    db = _make_shard(tmp_path, rows)
+    r1 = [s.sku_id for s in sample(db, budget=20, seed=1)]
+    r2 = [s.sku_id for s in sample(db, budget=20, seed=999)]
+    # With 170 rows and budget 20, seeds should produce different results
+    assert r1 != r2, "Different seeds should produce different results"
+
+
+def test_sample_small_shard(tmp_path: Path) -> None:
+    """If total rows < budget, return all available rows."""
+    rows = _make_rows([("us-east-1", 5)], ["m5"])
+    db = _make_shard(tmp_path, rows)
+    result = sample(db, budget=20, seed=42)
+    assert len(result) <= 5
+
+
+def test_sample_no_duplicates(tmp_path: Path) -> None:
+    """No duplicate (sku_id, dimension) pairs in the sample."""
+    families = ["m5", "c5", "r5", "t3"]
+    rows = _make_rows(
+        [("us-east-1", 100), ("eu-west-1", 50), ("ap-southeast-1", 5)],
+        families,
+    )
+    db = _make_shard(tmp_path, rows)
+    result = sample(db, budget=20, seed=42)
+    seen = set()
+    for s in result:
+        key = (s.sku_id, s.dimension)
+        assert key not in seen, f"Duplicate sample: {key}"
+        seen.add(key)

--- a/pipeline/tests/test_validate_vantage.py
+++ b/pipeline/tests/test_validate_vantage.py
@@ -1,0 +1,211 @@
+"""Tests for pipeline.validate.vantage — offline EC2 cross-check."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from validate.vantage import cross_check
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ec2_shard(tmp_path: Path, rows: list[dict]) -> Path:
+    """Create a minimal EC2 SQLite shard."""
+    db_path = tmp_path / "aws-ec2.db"
+    con = sqlite3.connect(db_path)
+    try:
+        con.executescript(
+            """
+            PRAGMA foreign_keys = ON;
+            CREATE TABLE skus (
+                sku_id            TEXT NOT NULL PRIMARY KEY,
+                provider          TEXT NOT NULL,
+                service           TEXT NOT NULL,
+                kind              TEXT NOT NULL,
+                resource_name     TEXT NOT NULL,
+                region            TEXT NOT NULL,
+                region_normalized TEXT NOT NULL,
+                terms_hash        TEXT NOT NULL
+            ) WITHOUT ROWID;
+            CREATE TABLE prices (
+                sku_id     TEXT NOT NULL REFERENCES skus(sku_id) ON DELETE CASCADE,
+                dimension  TEXT NOT NULL,
+                tier       TEXT NOT NULL DEFAULT '',
+                amount     REAL NOT NULL,
+                unit       TEXT NOT NULL,
+                PRIMARY KEY (sku_id, dimension, tier)
+            ) WITHOUT ROWID;
+            CREATE TABLE terms (
+                sku_id         TEXT NOT NULL PRIMARY KEY REFERENCES skus(sku_id) ON DELETE CASCADE,
+                commitment     TEXT NOT NULL,
+                tenancy        TEXT NOT NULL DEFAULT '',
+                os             TEXT NOT NULL DEFAULT '',
+                support_tier   TEXT,
+                upfront        TEXT,
+                payment_option TEXT
+            ) WITHOUT ROWID;
+            CREATE TABLE metadata (
+                key   TEXT PRIMARY KEY,
+                value TEXT
+            );
+            INSERT INTO metadata VALUES ('currency', 'USD');
+            """
+        )
+        for r in rows:
+            con.execute(
+                "INSERT INTO skus VALUES (?,?,?,?,?,?,?,?)",
+                (
+                    r["sku_id"],
+                    "aws",
+                    "ec2",
+                    "compute.vm",
+                    r["instance_type"],
+                    r["region"],
+                    r["region"],
+                    "hash1",
+                ),
+            )
+            con.execute(
+                "INSERT INTO prices VALUES (?,?,?,?,?)",
+                (r["sku_id"], "on-demand", "", r["amount"], "USD"),
+            )
+            con.execute(
+                "INSERT INTO terms VALUES (?,?,?,?,?,?,?)",
+                (r["sku_id"], "on_demand", r.get("tenancy", "shared"), r.get("os", "linux"),
+                 None, None, None),
+            )
+        con.commit()
+    finally:
+        con.close()
+    return db_path
+
+
+def _make_instances_json(tmp_path: Path, instances: list[dict]) -> Path:
+    """Write a vantage instances.json with the given entries."""
+    path = tmp_path / "instances.json"
+    path.write_text(json.dumps(instances))
+    return path
+
+
+def _vantage_entry(instance_type: str, region: str, price: float) -> dict:
+    """Build a minimal vantage instances.json entry."""
+    return {
+        "instance_type": instance_type,
+        "pricing": {
+            region: {
+                "linux": {
+                    "ondemand": str(price),
+                }
+            }
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_cross_check_no_drift(tmp_path: Path) -> None:
+    """All catalog prices match vantage -> no drift records."""
+    rows = [
+        {"sku_id": "m5.large::us-east-1", "instance_type": "m5.large", "region": "us-east-1", "amount": 0.096},
+        {"sku_id": "c5.large::eu-west-1", "instance_type": "c5.large", "region": "eu-west-1", "amount": 0.085},
+    ]
+    instances = [
+        _vantage_entry("m5.large", "us-east-1", 0.096),
+        _vantage_entry("c5.large", "eu-west-1", 0.085),
+    ]
+    db = _make_ec2_shard(tmp_path, rows)
+    inst_json = _make_instances_json(tmp_path, instances)
+    drift = cross_check(db, instances_json=inst_json)
+    assert drift == []
+
+
+def test_cross_check_drift_detected(tmp_path: Path) -> None:
+    """One catalog price >1% off vantage -> exactly 1 drift record."""
+    rows = [
+        {"sku_id": "m5.large::us-east-1", "instance_type": "m5.large", "region": "us-east-1", "amount": 0.096},
+        {"sku_id": "c5.large::eu-west-1", "instance_type": "c5.large", "region": "eu-west-1", "amount": 0.085},
+        {"sku_id": "r5.large::ap-1", "instance_type": "r5.large", "region": "ap-southeast-1", "amount": 0.126},
+    ]
+    # r5.large has upstream price 5% higher
+    instances = [
+        _vantage_entry("m5.large", "us-east-1", 0.096),
+        _vantage_entry("c5.large", "eu-west-1", 0.085),
+        _vantage_entry("r5.large", "ap-southeast-1", 0.126 * 1.05),
+    ]
+    db = _make_ec2_shard(tmp_path, rows)
+    inst_json = _make_instances_json(tmp_path, instances)
+    drift = cross_check(db, instances_json=inst_json)
+    assert len(drift) == 1
+    rec = drift[0]
+    assert "r5.large" in rec.sku_id or rec.sku_id == "r5.large::ap-1"
+    assert rec.catalog_amount == pytest.approx(0.126)
+    assert rec.source == "vantage"
+
+
+def test_cross_check_exact_one_mismatch(tmp_path: Path) -> None:
+    """Exactly 1 drifted instance type is flagged, others pass."""
+    rows = [
+        {"sku_id": "m5.large::us-east-1", "instance_type": "m5.large", "region": "us-east-1", "amount": 0.200},
+        {"sku_id": "m5.large::eu-west-1", "instance_type": "m5.large", "region": "eu-west-1", "amount": 0.220},
+    ]
+    # us-east-1 drifts, eu-west-1 matches
+    instances = [
+        _vantage_entry("m5.large", "us-east-1", 0.200 * 1.10),  # 10% diff
+        _vantage_entry("m5.large", "eu-west-1", 0.220),
+    ]
+    db = _make_ec2_shard(tmp_path, rows)
+    inst_json = _make_instances_json(tmp_path, instances)
+    drift = cross_check(db, instances_json=inst_json)
+    assert len(drift) == 1
+    assert "us-east-1" in drift[0].sku_id
+
+
+def test_cross_check_no_match_in_vantage(tmp_path: Path) -> None:
+    """Instance type in shard not found in vantage -> not flagged as drift."""
+    rows = [
+        {"sku_id": "x99.large::us-east-1", "instance_type": "x99.large", "region": "us-east-1", "amount": 0.500},
+    ]
+    instances = [
+        _vantage_entry("m5.large", "us-east-1", 0.096),
+    ]
+    db = _make_ec2_shard(tmp_path, rows)
+    inst_json = _make_instances_json(tmp_path, instances)
+    drift = cross_check(db, instances_json=inst_json)
+    # No vantage data for x99.large -> not treated as drift (freshness issue)
+    assert drift == []
+
+
+def test_cross_check_filters_os_and_tenancy(tmp_path: Path) -> None:
+    """Only linux+shared rows are checked; windows rows are ignored."""
+    rows = [
+        {
+            "sku_id": "m5.large::us-east-1::linux",
+            "instance_type": "m5.large",
+            "region": "us-east-1",
+            "amount": 0.096,
+            "os": "linux",
+            "tenancy": "shared",
+        },
+        {
+            "sku_id": "m5.large::us-east-1::windows",
+            "instance_type": "m5.large",
+            "region": "us-east-1",
+            "amount": 9999.0,  # would flag if checked
+            "os": "windows",
+            "tenancy": "shared",
+        },
+    ]
+    instances = [_vantage_entry("m5.large", "us-east-1", 0.096)]
+    db = _make_ec2_shard(tmp_path, rows)
+    inst_json = _make_instances_json(tmp_path, instances)
+    drift = cross_check(db, instances_json=inst_json)
+    assert drift == []

--- a/pipeline/validate/__main__.py
+++ b/pipeline/validate/__main__.py
@@ -1,0 +1,63 @@
+"""Entry point for ``python -m validate``.
+
+Usage::
+
+    python -m validate \\
+      --shard aws-ec2 \\
+      --shard-db dist/pipeline/aws-ec2.db \\
+      --budget 20 \\
+      --report out/aws-ec2.report.json \\
+      [--vantage-json path/to/instances.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from validate.driver import run_validation
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m validate",
+        description="Validate a sku shard against upstream providers.",
+    )
+    parser.add_argument("--shard", required=True, help="Shard identifier, e.g. aws-ec2")
+    parser.add_argument("--shard-db", required=True, type=Path, help="Path to the SQLite shard")
+    parser.add_argument("--budget", type=int, default=20, help="Sampling budget (default: 20)")
+    parser.add_argument("--report", required=True, type=Path, help="Path for the JSON report")
+    parser.add_argument(
+        "--vantage-json",
+        type=Path,
+        default=None,
+        help="Path to vantage instances.json (required for aws-ec2 shard)",
+    )
+    parser.add_argument("--seed", type=int, default=None, help="Random seed for sampler")
+    parser.add_argument("--verbose", action="store_true", help="Enable DEBUG logging")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    vantage_drift = None
+    if args.vantage_json is not None:
+        from validate.vantage import cross_check
+        vantage_drift = cross_check(args.shard_db, instances_json=args.vantage_json)
+
+    return run_validation(
+        shard=args.shard,
+        shard_db=args.shard_db,
+        budget=args.budget,
+        report=args.report,
+        vantage_drift=vantage_drift,
+        seed=args.seed,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/validate/aws.py
+++ b/pipeline/validate/aws.py
@@ -1,0 +1,139 @@
+"""AWS Pricing API revalidator.
+
+Uses ``boto3.client('pricing', region_name='us-east-1')`` (the Pricing
+endpoint is us-east-1-only) to re-fetch the upstream price for each sample.
+OIDC credentials are injected by the GitHub Actions workflow via
+``aws-actions/configure-aws-credentials``; locally, the default credential
+chain is used.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mypy_boto3_pricing import PricingClient
+
+from validate.sampler import Sample
+
+logger = logging.getLogger(__name__)
+
+_DRIFT_THRESHOLD = 0.01  # 1%
+
+
+@dataclass
+class DriftRecord:
+    """A single price-drift observation."""
+
+    sku_id: str
+    catalog_amount: float
+    upstream_amount: float
+    delta_pct: float
+    source: str = "aws"
+
+
+def _service_code(resource_name: str, sku_id: str) -> str:
+    """Derive the AWS Pricing ServiceCode from the resource name."""
+    # sku_id typically encodes the service prefix: "aws-ec2/...", "aws-rds/..."
+    prefix = sku_id.split("/")[0].lower()
+    if "rds" in prefix or "db." in resource_name.lower():
+        return "AmazonRDS"
+    if "s3" in prefix or "s3" in resource_name.lower():
+        return "AmazonS3"
+    if "lambda" in prefix:
+        return "AWSLambda"
+    if "ebs" in prefix:
+        return "AmazonEC2"  # EBS is under EC2 pricing
+    if "dynamodb" in prefix:
+        return "AmazonDynamoDB"
+    if "cloudfront" in prefix:
+        return "AmazonCloudFront"
+    # Default: EC2
+    return "AmazonEC2"
+
+
+def _extract_price(price_list_item: str) -> float | None:
+    """Extract the first OnDemand price from a PriceList JSON string."""
+    try:
+        obj = json.loads(price_list_item)
+        terms = obj.get("terms", {})
+        on_demand = terms.get("OnDemand", {})
+        for term in on_demand.values():
+            for pd in term.get("priceDimensions", {}).values():
+                per_unit = pd.get("pricePerUnit", {})
+                usd = per_unit.get("USD", "0")
+                val = float(usd)
+                if val > 0:
+                    return val
+    except (json.JSONDecodeError, ValueError, AttributeError, TypeError):
+        pass
+    return None
+
+
+def revalidate(
+    samples: list[Sample],
+    *,
+    client: PricingClient | None = None,
+) -> tuple[list[DriftRecord], list[str]]:
+    """Per-sample SigV4 ``pricing:GetProducts`` call via boto3 client.
+
+    Returns
+    -------
+    tuple[list[DriftRecord], list[str]]
+        ``(drift_records, missing_upstream_sku_ids)``.
+        Samples where the SKU is missing upstream are logged but *not* treated
+        as drift — that is a shard-freshness issue, not a mispricing.
+    """
+    import boto3
+
+    if client is None:
+        client = boto3.client("pricing", region_name="us-east-1")
+
+    drift: list[DriftRecord] = []
+    missing: list[str] = []
+
+    for s in samples:
+        service_code = _service_code(s.resource_name, s.sku_id)
+        filters = [
+            {"Type": "TERM_MATCH", "Field": "instanceType", "Value": s.resource_name},
+            {"Type": "TERM_MATCH", "Field": "regionCode", "Value": s.region},
+        ]
+        try:
+            resp = client.get_products(
+                ServiceCode=service_code,
+                Filters=filters,
+                FormatVersion="aws_v1",
+                MaxResults=1,
+            )
+        except Exception:
+            logger.exception("AWS Pricing API call failed for %s", s.sku_id)
+            missing.append(s.sku_id)
+            continue
+
+        price_list = resp.get("PriceList", [])
+        if not price_list:
+            logger.debug("No upstream price found for %s", s.sku_id)
+            missing.append(s.sku_id)
+            continue
+
+        upstream = _extract_price(price_list[0])
+        if upstream is None or upstream == 0:
+            logger.debug("Could not parse upstream price for %s", s.sku_id)
+            missing.append(s.sku_id)
+            continue
+
+        delta_pct = abs(s.price_amount - upstream) / upstream * 100
+        if delta_pct >= _DRIFT_THRESHOLD * 100:
+            drift.append(
+                DriftRecord(
+                    sku_id=s.sku_id,
+                    catalog_amount=s.price_amount,
+                    upstream_amount=upstream,
+                    delta_pct=delta_pct,
+                )
+            )
+
+    return drift, missing

--- a/pipeline/validate/azure.py
+++ b/pipeline/validate/azure.py
@@ -1,0 +1,98 @@
+"""Azure retail pricing revalidator.
+
+Uses the anonymous ``https://prices.azure.com/api/retail/prices`` endpoint
+filtered by ``meterName`` and ``armRegionName``. No authentication required.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import requests
+
+from validate.sampler import Sample
+
+logger = logging.getLogger(__name__)
+
+_AZURE_PRICES_URL = "https://prices.azure.com/api/retail/prices"
+_DRIFT_THRESHOLD = 0.01  # 1%
+
+
+@dataclass
+class DriftRecord:
+    """A single price-drift observation."""
+
+    sku_id: str
+    catalog_amount: float
+    upstream_amount: float
+    delta_pct: float
+    source: str = "azure"
+
+
+def revalidate(
+    samples: list[Sample],
+    *,
+    session: requests.Session | None = None,
+) -> tuple[list[DriftRecord], list[str]]:
+    """Re-fetch each sample from the Azure retail pricing API.
+
+    Parameters
+    ----------
+    samples:
+        Samples to validate.
+    session:
+        Optional ``requests.Session`` for dependency injection in tests.
+
+    Returns
+    -------
+    tuple[list[DriftRecord], list[str]]
+        ``(drift_records, missing_upstream_sku_ids)``.
+    """
+    if session is None:
+        session = requests.Session()
+
+    drift: list[DriftRecord] = []
+    missing: list[str] = []
+
+    for s in samples:
+        filter_str = (
+            f"meterName eq '{s.resource_name}' and armRegionName eq '{s.region}'"
+        )
+        try:
+            resp = session.get(
+                _AZURE_PRICES_URL,
+                params={"$filter": filter_str},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception:
+            logger.exception("Azure Pricing API call failed for %s", s.sku_id)
+            missing.append(s.sku_id)
+            continue
+
+        items = data.get("Items", [])
+        if not items:
+            logger.debug("No Azure upstream price for %s", s.sku_id)
+            missing.append(s.sku_id)
+            continue
+
+        # Use the first matching item's unitPrice.
+        upstream = float(items[0].get("unitPrice", 0) or 0)
+        if upstream == 0:
+            missing.append(s.sku_id)
+            continue
+
+        delta_pct = abs(s.price_amount - upstream) / upstream * 100
+        if delta_pct >= _DRIFT_THRESHOLD * 100:
+            drift.append(
+                DriftRecord(
+                    sku_id=s.sku_id,
+                    catalog_amount=s.price_amount,
+                    upstream_amount=upstream,
+                    delta_pct=delta_pct,
+                )
+            )
+
+    return drift, missing

--- a/pipeline/validate/driver.py
+++ b/pipeline/validate/driver.py
@@ -1,0 +1,170 @@
+"""Validation driver — orchestrates sampling, revalidation, and report writing.
+
+CLI usage::
+
+    python -m validate \\
+      --shard aws-ec2 \\
+      --shard-db dist/pipeline/aws-ec2.db \\
+      --budget 20 \\
+      --report out/aws-ec2.report.json \\
+      [--vantage-json path/to/instances.json]
+
+Exit 0 on pass, 1 on fail (any drift record or vantage drift record).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+from validate.sampler import Sample, sample
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+class RevalidateFunc(Protocol):
+    """Callable signature for per-provider revalidators."""
+
+    def __call__(
+        self,
+        samples: list[Sample],
+        **kwargs: Any,
+    ) -> tuple[list[Any], list[str]]:
+        ...
+
+
+@dataclasses.dataclass
+class ValidationReport:
+    """Structured validation report."""
+
+    shard: str
+    generated_at: str
+    sample_size: int
+    drift_records: list[dict]
+    missing_upstream: list[str]
+    vantage_drift: list[dict]
+    exit: str  # "pass" | "fail"
+
+    def as_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Per-shard revalidator dispatch
+# ---------------------------------------------------------------------------
+
+
+def _default_revalidator(shard: str) -> RevalidateFunc:
+    """Return the appropriate revalidator based on the shard prefix."""
+    if shard.startswith("aws-"):
+        from validate.aws import revalidate
+        return revalidate
+    if shard.startswith("azure-"):
+        from validate.azure import revalidate
+        return revalidate
+    if shard.startswith("gcp-"):
+        from validate.gcp import revalidate
+        return revalidate
+    if shard.startswith("openrouter"):
+        from validate.openrouter import revalidate
+        return revalidate
+    # Fallback: no-op
+    return lambda samples, **_: ([], [])
+
+
+# ---------------------------------------------------------------------------
+# Core orchestration
+# ---------------------------------------------------------------------------
+
+
+def run_validation(
+    shard: str,
+    shard_db: Path,
+    budget: int,
+    report: Path,
+    *,
+    revalidator: RevalidateFunc | None = None,
+    vantage_drift: list | None = None,
+    seed: int | None = None,
+) -> int:
+    """Run the full validation pipeline for one shard.
+
+    Parameters
+    ----------
+    shard:
+        Shard identifier (e.g. ``"aws-ec2"``).
+    shard_db:
+        Path to the SQLite shard file.
+    budget:
+        Number of samples to draw.
+    report:
+        Path to write the JSON report.
+    revalidator:
+        Injected revalidator callable for testing. ``None`` uses the
+        default per-prefix dispatch.
+    vantage_drift:
+        Pre-computed vantage drift records (for aws-ec2 only). ``None``
+        means no vantage check was done.
+    seed:
+        Random seed forwarded to the sampler.
+
+    Returns
+    -------
+    int
+        0 on pass, 1 on fail.
+    """
+    if revalidator is None:
+        revalidator = _default_revalidator(shard)
+
+    # --- Sample ---
+    samples = sample(shard_db, budget=budget, seed=seed)
+    logger.info("Sampled %d rows from %s", len(samples), shard)
+
+    # --- Revalidate ---
+    drift_objs, missing = revalidator(samples)
+
+    # --- Serialise drift records ---
+    drift_records: list[dict] = []
+    for rec in drift_objs:
+        if dataclasses.is_dataclass(rec):
+            drift_records.append(dataclasses.asdict(rec))
+        else:
+            drift_records.append(dict(rec))
+
+    # --- Vantage ---
+    vantage_drift_dicts: list[dict] = []
+    if vantage_drift:
+        for rec in vantage_drift:
+            if dataclasses.is_dataclass(rec):
+                vantage_drift_dicts.append(dataclasses.asdict(rec))
+            else:
+                vantage_drift_dicts.append(dict(rec))
+
+    # --- Determine pass/fail ---
+    has_drift = bool(drift_records) or bool(vantage_drift_dicts)
+    exit_status = "fail" if has_drift else "pass"
+
+    # --- Write report ---
+    report_data = ValidationReport(
+        shard=shard,
+        generated_at=datetime.now(UTC).isoformat(),
+        sample_size=len(samples),
+        drift_records=drift_records,
+        missing_upstream=list(missing),
+        vantage_drift=vantage_drift_dicts,
+        exit=exit_status,
+    )
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text(json.dumps(report_data.as_dict(), indent=2))
+    logger.info("Report written to %s (exit=%s)", report, exit_status)
+
+    return 0 if exit_status == "pass" else 1

--- a/pipeline/validate/gcp.py
+++ b/pipeline/validate/gcp.py
@@ -1,0 +1,155 @@
+"""GCP Cloud Billing revalidator.
+
+Uses Application Default Credentials (``google.auth.default()``) — under
+GitHub Actions, this picks up the Workload Identity Federation token injected
+by ``google-github-actions/auth@v2``. Then iterates
+``cloudbilling.googleapis.com/v1/services/{sid}/skus`` filtered by region.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import google.auth
+import google.auth.transport.requests
+import requests
+
+from validate.sampler import Sample
+
+logger = logging.getLogger(__name__)
+
+_BILLING_BASE = "https://cloudbilling.googleapis.com/v1/services"
+_DRIFT_THRESHOLD = 0.01  # 1%
+
+# Default GCE service ID (Compute Engine); callers may override for other shards.
+_DEFAULT_GCE_SERVICE_ID = "6F81-5844-456A"
+
+
+@dataclass
+class DriftRecord:
+    """A single price-drift observation."""
+
+    sku_id: str
+    catalog_amount: float
+    upstream_amount: float
+    delta_pct: float
+    source: str = "gcp"
+
+
+def _nanos_to_float(units: int | str, nanos: int) -> float:
+    """Convert Google Money (units + nanos) to a float."""
+    return int(units or 0) + nanos / 1e9
+
+
+def _get_bearer_token() -> str:
+    """Return a fresh bearer token via ADC."""
+    creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-billing.readonly"])
+    auth_req = google.auth.transport.requests.Request()
+    creds.refresh(auth_req)
+    return creds.token
+
+
+def revalidate(
+    samples: list[Sample],
+    *,
+    service_id: str = _DEFAULT_GCE_SERVICE_ID,
+    session: requests.Session | None = None,
+) -> tuple[list[DriftRecord], list[str]]:
+    """Re-fetch each sample from the GCP Cloud Billing API.
+
+    Parameters
+    ----------
+    samples:
+        Samples to validate.
+    service_id:
+        Cloud Billing service ID (e.g. ``"6F81-5844-456A"`` for GCE).
+    session:
+        Optional ``requests.Session`` for dependency injection in tests.
+
+    Returns
+    -------
+    tuple[list[DriftRecord], list[str]]
+        ``(drift_records, missing_upstream_sku_ids)``.
+    """
+    if session is None:
+        session = requests.Session()
+
+    try:
+        token = _get_bearer_token()
+        session.headers["Authorization"] = f"Bearer {token}"
+    except Exception:
+        logger.exception("Failed to obtain GCP credentials")
+        return [], [s.sku_id for s in samples]
+
+    drift: list[DriftRecord] = []
+    missing: list[str] = []
+
+    for s in samples:
+        url = f"{_BILLING_BASE}/{service_id}/skus"
+        params: dict = {}
+        upstream_price = _fetch_sku_price(session, url, params, s.region, s.resource_name)
+
+        if upstream_price is None:
+            logger.debug("No GCP upstream price for %s", s.sku_id)
+            missing.append(s.sku_id)
+            continue
+
+        delta_pct = abs(s.price_amount - upstream_price) / upstream_price * 100
+        if delta_pct >= _DRIFT_THRESHOLD * 100:
+            drift.append(
+                DriftRecord(
+                    sku_id=s.sku_id,
+                    catalog_amount=s.price_amount,
+                    upstream_amount=upstream_price,
+                    delta_pct=delta_pct,
+                )
+            )
+
+    return drift, missing
+
+
+def _fetch_sku_price(
+    session: requests.Session,
+    url: str,
+    params: dict,
+    region: str,
+    resource_name: str,
+) -> float | None:
+    """Paginate the SKU list and return the first matching price."""
+    page_token = ""
+    while True:
+        try:
+            query: dict = dict(params)
+            if page_token:
+                query["pageToken"] = page_token
+            resp = session.get(url, params=query, timeout=20)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception:
+            logger.exception("GCP Billing API call failed for %s / %s", resource_name, region)
+            return None
+
+        for sku in data.get("skus", []):
+            regions = sku.get("serviceRegions", [])
+            if region not in regions:
+                continue
+            pricing_info = sku.get("pricingInfo", [])
+            if not pricing_info:
+                continue
+            expr = pricing_info[0].get("pricingExpression", {})
+            rates = expr.get("tieredRates", [])
+            if not rates:
+                continue
+            up = rates[0].get("unitPrice", {})
+            nanos = int(up.get("nanos", 0))
+            units = up.get("units", "0")
+            price = _nanos_to_float(units, nanos)
+            if price > 0:
+                return price
+
+        page_token = data.get("nextPageToken", "")
+        if not page_token:
+            break
+
+    return None

--- a/pipeline/validate/openrouter.py
+++ b/pipeline/validate/openrouter.py
@@ -1,0 +1,106 @@
+"""OpenRouter endpoint revalidator.
+
+Calls ``GET https://openrouter.ai/api/v1/models/{id}/endpoints`` (anonymous)
+and compares per-provider prompt/completion token prices.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import requests
+
+from validate.sampler import Sample
+
+logger = logging.getLogger(__name__)
+
+_OPENROUTER_BASE = "https://openrouter.ai/api/v1/models"
+_DRIFT_THRESHOLD = 0.01  # 1%
+
+
+@dataclass
+class DriftRecord:
+    """A single price-drift observation."""
+
+    sku_id: str
+    catalog_amount: float
+    upstream_amount: float
+    delta_pct: float
+    source: str = "openrouter"
+
+
+def revalidate(
+    samples: list[Sample],
+    *,
+    session: requests.Session | None = None,
+) -> tuple[list[DriftRecord], list[str]]:
+    """Re-fetch each sample from the OpenRouter endpoints API.
+
+    Parameters
+    ----------
+    samples:
+        Samples to validate; ``dimension`` must be ``"prompt"`` or
+        ``"completion"``.
+    session:
+        Optional ``requests.Session`` for dependency injection in tests.
+
+    Returns
+    -------
+    tuple[list[DriftRecord], list[str]]
+        ``(drift_records, missing_upstream_sku_ids)``.
+    """
+    if session is None:
+        session = requests.Session()
+
+    drift: list[DriftRecord] = []
+    missing: list[str] = []
+
+    for s in samples:
+        model_id = s.resource_name
+        url = f"{_OPENROUTER_BASE}/{model_id}/endpoints"
+        try:
+            resp = session.get(url, timeout=15)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception:
+            logger.exception("OpenRouter API call failed for %s", s.sku_id)
+            missing.append(s.sku_id)
+            continue
+
+        endpoints = data.get("data", [])
+        if not endpoints:
+            logger.debug("No OpenRouter endpoint data for %s", s.sku_id)
+            missing.append(s.sku_id)
+            continue
+
+        # Use the first endpoint's pricing for the relevant dimension.
+        pricing = endpoints[0].get("pricing", {})
+        dimension_key = s.dimension  # "prompt" or "completion"
+        raw = pricing.get(dimension_key)
+        if raw is None:
+            missing.append(s.sku_id)
+            continue
+
+        try:
+            upstream = float(raw)
+        except (ValueError, TypeError):
+            missing.append(s.sku_id)
+            continue
+
+        if upstream == 0:
+            missing.append(s.sku_id)
+            continue
+
+        delta_pct = abs(s.price_amount - upstream) / upstream * 100
+        if delta_pct >= _DRIFT_THRESHOLD * 100:
+            drift.append(
+                DriftRecord(
+                    sku_id=s.sku_id,
+                    catalog_amount=s.price_amount,
+                    upstream_amount=upstream,
+                    delta_pct=delta_pct,
+                )
+            )
+
+    return drift, missing

--- a/pipeline/validate/sampler.py
+++ b/pipeline/validate/sampler.py
@@ -1,0 +1,158 @@
+"""Stratified sampler for shard validation.
+
+Spec §6 stratified sampling — partitions a budget across:
+  (a) top 3 regions by row count: 70% of budget
+  (b) one SKU from the long-tail region set: 10%
+  (c) top-N resource families by row count: 15%
+  (d) remainder filled from any row not yet selected: 5%
+
+Returns a deterministic list of Sample records given the same seed.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Sample:
+    sku_id: str
+    region: str
+    resource_name: str
+    price_amount: float
+    price_currency: str
+    dimension: str
+
+
+def sample(
+    shard_db: Path,
+    *,
+    budget: int = 20,
+    seed: int | None = None,
+) -> list[Sample]:
+    """Return a stratified sample from a shard SQLite database.
+
+    Parameters
+    ----------
+    shard_db:
+        Path to the SQLite shard file.
+    budget:
+        Maximum number of samples to return.
+    seed:
+        Random seed for deterministic results. ``None`` for random.
+
+    Returns
+    -------
+    list[Sample]
+        At most ``budget`` samples, de-duplicated by (sku_id, dimension).
+    """
+    rng = random.Random(seed)
+
+    con = sqlite3.connect(f"file:{shard_db}?mode=ro", uri=True)
+    try:
+        # Read the global currency once.
+        row = con.execute(
+            "SELECT value FROM metadata WHERE key = 'currency'"
+        ).fetchone()
+        currency = row[0] if row else "USD"
+
+        # Pull every (sku_id, region, resource_name, dimension, amount) row.
+        rows = con.execute(
+            """
+            SELECT s.sku_id, s.region, s.resource_name,
+                   p.dimension, p.amount
+            FROM skus s
+            JOIN prices p USING (sku_id)
+            """
+        ).fetchall()
+    finally:
+        con.close()
+
+    if not rows:
+        return []
+
+    # Build lookup structures.
+    all_items: list[tuple[str, str, str, str, float]] = rows  # typed alias
+
+    # Region row counts.
+    region_counts: dict[str, int] = {}
+    for _, region, _, _, _ in all_items:
+        region_counts[region] = region_counts.get(region, 0) + 1
+
+    sorted_regions = sorted(region_counts, key=lambda r: -region_counts[r])
+    top_regions = set(sorted_regions[:3])
+    long_tail_regions = set(sorted_regions[3:])
+
+    # Family extraction (first segment of resource_name before '.').
+    def _family(resource_name: str) -> str:
+        return resource_name.split(".")[0] if "." in resource_name else resource_name
+
+    family_counts: dict[str, int] = {}
+    for _, _, resource_name, _, _ in all_items:
+        fam = _family(resource_name)
+        family_counts[fam] = family_counts.get(fam, 0) + 1
+
+    sorted_families = sorted(family_counts, key=lambda f: -family_counts[f])
+    # Top families cover 15% of budget (at least 1).
+    top_family_n = max(1, math.ceil(budget * 0.15 / max(1, len(sorted_families))))
+    top_families = set(sorted_families[:top_family_n])
+
+    # Partition items by stratum.
+    top_region_items: list[tuple] = []
+    long_tail_items: list[tuple] = []
+    top_family_items: list[tuple] = []
+
+    for item in all_items:
+        _, region, resource_name, _, _ = item
+        fam = _family(resource_name)
+        if region in top_regions:
+            top_region_items.append(item)
+        elif region in long_tail_regions:
+            long_tail_items.append(item)
+        if fam in top_families:
+            top_family_items.append(item)
+
+    # Allocate budget slots.
+    top_region_budget = max(1, int(budget * 0.70))
+    long_tail_budget = max(1, int(budget * 0.10))
+    top_family_budget = max(1, int(budget * 0.15))
+    remainder_budget = budget - top_region_budget - long_tail_budget - top_family_budget
+    remainder_budget = max(0, remainder_budget)
+
+    selected: list[tuple] = []
+    seen: set[tuple[str, str]] = set()
+
+    def _pick(pool: list[tuple], n: int) -> None:
+        shuffled = list(pool)
+        rng.shuffle(shuffled)
+        for item in shuffled:
+            if len(selected) >= budget:
+                break
+            key = (item[0], item[3])  # (sku_id, dimension)
+            if key not in seen and n > 0:
+                selected.append(item)
+                seen.add(key)
+                n -= 1
+
+    _pick(top_region_items, top_region_budget)
+    if long_tail_items:
+        _pick(long_tail_items, long_tail_budget)
+    _pick(top_family_items, top_family_budget)
+    # Fill remainder from all items not yet chosen.
+    _pick(all_items, remainder_budget + budget - len(selected))
+
+    return [
+        Sample(
+            sku_id=sku_id,
+            region=region,
+            resource_name=resource_name,
+            price_amount=amount,
+            price_currency=currency,
+            dimension=dimension,
+        )
+        for sku_id, region, resource_name, dimension, amount in selected
+    ]

--- a/pipeline/validate/vantage.py
+++ b/pipeline/validate/vantage.py
@@ -1,0 +1,120 @@
+"""Offline EC2 cross-check against vantage-sh/ec2instances.info.
+
+Downloads ``instances.json`` at workflow start (handled by the GitHub Actions
+step) and joins with the EC2 shard on
+``(instance_type, region, os='linux', tenancy='shared')``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_VANTAGE_URL = (
+    "https://raw.githubusercontent.com/vantage-sh/ec2instances.info"
+    "/master/www/instances.json"
+)
+_DRIFT_THRESHOLD = 0.01  # 1%
+
+
+@dataclass
+class DriftRecord:
+    """A single price-drift observation from the vantage cross-check."""
+
+    sku_id: str
+    catalog_amount: float
+    upstream_amount: float
+    delta_pct: float
+    source: str = "vantage"
+
+
+def cross_check(
+    shard_db: Path,
+    *,
+    instances_json: Path,
+) -> list[DriftRecord]:
+    """Offline cross-check: load instances.json, join with EC2 shard.
+
+    Joins on ``(instance_type, region, os='linux', tenancy='shared')``.
+    Flags rows where the catalog price differs from vantage's on-demand
+    linux price by more than 1%.
+
+    Parameters
+    ----------
+    shard_db:
+        Path to the EC2 SQLite shard.
+    instances_json:
+        Path to the vantage ``instances.json`` snapshot.
+
+    Returns
+    -------
+    list[DriftRecord]
+        One record per (instance_type, region) pair that exceeds the drift
+        threshold.
+    """
+    with instances_json.open() as fh:
+        instances = json.load(fh)
+
+    # Build vantage lookup: (instance_type, region) -> price
+    vantage_prices: dict[tuple[str, str], float] = {}
+    for entry in instances:
+        itype = entry.get("instance_type", "")
+        pricing = entry.get("pricing", {})
+        for region, os_map in pricing.items():
+            linux_map = os_map.get("linux", {})
+            raw = linux_map.get("ondemand")
+            if raw is not None:
+                try:
+                    price = float(raw)
+                    if price > 0:
+                        vantage_prices[(itype, region)] = price
+                except (ValueError, TypeError):
+                    pass
+
+    if not vantage_prices:
+        logger.warning("No vantage prices loaded from %s", instances_json)
+        return []
+
+    # Query shard for linux/shared on-demand rows.
+    con = sqlite3.connect(f"file:{shard_db}?mode=ro", uri=True)
+    try:
+        rows = con.execute(
+            """
+            SELECT s.sku_id, s.resource_name, s.region, p.amount
+            FROM skus s
+            JOIN prices p USING (sku_id)
+            JOIN terms t USING (sku_id)
+            WHERE p.dimension = 'on-demand'
+              AND LOWER(t.os) IN ('linux', '')
+              AND LOWER(t.tenancy) IN ('shared', '')
+              AND t.commitment IN ('on_demand', '')
+            """
+        ).fetchall()
+    finally:
+        con.close()
+
+    drift: list[DriftRecord] = []
+    for sku_id, resource_name, region, catalog_price in rows:
+        key = (resource_name, region)
+        vantage_price = vantage_prices.get(key)
+        if vantage_price is None:
+            # Not found in vantage — treat as freshness issue, not drift.
+            continue
+
+        delta_pct = abs(catalog_price - vantage_price) / vantage_price * 100
+        if delta_pct >= _DRIFT_THRESHOLD * 100:
+            drift.append(
+                DriftRecord(
+                    sku_id=sku_id,
+                    catalog_amount=catalog_price,
+                    upstream_amount=vantage_price,
+                    delta_pct=delta_pct,
+                )
+            )
+
+    return drift


### PR DESCRIPTION
## Summary

- **`data-validate.yml`** — weekly (Mondays 04:00 UTC + `workflow_dispatch`) stratified-samples each on-demand shard, re-fetches via short-lived OIDC (AWS IAM role, GCP Workload Identity Federation; Azure/OpenRouter anonymous), fails on >1% drift, files a `catalog-drift` issue per failing shard. EC2 also runs an offline cross-check against `vantage-sh/ec2instances.info`.
- **`internal/updater` delta-chain walker** — new `Update(ctx, shard, opts)` walks the manifest's delta chain, ETag-caches the manifest (primary release URL + jsDelivr fallback on 5xx), sha256-verifies every delta, applies in a single SQLite transaction under advisory flock. Chain-too-long (>`MaxChain`, default 20) or `from`-mismatch triggers baseline fallback; no half-applied shards on disk.
- **`sku update --channel {stable,daily}`** — new flag + `SKU_UPDATE_CHANNEL` env + `profiles.<name>.channel` config key. `stable` downloads baselines only (predictable); `daily` walks per-day deltas (typical agent use case).
- **OIDC provisioning runbook** — `docs/ops/validation.md` covers AWS IAM role + GCP WIF pool setup, repo-variable wiring, rotation policy, and `catalog-drift` triage.

## Test plan

- [x] 259 Python pipeline tests green (35 new `test_validate_*`).
- [x] All Go unit tests green; `make lint` clean (0 issues).
- [x] Client-side: `updater.Update` covered by unit tests for stable-always-baseline, daily-304-noop, daily-short-chain, daily-chain-too-long fallback, schema-version mismatch.
- [ ] `data-validate.yml` workflow dispatch — **pending maintainer OIDC provisioning** (see Deferred below).

## Deferred / out of scope

- **First `data-validate.yml` dispatch.** Needs `AWS_VALIDATE_ROLE_ARN`, `GCP_WIF_PROVIDER`, `GCP_VALIDATE_SA` repo variables — maintainer provisions per `docs/ops/validation.md`. The workflow YAML, issue template, and Python validators all ship here so the dispatch is a one-step flip when provisioning is done. Azure- and OpenRouter-only dispatches (`-F shards=openrouter`) work today with no provisioning.
- Cosign / `actions/attest-build-provenance` for shard signing → M7.3.
- Property-based delta-chain tests via `pgregory.net/rapid` → M7.3.
- `deprecated_shards` manifest flag exercised end-to-end — revisit when a provider objects.

## Notes for reviewer

- `internal/sqliteutil` is new — just a thin advisory-flock helper (unix `syscall.Flock`, windows no-op stub) used by the delta applier to serialise concurrent `sku update` invocations.
- Plan referenced `internal/skuerr` which does not exist — wired against the real `internal/errors` (`skuerrors`) package. Schema-version mismatches raise `CodeValidation` (exit 4) with reasons `shard_too_old` / `shard_too_new`, matching spec §4.
- `config.Profile.Channel` already existed (added pre-M3a.4); no config struct changes needed.