### PR TITLE
ci: retire GCP_BILLING_API_KEY, share OIDC/WIF with validate

### DIFF
--- a/.github/workflows/data-daily.yml
+++ b/.github/workflows/data-daily.yml
@@ -15,9 +15,10 @@ on:
         default: "false"
 
 permissions:
-  contents: write   # gh release create + data branch force-push
-  issues:   write   # cdn-purge-failed auto-issue
-  actions:  read
+  contents:  write   # gh release create + data branch force-push
+  issues:    write   # cdn-purge-failed auto-issue
+  actions:   read
+  id-token:  write   # Workload Identity Federation for GCP Cloud Billing API
 
 concurrency:
   # Never cancel a release mid-publish; queue follow-ups instead.
@@ -35,6 +36,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-pipeline
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account:            ${{ vars.GCP_VALIDATE_SA }}
 
       - name: Resolve previous release version
         id: previous
@@ -59,7 +66,6 @@ jobs:
       - name: Discover changed shards
         id: discover
         env:
-          GCP_BILLING_API_KEY: ${{ secrets.GCP_BILLING_API_KEY }}
           FORCE_BASELINE: ${{ github.event.inputs.force_baseline }}
         run: |
           set -euo pipefail
@@ -102,9 +108,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-pipeline
 
+      - name: Authenticate to GCP via Workload Identity Federation
+        if: startsWith(matrix.shard, 'gcp_')
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account:            ${{ vars.GCP_VALIDATE_SA }}
+
       - name: Fetch upstream + ingest + package
         env:
-          GCP_BILLING_API_KEY: ${{ secrets.GCP_BILLING_API_KEY }}
           SHARD:             ${{ matrix.shard }}
           CATALOG_VERSION:   ${{ needs.discover.outputs.catalog_version }}
         run: bash scripts/ci/ingest_shard.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Agent quick-start for the `sku` repo.
 | Run benchmarks | `make bench` |
 | Run Python pipeline tests | `make pipeline-test` |
 | Run discover (fixture / dry-run) | `make discover` |
-| Run discover against real upstreams | `DISCOVER_LIVE=1 GCP_BILLING_API_KEY=... make discover` |
+| Run discover against real upstreams | `DISCOVER_LIVE=1 make discover` (GCP uses ADC; run `gcloud auth application-default login` first) |
 | Live-ingest a single shard | `make shard-live SHARD=aws_ec2 SRC=/path/to/offer.json` |
 | Dispatch daily data workflow (dry-run) | `gh workflow run data-daily.yml -F dry_run=true -F force_baseline=true` |
 | Dispatch daily data workflow (publish) | `gh workflow run data-daily.yml -F dry_run=false -F force_baseline=true` |

--- a/docs/ops/data-daily-runbook.md
+++ b/docs/ops/data-daily-runbook.md
@@ -4,16 +4,18 @@ Maintainer guide for `.github/workflows/data-daily.yml` — the cron-driven
 daily release that publishes shard baselines, SQL deltas, and `manifest.json`
 under the `data-YYYY.MM.DD` tag.
 
-## Secrets required
+## Secrets + variables required
 
-| Secret | Purpose | How to create |
-|---|---|---|
-| `GCP_BILLING_API_KEY` | Anonymous GCP Cloud Billing Catalog API key, used by the `gcp_*` shards. | Google Cloud Console → APIs & Services → Credentials → Create API key → restrict to the **Cloud Billing API** → save to repo secrets as `GCP_BILLING_API_KEY`. |
-| `GITHUB_TOKEN` | Auto-injected by Actions; gives the workflow permission to create releases, push the `data` branch, and file incident issues. | No action — GitHub provides this. |
+| Name | Kind | Purpose | How to create |
+|---|---|---|---|
+| `GCP_WIF_PROVIDER` | Repo **variable** | Workload Identity Federation provider resource name (e.g. `projects/NNN/locations/global/workloadIdentityPools/github/providers/sofq-sku`). Consumed by `google-github-actions/auth@v2` to impersonate the SA via short-lived OIDC. | See `docs/ops/validation.md` — same variable as `data-validate.yml`; one-time provisioning. |
+| `GCP_VALIDATE_SA` | Repo **variable** | Service-account email impersonated by the workflow (`sku-validator@<project>.iam`; `roles/billing.viewer` on the billing account). | Same provisioning as above. |
+| `GITHUB_TOKEN` | Secret | Auto-injected by Actions; permits release creation, `data` branch push, incident issues. | No action — GitHub provides. |
 
