### PR TITLE
chore(ci): bump google auth action to v3

### DIFF
--- a/.github/workflows/data-daily.yml
+++ b/.github/workflows/data-daily.yml
@@ -147,7 +147,7 @@ jobs:
       - uses: ./.github/actions/setup-pipeline
 
       - name: Download today's shard
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: shard-${{ matrix.shard }}
           path: dist/pipeline/today/
@@ -193,13 +193,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-pipeline
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v6
         with:
           pattern: release-*
           merge-multiple: true
           path: dist/pipeline/release/
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v6
         with:
           name: discover
           path: dist/pipeline/discover/

--- a/.github/workflows/data-daily.yml
+++ b/.github/workflows/data-daily.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: ./.github/actions/setup-pipeline
 
       - name: Authenticate to GCP via Workload Identity Federation
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account:            ${{ vars.GCP_VALIDATE_SA }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Authenticate to GCP via Workload Identity Federation
         if: startsWith(matrix.shard, 'gcp_')
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account:            ${{ vars.GCP_VALIDATE_SA }}

--- a/.github/workflows/data-validate.yml
+++ b/.github/workflows/data-validate.yml
@@ -70,7 +70,7 @@ jobs:
           aws-region: us-east-1
       - name: Authenticate to Google Cloud (WIF)
         if: startsWith(matrix.shard, 'gcp-')
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: ${{ vars.GCP_VALIDATE_SA }}
@@ -135,7 +135,7 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
       - if: steps.cadence.outputs.run == 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: ${{ vars.GCP_VALIDATE_SA }}

--- a/.github/workflows/data-weekly.yml
+++ b/.github/workflows/data-weekly.yml
@@ -18,7 +18,7 @@ jobs:
       - run: cd pipeline && uv sync
       - name: Authenticate to Google Cloud (WIF)
         id: gcp-auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: ${{ vars.GCP_VALIDATE_SA }}

--- a/cmd/sku/update_test.go
+++ b/cmd/sku/update_test.go
@@ -210,12 +210,29 @@ func TestUpdate_UnsupportedShard(t *testing.T) {
 	require.Contains(t, stderr, "unsupported_shard")
 }
 
-// TestUpdate_HTTPError returns CodeServer when the server replies 502.
+// TestUpdate_HTTPError returns CodeServer when the shard asset download
+// replies 502. The manifest itself must succeed; otherwise the updater may
+// legitimately fall back to its secondary manifest URL and make this test
+// environment-dependent.
 func TestUpdate_HTTPError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "bad gateway", http.StatusBadGateway)
+	_, hexSum := buildTestZst(t)
+
+	var manifest string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(manifest))
+		case "/openrouter.db.zst":
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+		case "/openrouter.db.zst.sha256":
+			_, _ = w.Write([]byte(hexSum + "  openrouter.db.zst\n"))
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 	defer srv.Close()
+	manifest = singleShardManifest("openrouter", srv.URL, hexSum)
 
 	dataDir := t.TempDir()
 	t.Setenv("SKU_DATA_DIR", dataDir)


### PR DESCRIPTION
## Summary
- bump google-github-actions/auth from v2 to v3 in data daily, weekly, and validate workflows
- remove the GitHub Actions Node 20 deprecation warning triggered by the Google auth action in GCP-authenticated jobs

## Verification
- searched workflow files and confirmed there are no remaining google-github-actions/auth@v2 references
- ran git diff --check -- .github/workflows/data-validate.yml .github/workflows/data-daily.yml .github/workflows/data-weekly.yml
- actionlint is not installed in this workspace, so full local workflow linting was not run