### PR TITLE
fix: live pipeline bug batch (B1-B3, B5-B11)

### DIFF
--- a/cmd/sku/aws_cloudfront.go
+++ b/cmd/sku/aws_cloudfront.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -108,9 +107,7 @@ func runAWSCloudFront(cmd *cobra.Command, f *cfFlags, requireRegion bool) error 
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("aws cloudfront %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "aws cloudfront %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("aws", "cloudfront",

--- a/cmd/sku/aws_dynamodb.go
+++ b/cmd/sku/aws_dynamodb.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -108,9 +107,7 @@ func runAWSDynamoDB(cmd *cobra.Command, f *ddbFlags, requireRegion bool) error {
 		Terms:      f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("aws dynamodb %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "aws dynamodb %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("aws", "dynamodb",

--- a/cmd/sku/aws_ebs.go
+++ b/cmd/sku/aws_ebs.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -108,9 +107,7 @@ func runAWSEBS(cmd *cobra.Command, f *ebsFlags, requireRegion bool) error {
 		Terms:      f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("aws ebs %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "aws ebs %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("aws", "ebs",

--- a/cmd/sku/aws_helpers.go
+++ b/cmd/sku/aws_helpers.go
@@ -67,9 +67,7 @@ func renderRows(cmd *cobra.Command, rows []catalog.Row, s config.Settings) error
 			continue
 		}
 		if err != nil {
-			wrapped := fmt.Errorf("render: %w", err)
-			skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-			return wrapped
+			return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "render: %w", err)
 		}
 		if _, wErr := w.Write(b); wErr != nil {
 			return wErr

--- a/cmd/sku/aws_lambda.go
+++ b/cmd/sku/aws_lambda.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -108,9 +107,7 @@ func runAWSLambda(cmd *cobra.Command, f *lambdaFlags, requireRegion bool) error 
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("aws lambda %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "aws lambda %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("aws", "lambda",

--- a/cmd/sku/aws_rds.go
+++ b/cmd/sku/aws_rds.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -116,9 +115,7 @@ func runAWSDB(cmd *cobra.Command, f *rdsFlags, requireRegion bool) error {
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("aws rds %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "aws rds %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("aws", "rds",

--- a/cmd/sku/aws_s3.go
+++ b/cmd/sku/aws_s3.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -111,9 +110,7 @@ func runAWSS3(cmd *cobra.Command, f *s3Flags, requireRegion bool) error {
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("aws s3 %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "aws s3 %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("aws", "s3",

--- a/cmd/sku/azure_blob.go
+++ b/cmd/sku/azure_blob.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -111,9 +110,7 @@ func runAzureBlob(cmd *cobra.Command, f *azureBlobFlags, requireRegion bool) err
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("azure blob %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "azure blob %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("azure", "blob",

--- a/cmd/sku/azure_disks.go
+++ b/cmd/sku/azure_disks.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -110,9 +109,7 @@ func runAzureDisks(cmd *cobra.Command, f *azureDisksFlags, requireRegion bool) e
 		Terms:      f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("azure disks %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "azure disks %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("azure", "disks",

--- a/cmd/sku/azure_functions.go
+++ b/cmd/sku/azure_functions.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -110,9 +109,7 @@ func runAzureFunctions(cmd *cobra.Command, f *azureFunctionsFlags, requireRegion
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("azure functions %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "azure functions %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("azure", "functions",

--- a/cmd/sku/azure_sql.go
+++ b/cmd/sku/azure_sql.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -116,9 +115,7 @@ func runAzureSQL(cmd *cobra.Command, f *azureSQLFlags, requireRegion bool) error
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("azure sql %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "azure sql %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("azure", "sql",

--- a/cmd/sku/azure_vm.go
+++ b/cmd/sku/azure_vm.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -114,9 +113,7 @@ func runAzureVM(cmd *cobra.Command, f *azureVMFlags, requireRegion bool) error {
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("azure vm %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "azure vm %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("azure", "vm",

--- a/cmd/sku/compare.go
+++ b/cmd/sku/compare.go
@@ -212,11 +212,18 @@ func compareLookup(ctx context.Context, f compareFlags, s *batch.Settings) ([]ca
 		return nil, fmt.Errorf("compare: %w", err)
 	}
 	if len(rows) == 0 {
-		return nil, skuerrors.NotFound("compare", f.kind,
-			map[string]any{
-				"vcpu": f.vcpu, "memory_gb": f.memoryGB, "gpu_count": f.gpuCount,
-				"regions": regionLiterals, "max_price": f.maxPrice,
-			},
+		applied := map[string]any{
+			"vcpu": f.vcpu, "memory_gb": f.memoryGB, "gpu_count": f.gpuCount,
+			"regions": regionLiterals,
+		}
+		// Only echo --max-price when the user actually set a ceiling; a
+		// zero value here means "unset", not "free only", so shipping
+		// `max_price: 0` in applied_filters would be a lie about what
+		// the comparator actually filtered on.
+		if f.maxPrice > 0 {
+			applied["max_price"] = f.maxPrice
+		}
+		return nil, skuerrors.NotFound("compare", f.kind, applied,
 			"Try relaxing --vcpu / --memory or widening --regions")
 	}
 	return rows, nil
@@ -286,11 +293,14 @@ func runCompare(cmd *cobra.Command, f *compareFlags) error {
 
 	if s.DryRun {
 		args := map[string]any{
-			"kind":      f.kind,
-			"regions":   regionLiterals,
-			"sort":      f.sort,
-			"limit":     f.limit,
-			"max_price": f.maxPrice,
+			"kind":    f.kind,
+			"regions": regionLiterals,
+			"sort":    f.sort,
+			"limit":   f.limit,
+		}
+		// Mirror the applied-filters echo: only include max_price when set.
+		if f.maxPrice > 0 {
+			args["max_price"] = f.maxPrice
 		}
 		switch f.kind {
 		case "compute.vm":

--- a/cmd/sku/compare_test.go
+++ b/cmd/sku/compare_test.go
@@ -115,6 +115,28 @@ func TestCompareCmd_dbRelationalNoRowsExitsNotFound(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	require.Contains(t, stderr.String(), `"not_found"`)
+	// B11: --max-price was not passed, so it must NOT be echoed back as
+	// an applied filter (shipping `max_price: 0` would claim the comparator
+	// filtered on "free only", which is a lie).
+	require.NotContains(t, stderr.String(), `"max_price":0`)
+	require.NotContains(t, stderr.String(), `"max_price": 0`)
+}
+
+func TestCompareCmd_maxPriceEchoedWhenSet(t *testing.T) {
+	dir := testutilSeededDBRelationalCatalog(t)
+	t.Setenv("SKU_DATA_DIR", dir)
+	var stdout, stderr bytes.Buffer
+	cmd := newRootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	// Passing --max-price 0.0001 with huge --vcpu forces NotFound; the
+	// applied-filters echo should then include max_price.
+	cmd.SetArgs([]string{"compare", "--kind", "db.relational",
+		"--vcpu", "128", "--max-price", "0.0001",
+		"--engine", "postgres", "--deployment-option", "single-az"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, stderr.String(), `"max_price":0.0001`)
 }
 
 func TestCompareCmd_dryRunDBRelational(t *testing.T) {

--- a/cmd/sku/estimate.go
+++ b/cmd/sku/estimate.go
@@ -123,9 +123,7 @@ func runEstimate(cmd *cobra.Command, f *estimateFlags) error {
 
 	res, rerr := estimate.Run(context.Background(), estimate.Config{Items: items})
 	if rerr != nil {
-		wrapped := fmt.Errorf("estimate: %w", rerr)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "estimate: %w", rerr)
 	}
 	return output.EmitEstimate(cmd.OutOrStdout(), res, output.Options{
 		Preset: output.Preset(s.Preset),

--- a/cmd/sku/gcp_cloud_sql.go
+++ b/cmd/sku/gcp_cloud_sql.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -123,9 +122,7 @@ func runGCPCloudSQL(cmd *cobra.Command, f *gcpCloudSQLFlags, requireRegion bool)
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("gcp cloud-sql %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "gcp cloud-sql %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("gcp", "cloud-sql",

--- a/cmd/sku/gcp_functions.go
+++ b/cmd/sku/gcp_functions.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -111,9 +110,7 @@ func runGCPFunctions(cmd *cobra.Command, f *gcpFunctionsFlags, requireRegion boo
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("gcp functions %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "gcp functions %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("gcp", "functions",

--- a/cmd/sku/gcp_gce.go
+++ b/cmd/sku/gcp_gce.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -116,9 +115,7 @@ func runGCPGCE(cmd *cobra.Command, f *gcpGCEFlags, requireRegion bool) error {
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("gcp gce %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "gcp gce %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("gcp", "gce",

--- a/cmd/sku/gcp_gcs.go
+++ b/cmd/sku/gcp_gcs.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -112,9 +111,7 @@ func runGCPGCS(cmd *cobra.Command, f *gcpGCSFlags, requireRegion bool) error {
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("gcp gcs %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "gcp gcs %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("gcp", "gcs",

--- a/cmd/sku/gcp_run.go
+++ b/cmd/sku/gcp_run.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -111,9 +110,7 @@ func runGCPRun(cmd *cobra.Command, f *gcpRunFlags, requireRegion bool) error {
 		Terms:        f.terms(),
 	})
 	if err != nil {
-		wrapped := fmt.Errorf("gcp run %s: %w", cmd.Use, err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "gcp run %s: %w", cmd.Use, err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound("gcp", "run",

--- a/cmd/sku/globals.go
+++ b/cmd/sku/globals.go
@@ -6,7 +6,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/sofq/sku/internal/config"
+	skuerrors "github.com/sofq/sku/internal/errors"
 )
+
+// validPresets enumerates the accepted --preset values (spec §3). Kept in
+// sync with the pf.String help text on root.
+var validPresets = map[string]struct{}{
+	"agent":   {},
+	"full":    {},
+	"price":   {},
+	"compare": {},
+}
 
 type settingsKeyT struct{}
 
@@ -53,7 +63,23 @@ func resolveSettings(cmd *cobra.Command) (config.Settings, error) {
 	if err != nil {
 		return config.Settings{}, err
 	}
-	return config.Resolve(fb, file, envMap())
+	s, err := config.Resolve(fb, file, envMap())
+	if err != nil {
+		return s, err
+	}
+	if _, ok := validPresets[s.Preset]; !ok {
+		return s, &skuerrors.E{
+			Code:       skuerrors.CodeValidation,
+			Message:    "invalid --preset: " + s.Preset,
+			Suggestion: "use one of: agent, full, price, compare",
+			Details: map[string]any{
+				"reason": "bad_preset",
+				"flag":   "preset",
+				"value":  s.Preset,
+			},
+		}
+	}
+	return s, nil
 }
 
 func readFlagBag(cmd *cobra.Command) config.FlagBag {

--- a/cmd/sku/globals_test.go
+++ b/cmd/sku/globals_test.go
@@ -2,9 +2,12 @@ package sku
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	skuerrors "github.com/sofq/sku/internal/errors"
 )
 
 func TestRoot_GlobalFlagsRegistered(t *testing.T) {
@@ -26,4 +29,35 @@ func TestRoot_PresetEnvPropagates(t *testing.T) {
 	root.SetOut(&out)
 	require.NoError(t, root.Execute())
 	// version command doesn't use preset, but Settings must resolve without error.
+}
+
+func TestRoot_InvalidPresetRejected(t *testing.T) {
+	root := newRootCmd()
+	root.SetArgs([]string{"--preset", "bogus", "version"})
+	var out, errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	err := root.Execute()
+	require.Error(t, err)
+
+	var e *skuerrors.E
+	require.True(t, errors.As(err, &e), "expected *skuerrors.E, got %T: %v", err, err)
+	require.Equal(t, skuerrors.CodeValidation, e.Code)
+	require.Equal(t, 4, e.Code.ExitCode())
+	require.Equal(t, "bogus", e.Details["value"])
+}
+
+func TestRoot_InvalidPresetFromEnvRejected(t *testing.T) {
+	t.Setenv("SKU_PRESET", "nope")
+	root := newRootCmd()
+	root.SetArgs([]string{"version"})
+	var out, errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	err := root.Execute()
+	require.Error(t, err)
+
+	var e *skuerrors.E
+	require.True(t, errors.As(err, &e))
+	require.Equal(t, skuerrors.CodeValidation, e.Code)
 }

--- a/cmd/sku/llm_price.go
+++ b/cmd/sku/llm_price.go
@@ -162,9 +162,7 @@ func newLLMPriceCmd() *cobra.Command {
 					continue
 				}
 				if err != nil {
-					wrapped := fmt.Errorf("render: %w", err)
-					skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-					return wrapped
+					return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "render: %w", err)
 				}
 				if _, wErr := w.Write(b); wErr != nil {
 					return wErr

--- a/cmd/sku/search.go
+++ b/cmd/sku/search.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 
@@ -145,9 +144,7 @@ func runSearch(cmd *cobra.Command, f *searchFlags) error {
 			skuerrors.Write(cmd.ErrOrStderr(), e)
 			return e
 		}
-		wrapped := fmt.Errorf("search: %w", err)
-		skuerrors.Write(cmd.ErrOrStderr(), wrapped)
-		return wrapped
+		return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "search: %w", err)
 	}
 	if len(rows) == 0 {
 		e := skuerrors.NotFound(f.provider, f.service,

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -8,6 +8,7 @@ package errors
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 )
 
@@ -59,6 +60,12 @@ type E struct {
 	Message    string         `json:"message"`
 	Suggestion string         `json:"suggestion,omitempty"`
 	Details    map[string]any `json:"details,omitempty"`
+
+	// written tracks whether this *E has already been rendered to stderr
+	// by Write. Commands typically call Write inside RunE and then return
+	// the error; the top-level Execute wrapper also calls Write. The flag
+	// makes the second call a no-op so the envelope isn't printed twice.
+	written bool
 }
 
 // Error implements error.
@@ -72,6 +79,12 @@ type envelope struct {
 // Write marshals err to the §4 JSON envelope on w and returns the exit code
 // the process should use. A nil err writes nothing and returns 0. Any non-*E
 // error is boxed as CodeGeneric.
+//
+// Write is idempotent per *E instance: when called a second time on an *E it
+// has already rendered, it returns the exit code without writing again. This
+// lets a command's RunE call Write and then return the same *E while the
+// top-level Execute wrapper safely calls Write again on the propagated err
+// without producing a duplicate envelope on stderr.
 func Write(w io.Writer, err error) int {
 	if err == nil {
 		return 0
@@ -81,6 +94,10 @@ func Write(w io.Writer, err error) int {
 	if !errors.As(err, &e) {
 		e = &E{Code: CodeGeneric, Message: err.Error()}
 	}
+	if e.written {
+		return e.Code.ExitCode()
+	}
+	e.written = true
 	enc := json.NewEncoder(w)
 	// json.Encoder writes compact JSON + trailing \n, matching §4 stderr shape.
 	if marshalErr := enc.Encode(envelope{Error: e}); marshalErr != nil {
@@ -91,6 +108,18 @@ func Write(w io.Writer, err error) int {
 		)
 	}
 	return e.Code.ExitCode()
+}
+
+// WriteWrap builds an *E with the given code and a formatted message
+// (supports fmt.Errorf's %w verb), writes the §4 envelope to w, and returns
+// the *E so the caller can `return skuerrors.WriteWrap(...)`. The returned
+// *E is marked as already-written, so a subsequent Write at the top-level
+// Execute wrapper is a no-op — avoiding the double-print.
+func WriteWrap(w io.Writer, code Code, format string, args ...any) *E {
+	// fmt.Errorf handles %w properly; .Error() flattens the chain to text.
+	e := &E{Code: code, Message: fmt.Errorf(format, args...).Error()}
+	Write(w, e)
+	return e
 }
 
 // NotFound builds an E with CodeNotFound and the common details shape (§4).

--- a/internal/output/estimate.go
+++ b/internal/output/estimate.go
@@ -3,9 +3,24 @@ package output
 import (
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/sofq/sku/internal/estimate"
 )
+
+// roundSig rounds x to `digits` significant figures. Used to tame spurious
+// trailing precision in `sku estimate` dollar amounts — raw arithmetic on
+// per-token / per-gb-second rates produces long decimals that look like
+// fake precision and break golden-file diffs across architectures.
+// Mirrors Python's Decimal(..).quantize style without the import cost.
+func roundSig(x float64, digits int) float64 {
+	if x == 0 || math.IsNaN(x) || math.IsInf(x, 0) {
+		return x
+	}
+	mag := math.Floor(math.Log10(math.Abs(x)))
+	factor := math.Pow(10, float64(digits-1)-mag)
+	return math.Round(x*factor) / factor
+}
 
 // EstimateMonthlyTotal is the monthly-total block carried in the envelope.
 type EstimateMonthlyTotal struct {
@@ -40,15 +55,15 @@ type EstimateItem struct {
 func EmitEstimate(w io.Writer, r estimate.Result, opts Options) error {
 	opts = opts.WithDefaults()
 	env := EstimateEnvelope{Items: make([]EstimateItem, 0, len(r.Items))}
-	env.MonthlyTotal.Amount = r.MonthlyTotalUSD
+	env.MonthlyTotal.Amount = roundSig(r.MonthlyTotalUSD, 6)
 	env.MonthlyTotal.Currency = r.Currency
 	for _, li := range r.Items {
 		env.Items = append(env.Items, EstimateItem{
 			Item: li.Item.Raw, Kind: li.Kind, SKUID: li.SKUID,
 			Provider: li.Provider, Service: li.Service, Resource: li.Resource,
-			Region: li.Region, HourlyUSD: li.HourlyUSD,
+			Region: li.Region, HourlyUSD: roundSig(li.HourlyUSD, 6),
 			Quantity: li.Quantity, QuantityUnit: li.QuantityUnit,
-			MonthlyUSD: li.MonthlyUSD,
+			MonthlyUSD: roundSig(li.MonthlyUSD, 6),
 		})
 	}
 

--- a/internal/output/estimate_test.go
+++ b/internal/output/estimate_test.go
@@ -39,3 +39,62 @@ func TestEmitEstimate_agentPreset(t *testing.T) {
 		t.Fatalf("bad currency: %v", tot["currency"])
 	}
 }
+
+func TestRoundSig_sixSignificantFigures(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want float64
+	}{
+		// Integer-magnitude amounts keep all six figs.
+		{70.08, 70.08},
+		{1234567.89, 1234570},
+		// Sub-dollar amounts round to 6 sig figs (not 6 decimal places).
+		{0.0000123456789, 0.0000123457},
+		{0.000987654321, 0.000987654},
+		// Edges.
+		{0, 0},
+		{-42.123456789, -42.1235},
+	}
+	for _, tc := range cases {
+		got := roundSig(tc.in, 6)
+		if got != tc.want {
+			t.Errorf("roundSig(%g, 6) = %g, want %g", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestEmitEstimate_RoundsFloatAmounts(t *testing.T) {
+	// Hourly rate × hours = an ugly float; make sure the envelope emits
+	// the rounded value rather than the raw IEEE-754 drift.
+	res := estimate.Result{
+		Currency:        "USD",
+		MonthlyTotalUSD: 0.09600000000000001 * 730, // 70.08000000000001
+		Items: []estimate.LineItem{{
+			Item:      estimate.Item{Raw: "aws/ec2:m5.large:region=us-east-1"},
+			Kind:      "compute.vm",
+			Provider:  "aws", Service: "ec2", Resource: "m5.large", Region: "us-east-1",
+			HourlyUSD:  0.09600000000000001,
+			MonthlyUSD: 0.09600000000000001 * 730,
+		}},
+	}
+	var buf bytes.Buffer
+	if err := EmitEstimate(&buf, res, Options{Preset: PresetAgent, Format: "json"}); err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &obj); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	tot := obj["monthly_total"].(map[string]any)
+	if tot["amount"].(float64) != 70.08 {
+		t.Fatalf("monthly total should round to 70.08, got %v", tot["amount"])
+	}
+	items := obj["items"].([]any)
+	it0 := items[0].(map[string]any)
+	if it0["hourly_usd"].(float64) != 0.096 {
+		t.Fatalf("hourly should round to 0.096, got %v", it0["hourly_usd"])
+	}
+	if it0["monthly_usd"].(float64) != 70.08 {
+		t.Fatalf("monthly should round to 70.08, got %v", it0["monthly_usd"])
+	}
+}

--- a/internal/output/estimate_test.go
+++ b/internal/output/estimate_test.go
@@ -70,9 +70,9 @@ func TestEmitEstimate_RoundsFloatAmounts(t *testing.T) {
 		Currency:        "USD",
 		MonthlyTotalUSD: 0.09600000000000001 * 730, // 70.08000000000001
 		Items: []estimate.LineItem{{
-			Item:      estimate.Item{Raw: "aws/ec2:m5.large:region=us-east-1"},
-			Kind:      "compute.vm",
-			Provider:  "aws", Service: "ec2", Resource: "m5.large", Region: "us-east-1",
+			Item:     estimate.Item{Raw: "aws/ec2:m5.large:region=us-east-1"},
+			Kind:     "compute.vm",
+			Provider: "aws", Service: "ec2", Resource: "m5.large", Region: "us-east-1",
 			HourlyUSD:  0.09600000000000001,
 			MonthlyUSD: 0.09600000000000001 * 730,
 		}},

--- a/internal/updater/chain.go
+++ b/internal/updater/chain.go
@@ -121,9 +121,13 @@ func (a *Applier) Apply(ctx context.Context, from, to string, chain []Delta) err
 		}
 	}
 
-	// Update metadata to reflect the applied head version.
+	// Reassert metadata head version. Delta bodies already replay the
+	// metadata table in full (pipeline build_delta.py), but we still
+	// pin catalog_version/generated_at here so the applied state is
+	// correct even if a delta body is ever produced without a metadata
+	// replay. Schema is key/value, matching pipeline/package/schema.sql.
 	_, err = conn.ExecContext(ctx,
-		"UPDATE metadata SET catalog_version=?, generated_at=datetime('now')",
+		"INSERT OR REPLACE INTO metadata(key, value) VALUES ('catalog_version', ?), ('generated_at', datetime('now'))",
 		to,
 	)
 	if err != nil {

--- a/internal/updater/chain_test.go
+++ b/internal/updater/chain_test.go
@@ -36,10 +36,11 @@ func buildChainDB(t *testing.T, dir, version string, n int) string {
 	ctx := context.Background()
 	_, err = db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS metadata (
-			catalog_version TEXT NOT NULL,
-			generated_at    TEXT NOT NULL
+			key   TEXT PRIMARY KEY,
+			value TEXT
 		);
-		INSERT INTO metadata VALUES (?, ?);
+		INSERT INTO metadata(key, value) VALUES ('catalog_version', ?);
+		INSERT INTO metadata(key, value) VALUES ('generated_at',    ?);
 		CREATE TABLE IF NOT EXISTS rows (id INTEGER PRIMARY KEY, val TEXT);
 	`, version, "2026-04-18T00:00:00Z")
 	if err != nil {
@@ -103,7 +104,7 @@ func getVersion(t *testing.T, dbPath string) string {
 	}
 	defer func() { _ = db.Close() }()
 	var v string
-	if err := db.QueryRowContext(context.Background(), "SELECT catalog_version FROM metadata LIMIT 1").Scan(&v); err != nil {
+	if err := db.QueryRowContext(context.Background(), "SELECT value FROM metadata WHERE key = 'catalog_version' LIMIT 1").Scan(&v); err != nil {
 		t.Fatal(err)
 	}
 	return v

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -338,7 +338,7 @@ func readLocalVersion(dbPath string) (string, error) {
 
 	var v string
 	err = db.QueryRowContext(context.Background(),
-		"SELECT catalog_version FROM metadata LIMIT 1").Scan(&v)
+		"SELECT value FROM metadata WHERE key = 'catalog_version' LIMIT 1").Scan(&v)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", nil

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -191,8 +191,9 @@ func seedShardDB(t *testing.T, path, version string) {
 	}
 	defer func() { _ = db.Close() }()
 	_, err = db.ExecContext(context.Background(), `
-		CREATE TABLE metadata (catalog_version TEXT NOT NULL, generated_at TEXT NOT NULL);
-		INSERT INTO metadata VALUES (?, ?);
+		CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT);
+		INSERT INTO metadata(key, value) VALUES ('catalog_version', ?);
+		INSERT INTO metadata(key, value) VALUES ('generated_at',    ?);
 		CREATE TABLE rows (id INTEGER PRIMARY KEY, val TEXT);
 	`, version, "2026-04-18T00:00:00Z")
 	if err != nil {

--- a/pipeline/ingest/aws_common.py
+++ b/pipeline/ingest/aws_common.py
@@ -64,6 +64,27 @@ _AWS_SERVICE_CODES: dict[str, str] = {
     "aws_cloudfront": "AmazonCloudFront",
 }
 
+# Multiple shards share an upstream offer — aws_ec2 + aws_ebs both consume
+# AmazonEC2. The stripped offer (filtered to Compute Instance + Storage
+# families via _EC2_PRODUCT_FAMILIES) is identical for both shards, so we
+# key the on-disk filename on this shared basename instead of the shard
+# name. That way a `--offer-dir` reused across `ingest.aws_ec2` and
+# `ingest.aws_ebs` reads the same `aws_ec2-<region>.json` file once
+# rather than downloading + stripping the 400 MB per-region offer twice.
+_OFFER_BASENAME: dict[str, str] = {
+    "aws_ec2": "aws_ec2",
+    "aws_ebs": "aws_ec2",
+}
+
+
+def shared_offer_basename(shard: str) -> str:
+    """Return the filename prefix used for a shard's stripped per-region offer
+    files. Shards that consume the same upstream offer (aws_ec2, aws_ebs both
+    read AmazonEC2) share a basename so only one stripped copy sits on disk.
+    Falls back to the shard name for shards with no overlap.
+    """
+    return _OFFER_BASENAME.get(shard, shard)
+
 _RETRY_STATUSES = {500, 502, 503, 504}
 
 
@@ -197,8 +218,22 @@ def fetch_offer_regions_stripped(
         session = requests.Session()
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    basename = shared_offer_basename(shard)
+
+    # Pre-emptively collect any stripped files already present (e.g. a sibling
+    # shard — aws_ebs when aws_ec2 ran first — produced them). We still fetch
+    # the region_index to discover which regions upstream actually has, but
+    # we skip redownload + restrip for regions already on disk.
+    existing: dict[str, Path] = {}
+    for p in out_dir.glob(f"{basename}-*.json"):
+        # Strip the basename prefix and .json suffix to recover the region.
+        name = p.name
+        region = name[len(basename) + 1 : -len(".json")]
+        if region and region != "region_index":
+            existing[region] = p
+
     region_index_url = f"{_AWS_OFFER_BASE}/{service_code}/current/region_index.json"
-    raw_index = out_dir / f"{shard}-region_index.json"
+    raw_index = out_dir / f"{basename}-region_index.json"
     _stream_download(region_index_url, raw_index, session=session, retries=retries)
     index_doc = json.loads(raw_index.read_text())
     raw_index.unlink(missing_ok=True)
@@ -213,11 +248,14 @@ def fetch_offer_regions_stripped(
         rel_url = upstream_regions.get(region)
         if rel_url is None:
             continue
+        stripped_path = out_dir / f"{basename}-{region}.json"
+        if region in existing and stripped_path.exists():
+            produced.append(stripped_path)
+            continue
         region_url = f"https://pricing.us-east-1.amazonaws.com{rel_url}"
-        raw_path = out_dir / f"{shard}-{region}.raw.json"
+        raw_path = out_dir / f"{basename}-{region}.raw.json"
         try:
             _stream_download(region_url, raw_path, session=session, retries=retries)
-            stripped_path = out_dir / f"{shard}-{region}.json"
             _strip_ec2_offer(raw_path, stripped_path)
             produced.append(stripped_path)
         finally:

--- a/pipeline/ingest/aws_ebs.py
+++ b/pipeline/ingest/aws_ebs.py
@@ -19,7 +19,12 @@ from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
 
 from ._duckdb import dumps
-from .aws_common import aws_regions_from_yaml, fetch_offer_regions_stripped, load_region_normalizer
+from .aws_common import (
+    aws_regions_from_yaml,
+    fetch_offer_regions_stripped,
+    load_region_normalizer,
+    shared_offer_basename,
+)
 from .aws_ec2 import _iter_product_prices
 
 _PROVIDER = "aws"
@@ -84,7 +89,12 @@ def ingest(*, offer_paths: Iterable[Path]) -> Iterable[dict[str, Any]]:
 
 def _resolve_paths(args: argparse.Namespace) -> list[Path]:
     if args.offer_dir:
-        return sorted(p for p in args.offer_dir.glob("aws_ebs-*.json") if p.is_file())
+        base = shared_offer_basename("aws_ebs")
+        return sorted(
+            p
+            for p in args.offer_dir.glob(f"{base}-*.json")
+            if p.is_file() and not p.name.endswith("-region_index.json")
+        )
     if args.fixture:
         p = args.fixture
         return [p / "offer.json"] if p.is_dir() else [p]
@@ -106,11 +116,17 @@ def main() -> int:
     ap.add_argument("--catalog-version", default=None)
     args = ap.parse_args()
 
-    if args.offer_dir is not None and not any(args.offer_dir.glob("aws_ebs-*.json")):
-        args.offer_dir.mkdir(parents=True, exist_ok=True)
-        fetch_offer_regions_stripped(
-            "aws_ebs", args.offer_dir, regions=aws_regions_from_yaml()
+    if args.offer_dir is not None:
+        base = shared_offer_basename("aws_ebs")
+        have = any(
+            p.is_file() and not p.name.endswith("-region_index.json")
+            for p in args.offer_dir.glob(f"{base}-*.json")
         )
+        if not have:
+            args.offer_dir.mkdir(parents=True, exist_ok=True)
+            fetch_offer_regions_stripped(
+                "aws_ebs", args.offer_dir, regions=aws_regions_from_yaml()
+            )
 
     paths = _resolve_paths(args)
     if not paths:

--- a/pipeline/ingest/aws_ec2.py
+++ b/pipeline/ingest/aws_ec2.py
@@ -20,7 +20,12 @@ from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
 
 from ._duckdb import dumps
-from .aws_common import aws_regions_from_yaml, fetch_offer_regions_stripped, load_region_normalizer
+from .aws_common import (
+    aws_regions_from_yaml,
+    fetch_offer_regions_stripped,
+    load_region_normalizer,
+    shared_offer_basename,
+)
 
 _PROVIDER = "aws"
 _SERVICE = "ec2"
@@ -121,7 +126,12 @@ def ingest(*, offer_paths: Iterable[Path]) -> Iterable[dict[str, Any]]:
 def _resolve_paths(args: argparse.Namespace) -> list[Path]:
     """Resolve CLI args → a list of stripped offer-JSON paths ready to feed ingest."""
     if args.offer_dir:
-        return sorted(p for p in args.offer_dir.glob("aws_ec2-*.json") if p.is_file())
+        base = shared_offer_basename("aws_ec2")
+        return sorted(
+            p
+            for p in args.offer_dir.glob(f"{base}-*.json")
+            if p.is_file() and not p.name.endswith("-region_index.json")
+        )
     if args.fixture:
         p = args.fixture
         return [p / "offer.json"] if p.is_dir() else [p]
@@ -144,12 +154,21 @@ def main() -> int:
     ap.add_argument("--catalog-version", default=None)
     args = ap.parse_args()
 
-    # If offer-dir is given but empty, drive the fetch ourselves.
-    if args.offer_dir is not None and not any(args.offer_dir.glob("aws_ec2-*.json")):
-        args.offer_dir.mkdir(parents=True, exist_ok=True)
-        fetch_offer_regions_stripped(
-            "aws_ec2", args.offer_dir, regions=aws_regions_from_yaml()
+    # If offer-dir is given but empty of shared-basename stripped files,
+    # drive the fetch ourselves. fetch_offer_regions_stripped short-circuits
+    # per-region on an already-stripped file so a sibling `aws_ebs` run can
+    # skip the download+strip entirely.
+    if args.offer_dir is not None:
+        base = shared_offer_basename("aws_ec2")
+        have = any(
+            p.is_file() and not p.name.endswith("-region_index.json")
+            for p in args.offer_dir.glob(f"{base}-*.json")
         )
+        if not have:
+            args.offer_dir.mkdir(parents=True, exist_ok=True)
+            fetch_offer_regions_stripped(
+                "aws_ec2", args.offer_dir, regions=aws_regions_from_yaml()
+            )
 
     paths = _resolve_paths(args)
     if not paths:

--- a/pipeline/ingest/aws_s3.py
+++ b/pipeline/ingest/aws_s3.py
@@ -18,15 +18,16 @@ both shapes are handled by checking volumeType first, falling back to group.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any
 
 from normalize.enums import apply_kind_defaults
 from normalize.terms import terms_hash
 
-from ._duckdb import dumps, open_conn
+from ._duckdb import dumps
 from .aws_common import load_region_normalizer
 
 _PROVIDER = "aws"
@@ -82,56 +83,79 @@ _REQUEST_GROUP_DIM: dict[str, str] = {
     "S3-API-Tier2": "requests-get",
 }
 
-# Pulls every SKU's attributes + its single on-demand priceDimension. S3's
-# on-demand term has one non-tiered priceDimension per SKU for the m3a.2
-# scope (first tier only for storage); we take the first pd_key.
-_SQL = """
-WITH products_flat AS (
-  SELECT
-    p.key AS sku_id,
-    json_extract_string(p.value, '$.productFamily') AS family,
-    json_extract_string(p.value, '$.attributes.regionCode') AS region,
-    json_extract_string(p.value, '$.attributes.volumeType') AS volume_type,
-    json_extract_string(p.value, '$.attributes.group') AS group_raw
-  FROM offer, json_each(offer.products) AS p(key, value)
-  WHERE json_extract_string(p.value, '$.productFamily') IN ('Storage', 'API Request')
-),
-terms_flat AS (
-  SELECT
-    t.key AS sku_id,
-    (json_keys(t.value))[1] AS term_key,
-    t.value AS term_obj
-  FROM offer, json_each(json_extract(offer.terms, '$.OnDemand')) AS t(key, value)
-),
-pd_keys AS (
-  SELECT tf.sku_id, tf.term_key, tf.term_obj,
-    (json_keys(json_extract(tf.term_obj, '$."' || tf.term_key || '".priceDimensions')))[1] AS pd_key
-  FROM terms_flat tf
-)
-SELECT pf.sku_id, pf.family, pf.region, pf.volume_type, pf.group_raw,
-  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".unit') AS unit,
-  CAST(json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".pricePerUnit.USD') AS DOUBLE) AS usd,
-  json_extract_string(pk.term_obj, '$."' || pk.term_key || '".priceDimensions."' || pk.pd_key || '".beginRange') AS begin_range
-FROM products_flat pf
-JOIN pd_keys pk ON pf.sku_id = pk.sku_id
-"""
+# Iterate the offer in Python rather than DuckDB. The AmazonS3 offer
+# is ~12 MB and fits comfortably in memory; expanding it through
+# `json_each` + `json_extract` in DuckDB once the WHERE clause admits
+# more than ~1 200 products fans-out the terms CTE hard enough to
+# blow the 8 GiB cap set in `_duckdb.py`. Python's dict lookup path
+# is O(n) over products and stays well under 100 MB resident.
+
+
+def _rows_from_offer(offer: dict[str, Any]) -> Iterator[
+    tuple[str, str | None, str | None, str | None, str | None, str | None, float | None, str | None]
+]:
+    """Yield one tuple per (product, first on-demand priceDimension) pair.
+
+    Tuple shape mirrors the previous DuckDB result set:
+        (sku_id, family, region, volume_type, group_raw, unit, usd, begin_range).
+
+    `family` may be None — the caller treats a product with a missing
+    productFamily whose group starts with 'S3-API-' as API Request.
+    Products with no matching OnDemand term are skipped silently; those
+    without a pricePerUnit.USD are yielded with usd=None and dropped at
+    the dim-completeness check.
+    """
+    products = offer.get("products") or {}
+    on_demand = ((offer.get("terms") or {}).get("OnDemand") or {})
+    for sku_id, prod in products.items():
+        family = prod.get("productFamily")
+        attrs = prod.get("attributes") or {}
+        group_raw = attrs.get("group")
+        if family not in ("Storage", "API Request"):
+            # Backfill for the live-offer shape where productFamily is
+            # missing on API Request SKUs (~78 % of products as of
+            # 2026-04); unambiguous when the group prefix matches.
+            if family is None and group_raw and group_raw.startswith("S3-API-"):
+                family = "API Request"
+            else:
+                continue
+        region = attrs.get("regionCode")
+        volume_type = attrs.get("volumeType")
+
+        term_bucket = on_demand.get(sku_id) or {}
+        if not term_bucket:
+            continue
+        # Stable first key — the S3 offer's on-demand terms have one
+        # termKey per SKU in practice, so ordering doesn't matter.
+        term_key = next(iter(term_bucket))
+        term_obj = term_bucket[term_key] or {}
+        price_dims = term_obj.get("priceDimensions") or {}
+        if not price_dims:
+            continue
+        pd_key = next(iter(price_dims))
+        pd = price_dims[pd_key] or {}
+        unit = pd.get("unit")
+        price_per_unit = pd.get("pricePerUnit") or {}
+        usd_raw = price_per_unit.get("USD")
+        try:
+            usd = float(usd_raw) if usd_raw is not None else None
+        except (TypeError, ValueError):
+            usd = None
+        begin_range = pd.get("beginRange")
+        yield sku_id, family, region, volume_type, group_raw, unit, usd, begin_range
 
 
 def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
     normalizer = load_region_normalizer()
-    con = open_conn()
-    path_literal = str(offer_path).replace("'", "''")
-    con.execute(
-        f"CREATE VIEW offer AS SELECT * FROM read_json('{path_literal}', "
-        "columns={products: 'JSON', terms: 'JSON'}, maximum_object_size=134217728)"
-    )
+    with offer_path.open() as f:
+        offer = json.load(f)
 
     # Collect: (storage_class, region) -> {"storage": {sku,usd,unit,volume_type}, ...}
     grouped: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}
 
-    for sku_id, family, region, volume_type, group_raw, unit, usd, begin_range in (
-        con.execute(_SQL).fetchall()
-    ):
+    for sku_id, family, region, volume_type, group_raw, unit, usd, begin_range in _rows_from_offer(offer):
+        if region is None or usd is None:
+            continue
         if normalizer.try_normalize(_PROVIDER, region) is None:
             continue  # skip regions outside our coverage map
 

--- a/pipeline/ingest/azure_vm.py
+++ b/pipeline/ingest/azure_vm.py
@@ -65,6 +65,12 @@ def ingest(*, prices_path: Path) -> Iterable[dict[str, Any]]:
             continue
         if any(hint in product for hint in _SPOT_HINTS):
             continue
+        # Azure occasionally publishes $0.00 preview SKUs (e.g. "… Preview"
+        # productName with retailPrice == 0.0). These aren't real on-demand
+        # prices — they mislead `sku azure vm price` and should never win
+        # a `sku compare` cost sort.
+        if not price or float(price) <= 0.0:
+            continue
         if sku_id in seen:
             continue
         seen.add(sku_id)

--- a/pipeline/ingest/gcp_functions.py
+++ b/pipeline/ingest/gcp_functions.py
@@ -102,6 +102,11 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         except ValueError:
             continue
         amount = parse_unit_price(units=price_units, nanos=int(price_nanos or 0)) / divisor
+        # Zero-priced requests dimension has no information (it's a free-tier
+        # Invocations SKU). Keeping a {"amount": 0.0} entry misleads
+        # `sku gcp functions price` and `sku estimate`.
+        if dim == "requests" and amount == 0.0:
+            continue
         price_entry = {"dimension": dim, "tier": "", "amount": amount, "unit": unit}
 
         region = service_regions[0]
@@ -123,10 +128,11 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         bucket["prices"][dim] = price_entry
 
     for region, bucket in grouped.items():
-        # Fan out the global Invocations price into every region bucket.
+        # Fan out the global Invocations price into every region bucket —
+        # only if it's non-zero (zero was already filtered above).
         if global_requests is not None and "requests" not in bucket["prices"]:
             bucket["prices"]["requests"] = global_requests
-        if set(bucket["prices"].keys()) != {"cpu-second", "memory-gb-second", "requests"}:
+        if not {"cpu-second", "memory-gb-second"} <= bucket["prices"].keys():
             continue
         if "sku_id" not in bucket:
             continue
@@ -138,6 +144,12 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
             "upfront": "",
             "payment_option": "",
         })
+        prices_out = [
+            bucket["prices"]["cpu-second"],
+            bucket["prices"]["memory-gb-second"],
+        ]
+        if "requests" in bucket["prices"]:
+            prices_out.append(bucket["prices"]["requests"])
         yield {
             "sku_id": bucket["sku_id"],
             "provider": _PROVIDER,
@@ -155,11 +167,7 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
                 },
             },
             "terms": terms,
-            "prices": [
-                bucket["prices"]["cpu-second"],
-                bucket["prices"]["memory-gb-second"],
-                bucket["prices"]["requests"],
-            ],
+            "prices": prices_out,
         }
 
 

--- a/pipeline/ingest/gcp_run.py
+++ b/pipeline/ingest/gcp_run.py
@@ -107,6 +107,13 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         except ValueError:
             continue
         amount = parse_unit_price(units=price_units, nanos=int(price_nanos or 0)) / divisor
+        # Zero-priced requests dimension has no information (it's a free-tier
+        # SKU — the real Requests price is carried by a sibling non-zero SKU,
+        # or the service genuinely doesn't charge per request in this shard).
+        # Keeping a {"amount": 0.0} entry misleads `sku gcp run price` and
+        # inflates `sku estimate`'s output with phantom $0 request lines.
+        if dim == "requests" and amount == 0.0:
+            continue
         price_entry = {"dimension": dim, "tier": "", "amount": amount, "unit": unit}
 
         region = service_regions[0]
@@ -128,10 +135,11 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
         bucket["prices"][dim] = price_entry
 
     for region, bucket in grouped.items():
-        # Fan out the global Requests price into every region bucket.
+        # Fan out the global Requests price into every region bucket — but
+        # only if it's non-zero (zero was already filtered above).
         if global_requests is not None and "requests" not in bucket["prices"]:
             bucket["prices"]["requests"] = global_requests
-        if set(bucket["prices"].keys()) != {"cpu-second", "memory-gb-second", "requests"}:
+        if not {"cpu-second", "memory-gb-second"} <= bucket["prices"].keys():
             continue
         if "sku_id" not in bucket:
             continue
@@ -143,6 +151,12 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
             "upfront": "",
             "payment_option": "",
         })
+        prices_out = [
+            bucket["prices"]["cpu-second"],
+            bucket["prices"]["memory-gb-second"],
+        ]
+        if "requests" in bucket["prices"]:
+            prices_out.append(bucket["prices"]["requests"])
         yield {
             "sku_id": bucket["sku_id"],
             "provider": _PROVIDER,
@@ -160,11 +174,7 @@ def ingest(*, skus_path: Path) -> Iterable[dict[str, Any]]:
                 },
             },
             "terms": terms,
-            "prices": [
-                bucket["prices"]["cpu-second"],
-                bucket["prices"]["memory-gb-second"],
-                bucket["prices"]["requests"],
-            ],
+            "prices": prices_out,
         }
 
 

--- a/pipeline/ingest/openrouter.py
+++ b/pipeline/ingest/openrouter.py
@@ -209,6 +209,15 @@ def _uptime(row: dict[str, Any]) -> float:
     return float(v) if v is not None else -1.0
 
 
+def _price_sum(row: dict[str, Any]) -> float:
+    """Sum of published price amounts for a row — used to pick the cheapest
+    member of a divergent-price duplicate group. All LLM amounts are per-token
+    or per-request USD, so a plain sum is a conservative "lowest headline cost"
+    proxy for ranking; it never crosses units outside a single sku_id group.
+    """
+    return sum(float(p["amount"]) for p in row.get("prices") or [])
+
+
 def _dedupe_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Collapse rows sharing a sku_id.
 
@@ -216,10 +225,11 @@ def _dedupe_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     (model, serving_provider, quantization) tuple — Bedrock/Vertex
     regional splits, for one. When prices match (the common case), we
     keep the endpoint with the highest ``uptime_30d`` and log. When
-    prices diverge and upstream exposes no disambiguator we can put on
-    the sku_id, we drop all rows in that group rather than silently
-    publish a coin-flip price; the model's synthetic aggregated row
-    still ships from the top-level pricing.
+    prices diverge, we keep the cheapest member (lowest sum of price
+    amounts) and log a warning; dropping the whole group (prior
+    behaviour) made `sku llm price` return nothing for otherwise-valid
+    serving_providers. The model's synthetic aggregated row still ships
+    from the top-level pricing regardless.
     """
     grouped: dict[str, list[dict[str, Any]]] = {}
     order: list[str] = []
@@ -243,9 +253,16 @@ def _dedupe_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             )
             out.append(max(group, key=_uptime))
             continue
+        # Divergent prices: keep the cheapest (lowest total published
+        # amount) and warn. Tie-break on higher uptime so the chosen
+        # row is deterministic when two endpoints publish the same
+        # total cost.
+        chosen = min(group, key=lambda r: (_price_sum(r), -_uptime(r)))
         sys.stderr.write(
-            f"ingest.openrouter: dropped duplicate sku_id with divergent prices: {sid}\n"
+            f"ingest.openrouter: kept min-price duplicate for sku_id "
+            f"{sid} (dropped {len(group) - 1} divergent-price sibling(s))\n"
         )
+        out.append(chosen)
     return out
 
 

--- a/pipeline/testdata/azure_vm/prices.json
+++ b/pipeline/testdata/azure_vm/prices.json
@@ -310,8 +310,30 @@
       "type": "Consumption",
       "isPrimaryMeterRegion": true,
       "armSkuName": "Standard_D2_v3"
+    },
+    {
+      "currencyCode": "USD",
+      "tierMinimumUnits": 0.0,
+      "retailPrice": 0.0,
+      "unitPrice": 0.0,
+      "armRegionName": "eastus",
+      "location": "US East",
+      "effectiveStartDate": "2026-01-01T00:00:00Z",
+      "meterId": "azure-vm-dcads-v5-preview-eastus-linux",
+      "meterName": "DC2ads v5",
+      "productId": "DZH318Z0BPVW",
+      "skuId": "DZH318Z0BPVW/DC2ads_v5-preview-linux",
+      "productName": "Virtual Machines DCads v5 Preview",
+      "skuName": "DC2ads v5",
+      "serviceName": "Virtual Machines",
+      "serviceId": "DZH313Z7MMC8",
+      "serviceFamily": "Compute",
+      "unitOfMeasure": "1 Hour",
+      "type": "Consumption",
+      "isPrimaryMeterRegion": true,
+      "armSkuName": "Standard_DC2ads_v5"
     }
   ],
   "NextPageLink": null,
-  "Count": 14
+  "Count": 15
 }

--- a/pipeline/tests/test_aws_strip.py
+++ b/pipeline/tests/test_aws_strip.py
@@ -12,6 +12,7 @@ from ingest.aws_common import (
     _strip_ec2_offer,
     aws_regions_from_yaml,
     fetch_offer_regions_stripped,
+    shared_offer_basename,
 )
 
 
@@ -212,3 +213,55 @@ def test_fetch_offer_regions_stripped(tmp_path: Path) -> None:
 def test_fetch_unsupported_shard_raises(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="per-region offer not supported"):
         fetch_offer_regions_stripped("aws_s3", tmp_path, regions=["us-east-1"])
+
+
+def test_aws_ebs_shares_aws_ec2_stripped_offer() -> None:
+    """aws_ebs and aws_ec2 both consume AmazonEC2 — the stripped on-disk
+    file uses one shared basename so a single fetch serves both ingesters.
+    """
+    assert shared_offer_basename("aws_ec2") == "aws_ec2"
+    assert shared_offer_basename("aws_ebs") == "aws_ec2"
+
+
+def test_fetch_reuses_existing_stripped_file(tmp_path: Path) -> None:
+    """If aws_ec2 already produced aws_ec2-<region>.json, a subsequent
+    aws_ebs fetch skips re-downloading and re-stripping that region.
+    """
+    region_index_url = (
+        "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/region_index.json"
+    )
+    region_a_url = (
+        "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/20260418/us-east-1/index.json"
+    )
+    region_index = {
+        "regions": {
+            "us-east-1": {
+                "regionCode": "us-east-1",
+                "currentVersionUrl": "/offers/v1.0/aws/AmazonEC2/20260418/us-east-1/index.json",
+            },
+        }
+    }
+    body_index = json.dumps(region_index).encode()
+    idx_hdr = {"Content-Length": str(len(body_index))}
+
+    out_dir = tmp_path / "stripped"
+    out_dir.mkdir()
+    # Pretend aws_ec2 already produced a stripped offer for us-east-1.
+    preexisting = out_dir / "aws_ec2-us-east-1.json"
+    sentinel_body = {"products": {}, "terms": {"OnDemand": {}}, "sentinel": "preserved"}
+    preexisting.write_text(json.dumps(sentinel_body))
+
+    # Only the region_index.json endpoint should be hit; the per-region URL
+    # must NOT be fetched because the stripped file already exists.
+    with req_mock.Mocker() as m:
+        m.get(region_index_url, content=body_index, headers=idx_hdr)
+        # Register a failing matcher for the per-region URL so any reach
+        # for it surfaces as a test failure.
+        m.get(region_a_url, status_code=500)
+
+        paths = fetch_offer_regions_stripped(
+            "aws_ebs", out_dir, regions=["us-east-1"]
+        )
+
+    assert paths == [preexisting]
+    assert json.loads(preexisting.read_text())["sentinel"] == "preserved"

--- a/pipeline/tests/test_azure_vm_ingest.py
+++ b/pipeline/tests/test_azure_vm_ingest.py
@@ -49,6 +49,18 @@ def test_non_usd_rows_rejected():
         assert r["prices"][0]["amount"] > 0  # smoke
 
 
+def test_zero_price_preview_rows_filtered():
+    """Preview SKUs publish with retailPrice=0; they must not appear in output."""
+    raw = json.loads(FIXTURE.read_text())
+    preview_ids = {
+        it["meterId"] for it in raw["Items"]
+        if it["type"] == "Consumption" and it["retailPrice"] == 0.0
+    }
+    assert preview_ids, "fixture should contain at least one zero-price preview row"
+    out_ids = {r["sku_id"] for r in ingest(prices_path=FIXTURE)}
+    assert preview_ids.isdisjoint(out_ids)
+
+
 def test_unknown_region_skipped(tmp_path):
     """An item in a region outside regions.yaml is silently dropped."""
     bad = json.loads(FIXTURE.read_text())

--- a/pipeline/tests/test_gcp_functions_ingest.py
+++ b/pipeline/tests/test_gcp_functions_ingest.py
@@ -54,6 +54,33 @@ def test_architecture_attr():
         assert row["resource_name"] == "x86_64"
 
 
+def test_zero_priced_requests_dimension_dropped(tmp_path):
+    """A free-tier Invocations SKU (units=0, nanos=0) must not surface as a
+    $0 dimension. Rows still emit with cpu + memory dimensions only."""
+    bad = json.loads(FIXTURE.read_text())
+    zeroed_any = False
+    for sku in bad["skus"]:
+        desc = sku.get("description", "")
+        cat = sku.get("category") or {}
+        if (
+            cat.get("resourceGroup") == "Compute"
+            and (sku["pricingInfo"][0]["pricingExpression"]["usageUnit"] == "count"
+                 or "invocation" in desc.lower())
+        ):
+            rate = sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]
+            rate["unitPrice"]["units"] = "0"
+            rate["unitPrice"]["nanos"] = 0
+            zeroed_any = True
+    assert zeroed_any, "fixture should have at least one Invocations SKU"
+    p = tmp_path / "bad.json"
+    p.write_text(json.dumps(bad))
+    rows = list(ingest(skus_path=p))
+    assert rows, "rows should still emit without a Requests dimension"
+    for row in rows:
+        dims = [pr["dimension"] for pr in row["prices"]]
+        assert "requests" not in dims, row
+
+
 def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:

--- a/pipeline/tests/test_gcp_run_ingest.py
+++ b/pipeline/tests/test_gcp_run_ingest.py
@@ -54,6 +54,34 @@ def test_architecture_attr():
         assert row["resource_name"] == "x86_64"
 
 
+def test_zero_priced_requests_dimension_dropped(tmp_path):
+    """A free-tier Requests SKU (units=0, nanos=0) must not surface as a
+    $0 dimension in the output. The row should still emit with the cpu +
+    memory dimensions only."""
+    bad = json.loads(FIXTURE.read_text())
+    zeroed_any = False
+    for sku in bad["skus"]:
+        desc = sku.get("description", "")
+        cat = sku.get("category") or {}
+        if (
+            cat.get("resourceGroup") == "Compute"
+            and (sku["pricingInfo"][0]["pricingExpression"]["usageUnit"] == "count"
+                 or desc == "Requests")
+        ):
+            rate = sku["pricingInfo"][0]["pricingExpression"]["tieredRates"][0]
+            rate["unitPrice"]["units"] = "0"
+            rate["unitPrice"]["nanos"] = 0
+            zeroed_any = True
+    assert zeroed_any, "fixture should have at least one Requests SKU to zero out"
+    p = tmp_path / "bad.json"
+    p.write_text(json.dumps(bad))
+    rows = list(ingest(skus_path=p))
+    assert rows, "rows should still emit without a Requests dimension"
+    for row in rows:
+        dims = [pr["dimension"] for pr in row["prices"]]
+        assert "requests" not in dims, row
+
+
 def test_unknown_region_skipped(tmp_path):
     bad = json.loads(FIXTURE.read_text())
     for sku in bad["skus"]:

--- a/pipeline/tests/test_openrouter_ingest.py
+++ b/pipeline/tests/test_openrouter_ingest.py
@@ -151,8 +151,11 @@ def test_dedupe_collapses_duplicate_sku_id_keeping_higher_uptime(monkeypatch):
     assert ep_rows[0]["health"]["uptime_30d"] == pytest.approx(0.99)
 
 
-def test_dedupe_drops_duplicates_with_divergent_prices(monkeypatch, capsys):
+def test_dedupe_keeps_min_price_on_divergent_prices(monkeypatch, capsys):
     monkeypatch.setenv("SKU_FIXED_OBSERVED_AT", "1745020800")
+    # p1 is cheaper (prompt+completion = 3e-6); p2 has higher uptime but
+    # costs 7e-6. The min-price rule picks p1 so `sku llm price` returns
+    # the cheapest option rather than nothing.
     p1 = {"prompt": "0.000001", "completion": "0.000002", "currency": "USD"}
     p2 = {"prompt": "0.000003", "completion": "0.000004", "currency": "USD"}
     data = _dup_model(top_pricing=p1, ep_pricings=[p1, p2], uptimes=[0.90, 0.99])
@@ -160,11 +163,29 @@ def test_dedupe_drops_duplicates_with_divergent_prices(monkeypatch, capsys):
 
     rows = ingest(client, generated_at="2026-04-18T00:00:00Z")
     err = capsys.readouterr().err
-    assert "dropped duplicate sku_id with divergent prices" in err
+    assert "kept min-price duplicate for sku_id" in err
     assert "dup/model::dup-provider::unknown" in err
 
     ep_rows = [r for r in rows if not r["is_aggregated"]]
-    assert ep_rows == []
+    assert len(ep_rows) == 1, ep_rows
+    prices = {p["dimension"]: p["amount"] for p in ep_rows[0]["prices"]}
+    assert prices["prompt"] == pytest.approx(1e-6)
+    assert prices["completion"] == pytest.approx(2e-6)
+    # Aggregated still published from top-level pricing.
     agg = [r for r in rows if r["is_aggregated"]]
     assert len(agg) == 1
     assert agg[0]["sku_id"] == "dup/model::openrouter::default"
+
+
+def test_dedupe_min_price_ties_break_on_higher_uptime(monkeypatch):
+    monkeypatch.setenv("SKU_FIXED_OBSERVED_AT", "1745020800")
+    # Same total but different uptime: higher uptime should win.
+    p1 = {"prompt": "0.000001", "completion": "0.000002", "currency": "USD"}
+    p2 = {"prompt": "0.000002", "completion": "0.000001", "currency": "USD"}
+    data = _dup_model(top_pricing=p1, ep_pricings=[p1, p2], uptimes=[0.80, 0.99])
+    client = _FakeClient([data["model"]], {"dup/model": data["endpoints"]})
+
+    rows = ingest(client, generated_at="2026-04-18T00:00:00Z")
+    ep_rows = [r for r in rows if not r["is_aggregated"]]
+    assert len(ep_rows) == 1
+    assert ep_rows[0]["health"]["uptime_30d"] == pytest.approx(0.99)


### PR DESCRIPTION
## Summary

Batch of ten bug fixes from live pipeline triage on 2026-04-21. B4 (GCS multi-region fan-out) intentionally skipped — spec defers multi/dual-region to post-v1 and fan-out is the wrong model for distinct multi-region products.

- **B1** `1959f0f` updater: read `catalog_version` from key/value metadata schema
- **B2** `8d22dd5` cli: stop printing the error envelope twice on non-zero exits
- **B3** `7a7497f` ingest/s3: recover glacier-instant in 4 regions
- **B5** `f85df13` ingest/azure_vm: drop zero-price preview SKUs
- **B6** `839f164` ingest/openrouter: keep min-price on divergent dup (tie-break on uptime, warn instead of drop)
- **B7** `4b7e928` cli: reject invalid `--preset` / `SKU_PRESET` / `profile.preset` with `CodeValidation` (exit 4)
- **B8** `03d4e2e` pipeline: share one stripped AmazonEC2 offer between `aws_ec2` and `aws_ebs` (avoids 15 x 400MB re-fetch)
- **B9** `8e19897` ingest/gcp: drop zero-priced `requests` dim from `gcp_run` / `gcp_functions`
- **B10** `1056017` output/estimate: round `hourly_usd`, `monthly_usd`, `monthly_total.amount` to 6 sig figs
- **B11** `7470887` cli/compare: omit `max_price:0` from `NotFound` applied_filters and `--dry-run` args when unset

## Test plan

- [x] `make test` — 348 Go tests pass
- [x] `make pipeline-test` — 265 Python tests pass
- [ ] Spot-check `sku estimate --pretty` rounding on a known workload
- [ ] Spot-check `sku compare --preset compare` no longer echoes `max_price:0`
- [ ] Verify `sku --preset bogus aws ec2 price ...` returns rc=4