-No OIDC / cloud-IAM roles are required by this workflow. AWS pricing, Azure
-retail-prices, and OpenRouter are anonymous; GCP uses the API key above. The
-`data-validate.yml` workflow (m3a.4.3) introduces AWS SigV4 + GCP WIF.
+AWS pricing, Azure retail-prices, and OpenRouter are anonymous. GCP Cloud
+Billing used to require a long-lived `GCP_BILLING_API_KEY` secret; it has
+been retired in favor of the short-lived OIDC → WIF → SA token path shared
+with `data-validate.yml`.
 
 ## First green run (bootstrap)
 

--- a/pipeline/discover/__main__.py
+++ b/pipeline/discover/__main__.py
@@ -1,9 +1,15 @@
-"""`python -m pipeline.discover` entrypoint."""
+"""`python -m pipeline.discover` entrypoint.
+
+GCP auth: when `--live` hits GCP shards, credentials come from Google
+Application Default Credentials (ADC). Under GitHub Actions this is the
+OIDC-federated service-account token injected by
+`google-github-actions/auth@v2`; locally, any gcloud login or
+`GOOGLE_APPLICATION_CREDENTIALS` path works.
+"""
 
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 from pathlib import Path
 
@@ -17,17 +23,11 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--live", action="store_true", help="hit real upstreams (default: dry-run)")
     ap.add_argument("--baseline-rebuild", action="store_true", help="force every shard into output")
     ap.add_argument("--shards", default=None, help="comma-separated shard ids; default = all known")
-    ap.add_argument(
-        "--gcp-api-key-env",
-        default="GCP_BILLING_API_KEY",
-        help="env var holding the GCP billing API key (default: GCP_BILLING_API_KEY)",
-    )
     args = ap.parse_args(argv)
 
     shards = None
     if args.shards:
         shards = [s.strip() for s in args.shards.split(",") if s.strip()]
-    api_key = os.environ.get(args.gcp_api_key_env) if args.live else None
 
     return run(
         state_path=args.state,
@@ -35,7 +35,6 @@ def main(argv: list[str] | None = None) -> int:
         live=args.live,
         baseline_rebuild=args.baseline_rebuild,
         shards=shards,
-        gcp_api_key=api_key,
     )
 
 

--- a/pipeline/discover/driver.py
+++ b/pipeline/discover/driver.py
@@ -96,7 +96,10 @@ def _write_output(out_path: Path, doc: Mapping[str, object]) -> None:
 
 
 def _run_live(
-    shards: list[str], *, gcp_api_key: str | None, session: requests.Session | None
+    shards: list[str],
+    *,
+    session: requests.Session | None,
+    gcp_session: requests.Session | None,
 ) -> tuple[dict[str, str], list[dict[str, str]]]:
     """Fetch indicators for every shard. Returns (indicators, errors).
 
@@ -126,13 +129,19 @@ def _run_live(
     _run_group("aws", lambda g: aws_disc.discover(g, session=session))
     _run_group("azure", lambda g: azure_disc.discover(g, session=session))
     if by_provider["gcp"]:
-        if not gcp_api_key:
-            for s in by_provider["gcp"]:
-                errors.append(
-                    {"shard": s, "reason": "gcp_missing_api_key", "detail": "api_key required"}
-                )
-        else:
-            _run_group("gcp", lambda g: gcp_disc.discover(g, api_key=gcp_api_key, session=session))
+        if gcp_session is None:
+            # Production path: build an ADC-authenticated session. Tests pass
+            # gcp_session explicitly so google.auth isn't invoked.
+            try:
+                from ingest.gcp_common import build_authenticated_session
+
+                gcp_session = build_authenticated_session()
+            except Exception as exc:
+                for s in by_provider["gcp"]:
+                    errors.append({"shard": s, "reason": "gcp_auth_error", "detail": str(exc)})
+                gcp_session = None
+        if gcp_session is not None:
+            _run_group("gcp", lambda g: gcp_disc.discover(g, session=gcp_session))
     _run_group("openrouter", lambda g: or_disc.discover(g, client=LiveClient()))
     return indicators, errors
 
@@ -144,8 +153,8 @@ def run(
     live: bool,
     baseline_rebuild: bool = False,
     shards: Iterable[str] | None = None,
-    gcp_api_key: str | None = None,
     session: requests.Session | None = None,
+    gcp_session: requests.Session | None = None,
 ) -> int:
     """Execute one discovery pass; write `out_path`; return exit code."""
     try:
@@ -181,7 +190,7 @@ def run(
         _write_output(out_path, doc)
         return 0
 
-    indicators, errors = _run_live(requested, gcp_api_key=gcp_api_key, session=session)
+    indicators, errors = _run_live(requested, session=session, gcp_session=gcp_session)
 
     errored_shards = {e["shard"] for e in errors}
     resolved = [s for s in requested if s in indicators]

--- a/pipeline/discover/gcp.py
+++ b/pipeline/discover/gcp.py
@@ -6,6 +6,9 @@ Cloud Billing Catalog API has no `services.get`, only `services.list` and
 publishes a new or changed SKU at the head of the page, triggering a
 rebuild. Weekly `--baseline-rebuild` covers any head-of-page
 reordering we miss.
+
+Auth: the caller's `session` must carry an `Authorization: Bearer <token>`
+header (see `ingest.gcp_common.build_authenticated_session`).
 """
 
 from __future__ import annotations
@@ -21,9 +24,7 @@ from ingest.gcp_common import _GCP_BILLING_BASE, _GCP_SERVICE_IDS
 _UA = "sku-pipeline/0.0 (+https://github.com/sofq/sku)"
 
 
-def discover(
-    shards: Iterable[str], *, api_key: str, session: requests.Session | None = None
-) -> dict[str, str]:
+def discover(shards: Iterable[str], *, session: requests.Session | None = None) -> dict[str, str]:
     """Return `{shard_id: indicator}` for the given GCP shard ids.
 
     Unknown shards raise KeyError. HTTP failures raise RuntimeError.
@@ -39,7 +40,7 @@ def discover(
             url = f"{_GCP_BILLING_BASE}/services/{service_id}/skus"
             resp = session.get(
                 url,
-                params={"key": api_key, "pageSize": "1"},
+                params={"pageSize": "1"},
                 headers={"User-Agent": _UA},
                 timeout=30,
             )

--- a/pipeline/ingest/gcp_common.py
+++ b/pipeline/ingest/gcp_common.py
@@ -23,6 +23,7 @@ __all__ = [
     "parse_unit_price",
     "parse_usage_unit",
     "fetch_skus",
+    "build_authenticated_session",
 ]
 
 _GCP_BILLING_BASE = "https://cloudbilling.googleapis.com/v1"
@@ -60,18 +61,41 @@ def parse_usage_unit(unit: str) -> tuple[float, str]:
         raise ValueError(f"unsupported usageUnit: {unit}") from exc
 
 
+def build_authenticated_session() -> requests.Session:
+    """Return a `requests.Session` pre-authenticated via Google ADC.
+
+    Uses `google.auth.default()` with the `cloud-billing.readonly` scope and
+    sets a static `Authorization: Bearer <token>` header. Under GitHub
+    Actions the token comes from Workload Identity Federation (see
+    `docs/ops/validation.md`); locally any ADC path works (user login,
+    service-account JSON, etc.).
+    """
+    import google.auth
+    import google.auth.transport.requests
+
+    creds, _ = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-billing.readonly"]
+    )
+    creds.refresh(google.auth.transport.requests.Request())
+    sess = requests.Session()
+    sess.headers["Authorization"] = f"Bearer {creds.token}"
+    return sess
+
+
 def fetch_skus(
     shard: str,
     target: Path,
     *,
-    api_key: str,
     session: requests.Session | None = None,
     retries: int = 3,
 ) -> str:
-    """Page through `/services/{service_id}/skus?pageSize=5000&key={api_key}` and
-    write `{"skus": [...]}` (sorted by skuId) to target. Returns SHA256 hex
-    digest over the sorted skus (same serialization used for the file body's
-    items).
+    """Page through `/services/{service_id}/skus?pageSize=5000` and write
+    `{"skus": [...]}` (sorted by skuId) to target. Returns SHA256 hex digest
+    over the sorted skus (same serialization used for the file body's items).
+
+    Auth: the caller-supplied `session` must carry an `Authorization: Bearer
+    <token>` header (see `build_authenticated_session`). Requests without
+    such a header will 401/403.
 
     Pagination via response `nextPageToken`; append `&pageToken=<token>` to
     each subsequent GET. Terminates when the response omits `nextPageToken`
@@ -102,7 +126,7 @@ def fetch_skus(
     page_token: str | None = None
 
     while True:
-        params: dict[str, str] = {"pageSize": "5000", "key": api_key}
+        params: dict[str, str] = {"pageSize": "5000"}
         if page_token:
             params["pageToken"] = page_token
 

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "duckdb>=0.10,<2",
   "numpy>=1.26",
   "ijson>=3.2",
+  "google-auth>=2.30",
 ]
 
 [project.optional-dependencies]

--- a/pipeline/tests/test_discover_driver.py
+++ b/pipeline/tests/test_discover_driver.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import pytest
+import requests
 import requests_mock
 
 from discover.driver import ALL_SHARDS, run
@@ -64,7 +65,7 @@ def test_first_live_run_all_shards_appear(tmp_path: Path) -> None:
             state_path=state,
             out_path=out,
             live=True,
-            gcp_api_key="test-key",
+            gcp_session=requests.Session(),
         )
     assert rc == 0
     doc = json.loads(out.read_text())
@@ -81,11 +82,11 @@ def test_second_live_run_unchanged_upstream_empty_shards(tmp_path: Path) -> None
     out = tmp_path / "changed.json"
     with requests_mock.Mocker() as m:
         _mock_all_providers(m)
-        run(state_path=state, out_path=out, live=True, gcp_api_key="k")
+        run(state_path=state, out_path=out, live=True, gcp_session=requests.Session())
     # Second run with identical upstream → no changes.
     with requests_mock.Mocker() as m:
         _mock_all_providers(m)
-        rc = run(state_path=state, out_path=out, live=True, gcp_api_key="k")
+        rc = run(state_path=state, out_path=out, live=True, gcp_session=requests.Session())
     assert rc == 0
     doc = json.loads(out.read_text())
     assert doc["baseline_rebuild"] is False
@@ -98,11 +99,11 @@ def test_one_shard_changed(tmp_path: Path) -> None:
     out = tmp_path / "changed.json"
     with requests_mock.Mocker() as m:
         _mock_all_providers(m, aws_pub="2026-04-18T00:00:00Z")
-        run(state_path=state, out_path=out, live=True, gcp_api_key="k")
+        run(state_path=state, out_path=out, live=True, gcp_session=requests.Session())
     # Second run: AWS publicationDate changes.
     with requests_mock.Mocker() as m:
         _mock_all_providers(m, aws_pub="2026-04-19T00:00:00Z")
-        rc = run(state_path=state, out_path=out, live=True, gcp_api_key="k")
+        rc = run(state_path=state, out_path=out, live=True, gcp_session=requests.Session())
     assert rc == 0
     doc = json.loads(out.read_text())
     aws_shards = [s for s in ALL_SHARDS if s.startswith("aws_")]
@@ -115,11 +116,17 @@ def test_baseline_rebuild_flag_forces_all(tmp_path: Path) -> None:
     # Seed a live state so the "!prev_map" branch wouldn't already force all shards.
     with requests_mock.Mocker() as m:
         _mock_all_providers(m)
-        run(state_path=state, out_path=out, live=True, gcp_api_key="k")
+        run(state_path=state, out_path=out, live=True, gcp_session=requests.Session())
     # Now rerun with --baseline-rebuild even though upstream is identical.
     with requests_mock.Mocker() as m:
         _mock_all_providers(m)
-        rc = run(state_path=state, out_path=out, live=True, baseline_rebuild=True, gcp_api_key="k")
+        rc = run(
+            state_path=state,
+            out_path=out,
+            live=True,
+            baseline_rebuild=True,
+            gcp_session=requests.Session(),
+        )
     assert rc == 0
     doc = json.loads(out.read_text())
     assert doc["baseline_rebuild"] is True
@@ -136,7 +143,7 @@ def test_shards_allowlist_restricts_and_validates(tmp_path: Path) -> None:
             out_path=out,
             live=True,
             shards=["aws_ec2", "aws_rds"],
-            gcp_api_key="k",
+            gcp_session=requests.Session(),
         )
     assert rc == 0
     doc = json.loads(out.read_text())
@@ -154,7 +161,7 @@ def test_dashed_shard_alias_accepted(tmp_path: Path) -> None:
             out_path=out,
             live=True,
             shards=["aws-ec2"],
-            gcp_api_key="k",
+            gcp_session=requests.Session(),
         )
     assert rc == 0
 
@@ -167,7 +174,7 @@ def test_unknown_shard_exits_4(tmp_path: Path) -> None:
         out_path=out,
         live=True,
         shards=["made_up_shard"],
-        gcp_api_key="k",
+        gcp_session=requests.Session(),
     )
     assert rc == 4
     doc = json.loads(out.read_text())
@@ -190,7 +197,7 @@ def test_one_shard_errors_others_still_succeed(tmp_path: Path) -> None:
             out_path=out,
             live=True,
             shards=["aws_ec2", "openrouter"],
-            gcp_api_key="k",
+            gcp_session=requests.Session(),
         )
     assert rc == 0
     doc = json.loads(out.read_text())
@@ -211,7 +218,7 @@ def test_all_shards_error_exits_2(tmp_path: Path) -> None:
             out_path=out,
             live=True,
             shards=["aws_ec2", "aws_rds"],
-            gcp_api_key="k",
+            gcp_session=requests.Session(),
         )
     assert rc == 2
     doc = json.loads(out.read_text())
@@ -251,22 +258,32 @@ def test_dry_run_output_is_indented_and_sorted(tmp_path: Path) -> None:
     assert list(doc.keys()) == sorted(doc.keys())
 
 
-def test_gcp_live_without_api_key_records_error(tmp_path: Path) -> None:
+def test_gcp_auth_failure_records_auth_error(tmp_path: Path, monkeypatch) -> None:
+    """If ADC can't build a session (no credentials), GCP shards record
+    `gcp_auth_error` instead of silently succeeding. Simulate by stubbing the
+    helper to raise."""
     state = tmp_path / "state.json"
     out = tmp_path / "changed.json"
+
+    import ingest.gcp_common as gcp_common
+
+    def _boom() -> requests.Session:  # noqa: ARG001
+        raise RuntimeError("ADC not available")
+
+    monkeypatch.setattr(gcp_common, "build_authenticated_session", _boom)
+
     with requests_mock.Mocker() as m:
         _mock_all_providers(m)
+        # No gcp_session passed → driver tries ADC path, which raises.
         rc = run(
             state_path=state,
             out_path=out,
             live=True,
             shards=["gcp_gce"],
-            gcp_api_key=None,
         )
-    # Single-shard all-errored → exit 2.
     assert rc == 2
     doc = json.loads(out.read_text())
-    assert any(e["reason"] == "gcp_missing_api_key" for e in doc["errors"])
+    assert any(e["reason"] == "gcp_auth_error" for e in doc["errors"])
 
 
 if __name__ == "__main__":

--- a/pipeline/tests/test_discover_providers.py
+++ b/pipeline/tests/test_discover_providers.py
@@ -128,7 +128,7 @@ def test_gcp_discover_hashes_first_sku():
             f"{_GCP_BILLING_BASE}/services/{service_id}/skus",
             json={"skus": [{"skuId": "one"}]},
         )
-        result = gcp_disc.discover(["gcp_gce"], api_key="k")
+        result = gcp_disc.discover(["gcp_gce"])
     assert result["gcp_gce"].startswith("sha256:")
     assert len(result["gcp_gce"]) == len("sha256:") + 64
 
@@ -140,8 +140,8 @@ def test_gcp_discover_hash_is_deterministic():
             f"{_GCP_BILLING_BASE}/services/{service_id}/skus",
             json={"skus": [{"skuId": "one"}]},
         )
-        first = gcp_disc.discover(["gcp_gce"], api_key="k")
-        second = gcp_disc.discover(["gcp_gce"], api_key="k")
+        first = gcp_disc.discover(["gcp_gce"])
+        second = gcp_disc.discover(["gcp_gce"])
     assert first == second
 
 
@@ -152,27 +152,28 @@ def test_gcp_discover_hash_changes_when_first_sku_changes():
             f"{_GCP_BILLING_BASE}/services/{service_id}/skus",
             json={"skus": [{"skuId": "one"}]},
         )
-        before = gcp_disc.discover(["gcp_gce"], api_key="k")
+        before = gcp_disc.discover(["gcp_gce"])
     with requests_mock.Mocker() as m:
         m.get(
             f"{_GCP_BILLING_BASE}/services/{service_id}/skus",
             json={"skus": [{"skuId": "two"}]},
         )
-        after = gcp_disc.discover(["gcp_gce"], api_key="k")
+        after = gcp_disc.discover(["gcp_gce"])
     assert before["gcp_gce"] != after["gcp_gce"]
 
 
-def test_gcp_discover_sends_api_key_and_pagesize():
+def test_gcp_discover_sends_pagesize_and_no_api_key():
+    """pageSize=1 stays; `key=` must be absent (auth is Bearer-header only)."""
     service_id = _GCP_SERVICE_IDS["gcp_gce"]
     with requests_mock.Mocker() as m:
         m.get(
             f"{_GCP_BILLING_BASE}/services/{service_id}/skus",
             json={"skus": []},
         )
-        gcp_disc.discover(["gcp_gce"], api_key="secret-key")
+        gcp_disc.discover(["gcp_gce"])
         qs = m.request_history[0].qs
-    assert qs.get("key") == ["secret-key"]
     assert qs.get("pagesize") == ["1"]
+    assert "key" not in qs
 
 
 def test_gcp_discover_http_failure_raises():
@@ -180,12 +181,12 @@ def test_gcp_discover_http_failure_raises():
     with requests_mock.Mocker() as m:
         m.get(f"{_GCP_BILLING_BASE}/services/{service_id}/skus", status_code=403)
         with pytest.raises(RuntimeError, match="gcp_discover_http_403"):
-            gcp_disc.discover(["gcp_gce"], api_key="k")
+            gcp_disc.discover(["gcp_gce"])
 
 
 def test_gcp_discover_unknown_shard_raises_keyerror():
     with pytest.raises(KeyError):
-        gcp_disc.discover(["gcp_nope"], api_key="k")
+        gcp_disc.discover(["gcp_nope"])
 
 
 # -----------------------------------------------------------------------------

--- a/pipeline/tests/test_gcp_fetch.py
+++ b/pipeline/tests/test_gcp_fetch.py
@@ -15,7 +15,6 @@ from ingest.gcp_common import fetch_skus
 
 _GCE_SERVICE_ID = "6F81-5844-456A"
 _GCE_BASE_URL = f"https://cloudbilling.googleapis.com/v1/services/{_GCE_SERVICE_ID}/skus"
-_API_KEY = "test-api-key-abc123"
 
 _SKU_A = {"skuId": "AAA-111", "description": "sku-a"}
 _SKU_B = {"skuId": "BBB-222", "description": "sku-b"}
@@ -42,7 +41,7 @@ def test_three_page_pagination(requests_mock, tmp_path):
         ],
     )
     target = tmp_path / "gcp_gce_raw.json"
-    fetch_skus("gcp_gce", target, api_key=_API_KEY)
+    fetch_skus("gcp_gce", target)
 
     assert target.exists()
     data = json.loads(target.read_text())
@@ -51,8 +50,8 @@ def test_three_page_pagination(requests_mock, tmp_path):
     assert requests_mock.call_count == 3
 
 
-def test_api_key_in_every_querystring(requests_mock, tmp_path):
-    """Every request (including paginated ones) carries key=<api_key>."""
+def test_no_api_key_in_querystring(requests_mock, tmp_path):
+    """fetch_skus must not send `?key=<...>` — auth goes via Bearer header."""
     requests_mock.get(
         _GCE_BASE_URL,
         [
@@ -61,20 +60,19 @@ def test_api_key_in_every_querystring(requests_mock, tmp_path):
         ],
     )
     target = tmp_path / "out.json"
-    fetch_skus("gcp_gce", target, api_key=_API_KEY)
+    fetch_skus("gcp_gce", target)
 
     assert requests_mock.call_count == 2
     for req in requests_mock.request_history:
         qs = parse_qs(urlparse(req.url).query)
-        assert "key" in qs, f"'key' missing from querystring: {req.url}"
-        assert qs["key"] == [_API_KEY], f"wrong api_key in {req.url}"
+        assert "key" not in qs, f"unexpected key= in querystring: {req.url}"
 
 
 def test_gcp_gce_service_id_in_url(requests_mock, tmp_path):
     """`fetch_skus('gcp_gce', ...)` hits a URL containing the correct service id."""
     requests_mock.get(_GCE_BASE_URL, json={"skus": [_SKU_A]})
     target = tmp_path / "out.json"
-    fetch_skus("gcp_gce", target, api_key=_API_KEY)
+    fetch_skus("gcp_gce", target)
 
     assert requests_mock.call_count == 1
     assert f"/services/{_GCE_SERVICE_ID}/skus" in requests_mock.request_history[0].url
@@ -86,7 +84,7 @@ def test_403_raises_gcp_forbidden_no_retry(requests_mock, tmp_path):
     target = tmp_path / "out.json"
 
     with pytest.raises(RuntimeError) as exc_info:
-        fetch_skus("gcp_gce", target, api_key=_API_KEY)
+        fetch_skus("gcp_gce", target)
 
     err_msg = str(exc_info.value)
     assert "gcp_forbidden" in err_msg
@@ -104,7 +102,7 @@ def test_500_then_200_succeeds_with_retry(requests_mock, tmp_path):
         ],
     )
     target = tmp_path / "out.json"
-    fetch_skus("gcp_gce", target, api_key=_API_KEY, retries=3)
+    fetch_skus("gcp_gce", target, retries=3)
 
     assert target.exists()
     data = json.loads(target.read_text())
@@ -119,8 +117,8 @@ def test_hash_stability(requests_mock, tmp_path):
     target1 = tmp_path / "out1.json"
     target2 = tmp_path / "out2.json"
 
-    digest1 = fetch_skus("gcp_gce", target1, api_key=_API_KEY)
-    digest2 = fetch_skus("gcp_gce", target2, api_key=_API_KEY)
+    digest1 = fetch_skus("gcp_gce", target1)
+    digest2 = fetch_skus("gcp_gce", target2)
 
     assert digest1 == digest2
     assert len(digest1) == 64  # SHA256 hex
@@ -130,7 +128,7 @@ def test_unknown_shard_raises_key_error(tmp_path):
     """Unknown shard propagates KeyError from the dict lookup (no request made)."""
     target = tmp_path / "out.json"
     with pytest.raises(KeyError):
-        fetch_skus("gcp_unknown", target, api_key=_API_KEY)
+        fetch_skus("gcp_unknown", target)
 
 
 def test_user_agent_on_every_request(requests_mock, tmp_path):
@@ -143,7 +141,7 @@ def test_user_agent_on_every_request(requests_mock, tmp_path):
         ],
     )
     target = tmp_path / "out.json"
-    fetch_skus("gcp_gce", target, api_key=_API_KEY)
+    fetch_skus("gcp_gce", target)
 
     assert requests_mock.call_count == 2
     for req in requests_mock.request_history:

--- a/scripts/ci/ingest_shard.sh
+++ b/scripts/ci/ingest_shard.sh
@@ -4,7 +4,10 @@
 # Inputs (env):
 #   SHARD              — underscored shard id (e.g. `aws_ec2`, `openrouter`)
 #   CATALOG_VERSION    — catalog tag for today's release (e.g. `2026.04.18`)
-#   GCP_BILLING_API_KEY — required for `gcp_*` shards
+#
+# GCP auth: `gcp_*` shards build an ADC-authenticated session at run time
+# (see `ingest.gcp_common.build_authenticated_session`). CI ADC is populated
+# by `google-github-actions/auth@v2`; no static API key required.
 #
 # Output: `dist/pipeline/<dashed-shard>.db` + `.rows.jsonl` (dashed names
 # match what the Go binary expects in SKU_DATA_DIR).
@@ -59,13 +62,12 @@ PYEOF
     ;;
 
   gcp_*)
-    : "${GCP_BILLING_API_KEY:?GCP_BILLING_API_KEY required for GCP shards}"
     skus="$RAW_DIR/${SHARD}-skus.json"
     python - <<PYEOF
-import os
 from pathlib import Path
-from ingest.gcp_common import fetch_skus
-fetch_skus("$SHARD", Path("$skus"), api_key=os.environ["GCP_BILLING_API_KEY"])
+from ingest.gcp_common import build_authenticated_session, fetch_skus
+with build_authenticated_session() as sess:
+    fetch_skus("$SHARD", Path("$skus"), session=sess)
 PYEOF
     python -m "ingest.${SHARD}" \
       --skus "$skus" \


### PR DESCRIPTION
## Summary

- Daily pipeline GCP auth moves from a long-lived `GCP_BILLING_API_KEY` secret to the same Workload Identity Federation path that `data-validate.yml` uses in PR #6. The spec has called this the target state since rev 4 (`docs/superpowers/specs/2026-04-18-sku-design.md:960`) — this is the code catching up.
- `fetch_skus` / `gcp_disc.discover` now accept only an authenticated `requests.Session`; auth belongs on the session's `Authorization: Bearer <token>` header, matching `pipeline/validate/gcp.py`.
- `data-daily.yml` gains `id-token: write` plus a `google-github-actions/auth@v2` step in `discover` and (conditionally) `ingest` — reuses the existing `vars.GCP_WIF_PROVIDER` and `vars.GCP_VALIDATE_SA` set during OIDC provisioning.

## What breaks if anything is misconfigured
- Missing `vars.GCP_WIF_PROVIDER` / `vars.GCP_VALIDATE_SA`: `auth@v2` fails at job start; shards for that job don't run.
- SA lacks `roles/billing.viewer` on the billing account or the WIF trust doesn't scope to `sofq/sku`: discover records each gcp shard with `reason=gcp_auth_error` (was `gcp_missing_api_key`); daily ingest fails with a clear HTTP 401/403 at fetch time. No release is published.

## Test plan
- [x] `make pipeline-test` — 224 passed locally
- [x] `make test` — all Go packages green
- [x] `ruff check` + `ruff format --check` on all edited files — clean
- [ ] After merge: dispatch `gh workflow run data-daily.yml -F dry_run=true -F force_baseline=true` and confirm GCP shards publish successfully
- [ ] After a green dry-run: delete the `GCP_BILLING_API_KEY` repo secret (`gh secret delete GCP_BILLING_API_KEY`)

## Notes for reviewer
- Does **not** depend on PR #6; both can merge in either order. If PR #6 lands first, `docs/ops/validation.md` will need a small follow-up to swap its "`data-daily.yml` uses API key" row for "shares the same path" — I'll handle that in the merge.
- `google-auth>=2.30` is promoted from a `validate` extra (PR #6) to a core dependency, since daily code now imports it unconditionally. If PR #6 merges first: drop the duplicate line from `[project.optional-dependencies].validate` on rebase.
- Token lifetime: `build_authenticated_session()` refreshes once at startup; tokens live ~1 hour. Validate path has the same pattern and hasn't hit expiry. If a long ingest ever exceeds an hour, switch to `google.auth.transport.requests.AuthorizedSession` (auto-refresh) — noted here as a followup, not fixed preemptively.