### PR TITLE
feat: wire --auto-fetch, sku update --status, sku llm compare

### DIFF
--- a/.github/workflows/data-daily.yml
+++ b/.github/workflows/data-daily.yml
@@ -147,7 +147,7 @@ jobs:
       - uses: ./.github/actions/setup-pipeline
 
       - name: Download today's shard
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: shard-${{ matrix.shard }}
           path: dist/pipeline/today/
@@ -193,13 +193,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-pipeline
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v6
         with:
           pattern: release-*
           merge-multiple: true
           path: dist/pipeline/release/
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v6
         with:
           name: discover
           path: dist/pipeline/discover/

--- a/.github/workflows/data-daily.yml
+++ b/.github/workflows/data-daily.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: ./.github/actions/setup-pipeline
 
       - name: Authenticate to GCP via Workload Identity Federation
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account:            ${{ vars.GCP_VALIDATE_SA }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Authenticate to GCP via Workload Identity Federation
         if: startsWith(matrix.shard, 'gcp_')
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account:            ${{ vars.GCP_VALIDATE_SA }}

--- a/.github/workflows/data-validate.yml
+++ b/.github/workflows/data-validate.yml
@@ -70,7 +70,7 @@ jobs:
           aws-region: us-east-1
       - name: Authenticate to Google Cloud (WIF)
         if: startsWith(matrix.shard, 'gcp-')
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: ${{ vars.GCP_VALIDATE_SA }}
@@ -135,7 +135,7 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
       - if: steps.cadence.outputs.run == 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: ${{ vars.GCP_VALIDATE_SA }}

--- a/.github/workflows/data-weekly.yml
+++ b/.github/workflows/data-weekly.yml
@@ -18,7 +18,7 @@ jobs:
       - run: cd pipeline && uv sync
       - name: Authenticate to Google Cloud (WIF)
         id: gcp-auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: ${{ vars.GCP_VALIDATE_SA }}

--- a/cmd/sku/aws_cloudfront.go
+++ b/cmd/sku/aws_cloudfront.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -82,13 +81,11 @@ func runAWSCloudFront(cmd *cobra.Command, f *cfFlags, requireRegion bool) error 
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAWSCloudFront)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAWSCloudFront)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAWSCloudFront, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAWSCloudFront))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/aws_dynamodb.go
+++ b/cmd/sku/aws_dynamodb.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -82,13 +81,11 @@ func runAWSDynamoDB(cmd *cobra.Command, f *ddbFlags, requireRegion bool) error {
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAWSDynamoDB)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAWSDynamoDB)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAWSDynamoDB, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAWSDynamoDB))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/aws_ebs.go
+++ b/cmd/sku/aws_ebs.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -82,13 +81,11 @@ func runAWSEBS(cmd *cobra.Command, f *ebsFlags, requireRegion bool) error {
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAWSEBS)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAWSEBS)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAWSEBS, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAWSEBS))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/aws_ec2.go
+++ b/cmd/sku/aws_ec2.go
@@ -56,11 +56,11 @@ func ec2Lookup(ctx context.Context, f ec2Flags, requireRegion bool, s *batch.Set
 			"pass --region <aws-region>, e.g. --region us-east-1")
 	}
 
-	shardPath := catalog.ShardPath(shardAWSEC2)
-	if _, err := os.Stat(shardPath); err != nil {
-		return nil, shardMissingErr(shardAWSEC2)
+	autoFetch := s != nil && s.AutoFetch
+	if err := ensureShard(ctx, shardAWSEC2, autoFetch, nil); err != nil {
+		return nil, err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAWSEC2))
 	if err != nil {
 		return nil, &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 	}

--- a/cmd/sku/aws_helpers.go
+++ b/cmd/sku/aws_helpers.go
@@ -1,8 +1,12 @@
 package sku
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -11,6 +15,7 @@ import (
 	"github.com/sofq/sku/internal/config"
 	skuerrors "github.com/sofq/sku/internal/errors"
 	"github.com/sofq/sku/internal/output"
+	"github.com/sofq/sku/internal/updater"
 )
 
 func shardMissingErr(shard string) *skuerrors.E {
@@ -47,6 +52,46 @@ func applyStaleGate(cmd *cobra.Command, cat *catalog.Catalog, shard string, s co
 			age, s.StaleWarningDays, shard)
 	}
 	return nil
+}
+
+// autoFetchShard downloads shard using the manifest-based updater.
+func autoFetchShard(ctx context.Context, shard string, stderr io.Writer) error {
+	if stderr != nil {
+		_, _ = fmt.Fprintf(stderr, "auto-fetch: downloading %s shard...\n", shard)
+	}
+	// No fallback: SKU_UPDATE_BASE_URL fully controls the manifest URL in tests;
+	// production uses the default GitHub URL directly.
+	manifestSrc := updater.NewHTTPSource(resolveManifestPrimaryURL(), "", nil)
+	_, err := updater.Update(ctx, shard, updater.UpdateOptions{
+		Options:  updater.Options{DestDir: catalog.DataDir()},
+		Channel:  updater.ChannelStable,
+		Manifest: manifestSrc,
+		MaxChain: 20,
+	})
+	if err != nil {
+		msg := err.Error()
+		if idx := strings.Index(msg, ": "); idx >= 0 {
+			msg = msg[idx+2:]
+		}
+		return &skuerrors.E{
+			Code:       skuerrors.CodeServer,
+			Message:    fmt.Sprintf("auto-fetch %s: %s", shard, msg),
+			Suggestion: fmt.Sprintf("Run: sku update %s", shard),
+		}
+	}
+	return nil
+}
+
+// ensureShard returns nil if the shard DB exists. If not and autoFetch is true
+// it downloads via updater.Update; otherwise returns shardMissingErr.
+func ensureShard(ctx context.Context, shard string, autoFetch bool, stderr io.Writer) error {
+	if _, err := os.Stat(catalog.ShardPath(shard)); err == nil {
+		return nil
+	}
+	if !autoFetch {
+		return shardMissingErr(shard)
+	}
+	return autoFetchShard(ctx, shard, stderr)
 }
 
 func renderRows(cmd *cobra.Command, rows []catalog.Row, s config.Settings) error {

--- a/cmd/sku/aws_lambda.go
+++ b/cmd/sku/aws_lambda.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -82,13 +81,11 @@ func runAWSLambda(cmd *cobra.Command, f *lambdaFlags, requireRegion bool) error 
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAWSLambda)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAWSLambda)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAWSLambda, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAWSLambda))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/aws_rds.go
+++ b/cmd/sku/aws_rds.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -91,13 +90,11 @@ func runAWSDB(cmd *cobra.Command, f *rdsFlags, requireRegion bool) error {
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAWSRDS)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAWSRDS)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAWSRDS, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAWSRDS))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/aws_s3.go
+++ b/cmd/sku/aws_s3.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -85,13 +84,11 @@ func runAWSS3(cmd *cobra.Command, f *s3Flags, requireRegion bool) error {
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAWSS3)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAWSS3)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAWSS3, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAWSS3))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/azure_blob.go
+++ b/cmd/sku/azure_blob.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -85,13 +84,11 @@ func runAzureBlob(cmd *cobra.Command, f *azureBlobFlags, requireRegion bool) err
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAzureBlob)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAzureBlob)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAzureBlob, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAzureBlob))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/azure_disks.go
+++ b/cmd/sku/azure_disks.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -84,13 +83,11 @@ func runAzureDisks(cmd *cobra.Command, f *azureDisksFlags, requireRegion bool) e
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAzureDisks)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAzureDisks)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAzureDisks, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAzureDisks))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/azure_functions.go
+++ b/cmd/sku/azure_functions.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -84,13 +83,11 @@ func runAzureFunctions(cmd *cobra.Command, f *azureFunctionsFlags, requireRegion
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAzureFunctions)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAzureFunctions)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAzureFunctions, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAzureFunctions))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/azure_mariadb.go
+++ b/cmd/sku/azure_mariadb.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -88,13 +87,11 @@ func runAzureMariaDB(cmd *cobra.Command, f *azureMariaDBFlags, requireRegion boo
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAzureMariaDB)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAzureMariaDB)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAzureMariaDB, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAzureMariaDB))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/azure_mysql.go
+++ b/cmd/sku/azure_mysql.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -88,13 +87,11 @@ func runAzureMySQL(cmd *cobra.Command, f *azureMySQLFlags, requireRegion bool) e
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAzureMySQL)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAzureMySQL)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAzureMySQL, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAzureMySQL))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/azure_postgres.go
+++ b/cmd/sku/azure_postgres.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -88,13 +87,11 @@ func runAzurePostgres(cmd *cobra.Command, f *azurePostgresFlags, requireRegion b
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAzurePostgres)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAzurePostgres)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAzurePostgres, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAzurePostgres))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/azure_sql.go
+++ b/cmd/sku/azure_sql.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -89,13 +88,11 @@ func runAzureSQL(cmd *cobra.Command, f *azureSQLFlags, requireRegion bool) error
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAzureSQL)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAzureSQL)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAzureSQL, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAzureSQL))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/azure_vm.go
+++ b/cmd/sku/azure_vm.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -87,13 +86,11 @@ func runAzureVM(cmd *cobra.Command, f *azureVMFlags, requireRegion bool) error {
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardAzureVM)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardAzureVM)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardAzureVM, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardAzureVM))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/batch_settings.go
+++ b/cmd/sku/batch_settings.go
@@ -17,6 +17,7 @@ func ToBatchSettings(g config.Settings) batch.Settings {
 		Fields:            g.Fields,
 		IncludeRaw:        g.IncludeRaw,
 		IncludeAggregated: g.IncludeAggregated,
+		AutoFetch:         g.AutoFetch,
 		StaleOK:           g.StaleOK,
 		StaleWarningDays:  g.StaleWarningDays,
 		StaleErrorDays:    g.StaleErrorDays,

--- a/cmd/sku/batch_settings_test.go
+++ b/cmd/sku/batch_settings_test.go
@@ -11,14 +11,14 @@ func TestToBatchSettings_copiesAllFields(t *testing.T) {
 	g := config.Settings{
 		Preset: "compare", Profile: "default", Format: "json", Pretty: true,
 		JQ: ".x", Fields: "a,b", IncludeRaw: true, IncludeAggregated: true,
-		StaleOK: true, StaleWarningDays: 14, StaleErrorDays: 30, DryRun: false,
-		Verbose: true, NoColor: true,
+		AutoFetch: true, StaleOK: true, StaleWarningDays: 14, StaleErrorDays: 30,
+		DryRun: false, Verbose: true, NoColor: true,
 	}
 	s := ToBatchSettings(g)
 	want := batch.Settings{
 		Preset: "compare", Profile: "default", Format: "json", Pretty: true,
 		JQ: ".x", Fields: "a,b", IncludeRaw: true, IncludeAggregated: true,
-		StaleOK: true, StaleWarningDays: 14, StaleErrorDays: 30,
+		AutoFetch: true, StaleOK: true, StaleWarningDays: 14, StaleErrorDays: 30,
 		Verbose: true, NoColor: true,
 	}
 	if s != want {

--- a/cmd/sku/gcp_cloud_sql.go
+++ b/cmd/sku/gcp_cloud_sql.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -104,13 +103,11 @@ func runGCPCloudSQL(cmd *cobra.Command, f *gcpCloudSQLFlags, requireRegion bool)
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardGCPCloudSQL)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardGCPCloudSQL)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardGCPCloudSQL, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardGCPCloudSQL))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/gcp_functions.go
+++ b/cmd/sku/gcp_functions.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -85,13 +84,11 @@ func runGCPFunctions(cmd *cobra.Command, f *gcpFunctionsFlags, requireRegion boo
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardGCPFunctions)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardGCPFunctions)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardGCPFunctions, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardGCPFunctions))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/gcp_gce.go
+++ b/cmd/sku/gcp_gce.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -89,13 +88,11 @@ func runGCPGCE(cmd *cobra.Command, f *gcpGCEFlags, requireRegion bool) error {
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardGCPGCE)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardGCPGCE)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardGCPGCE, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardGCPGCE))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/gcp_gcs.go
+++ b/cmd/sku/gcp_gcs.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -86,13 +85,11 @@ func runGCPGCS(cmd *cobra.Command, f *gcpGCSFlags, requireRegion bool) error {
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardGCPGCS)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardGCPGCS)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardGCPGCS, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardGCPGCS))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/gcp_run.go
+++ b/cmd/sku/gcp_run.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -85,13 +84,11 @@ func runGCPRun(cmd *cobra.Command, f *gcpRunFlags, requireRegion bool) error {
 			Preset: s.Preset,
 		})
 	}
-	shardPath := catalog.ShardPath(shardGCPRun)
-	if _, err := os.Stat(shardPath); err != nil {
-		e := shardMissingErr(shardGCPRun)
-		skuerrors.Write(cmd.ErrOrStderr(), e)
-		return e
+	if err := ensureShard(cmd.Context(), shardGCPRun, s.AutoFetch, cmd.ErrOrStderr()); err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardGCPRun))
 	if err != nil {
 		e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
 		skuerrors.Write(cmd.ErrOrStderr(), e)

--- a/cmd/sku/handlers.go
+++ b/cmd/sku/handlers.go
@@ -4,6 +4,7 @@ import "github.com/sofq/sku/internal/batch"
 
 func init() {
 	batch.Register("llm price", handleLLMPrice)
+	batch.Register("llm compare", handleLLMCompare)
 	batch.Register("aws ec2 price", handleAWSEC2Price)
 	batch.Register("aws ec2 list", handleAWSEC2List)
 	batch.Register("compare", handleCompare)

--- a/cmd/sku/llm.go
+++ b/cmd/sku/llm.go
@@ -8,5 +8,6 @@ func newLLMCmd() *cobra.Command {
 		Short: "Cross-provider LLM pricing (OpenRouter-backed)",
 	}
 	c.AddCommand(newLLMPriceCmd())
+	c.AddCommand(newLLMCompareCmd())
 	return c
 }

--- a/cmd/sku/llm_compare.go
+++ b/cmd/sku/llm_compare.go
@@ -1,0 +1,181 @@
+package sku
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sofq/sku/internal/batch"
+	"github.com/sofq/sku/internal/catalog"
+	skuerrors "github.com/sofq/sku/internal/errors"
+	"github.com/sofq/sku/internal/output"
+)
+
+// handleLLMCompare is the shared body used by both the Cobra command and the
+// batch dispatcher. Returns []catalog.Row sorted by cheapest prompt price first.
+func handleLLMCompare(ctx context.Context, args map[string]any, env batch.Env) (any, error) {
+	model := argString(args, "model")
+	servingProvider := argString(args, "serving_provider")
+	if model == "" {
+		return nil, skuerrors.Validation(
+			"flag_invalid", "model", "",
+			"pass --model <author>/<slug>, e.g. --model anthropic/claude-opus-4.6",
+		)
+	}
+
+	autoFetch := env.Settings != nil && env.Settings.AutoFetch
+	if err := ensureShard(ctx, shardOpenRouter, autoFetch, env.Stderr); err != nil {
+		return nil, err
+	}
+
+	cat, err := catalog.Open(catalog.ShardPath(shardOpenRouter))
+	if err != nil {
+		return nil, &skuerrors.E{
+			Code:       skuerrors.CodeServer,
+			Message:    err.Error(),
+			Suggestion: "Check that the shard file is readable and not truncated",
+		}
+	}
+	defer func() { _ = cat.Close() }()
+
+	s := env.Settings
+	age := cat.Age(time.Now().UTC())
+	if s != nil && s.StaleErrorDays > 0 && age >= s.StaleErrorDays && !s.StaleOK {
+		return nil, &skuerrors.E{
+			Code:       skuerrors.CodeStaleData,
+			Message:    fmt.Sprintf("catalog %d days old exceeds threshold %d", age, s.StaleErrorDays),
+			Suggestion: "Run: sku update " + shardOpenRouter,
+			Details:    map[string]any{"shard": shardOpenRouter, "age_days": age, "threshold_days": s.StaleErrorDays},
+		}
+	}
+
+	includeAggregated := s != nil && s.IncludeAggregated
+	rows, err := cat.LookupLLM(ctx, catalog.LLMFilter{
+		Model:             model,
+		ServingProvider:   servingProvider,
+		IncludeAggregated: includeAggregated,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("llm compare: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, skuerrors.NotFound(
+			shardOpenRouter, "llm",
+			map[string]any{"model": model, "serving_provider": servingProvider},
+			"Try `sku update openrouter` or drop --serving-provider",
+		)
+	}
+
+	// Populate MinPrice from prompt dimension; fall back to minimum across all.
+	for i := range rows {
+		for _, p := range rows[i].Prices {
+			if p.Dimension == "prompt" && (rows[i].MinPrice == 0 || p.Amount < rows[i].MinPrice) {
+				rows[i].MinPrice = p.Amount
+			}
+		}
+		if rows[i].MinPrice == 0 {
+			for _, p := range rows[i].Prices {
+				if rows[i].MinPrice == 0 || p.Amount < rows[i].MinPrice {
+					rows[i].MinPrice = p.Amount
+				}
+			}
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].MinPrice < rows[j].MinPrice
+	})
+
+	return rows, nil
+}
+
+func newLLMCompareCmd() *cobra.Command {
+	var (
+		model           string
+		servingProvider string
+	)
+	c := &cobra.Command{
+		Use:   "compare",
+		Short: "Compare serving-provider costs for a model, cheapest first",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			s := globalSettings(cmd)
+
+			if model == "" {
+				err := skuerrors.Validation(
+					"flag_invalid", "model", "",
+					"pass --model <author>/<slug>, e.g. --model anthropic/claude-opus-4.6",
+				)
+				skuerrors.Write(cmd.ErrOrStderr(), err)
+				return err
+			}
+
+			if s.DryRun {
+				return output.EmitDryRun(cmd.OutOrStdout(), output.DryRunPlan{
+					Command: "llm compare",
+					ResolvedArgs: map[string]any{
+						"model":            model,
+						"serving_provider": servingProvider,
+					},
+					Shards: []string{shardOpenRouter},
+					Preset: s.Preset,
+				})
+			}
+
+			batchSettings := ToBatchSettings(s)
+			args := map[string]any{"model": model, "serving_provider": servingProvider}
+			result, err := handleLLMCompare(cmd.Context(), args, batch.Env{
+				Settings: &batchSettings,
+				Stdout:   cmd.OutOrStdout(),
+				Stderr:   cmd.ErrOrStderr(),
+			})
+			if err != nil {
+				skuerrors.Write(cmd.ErrOrStderr(), err)
+				return err
+			}
+			rows := result.([]catalog.Row)
+
+			// Stale warning (not fatal).
+			if cat2, openErr := catalog.Open(catalog.ShardPath(shardOpenRouter)); openErr == nil {
+				age := cat2.Age(time.Now().UTC())
+				if s.StaleWarningDays > 0 && age >= s.StaleWarningDays && !s.StaleOK {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+						"warning: catalog is %d days old (warn threshold %d); run `sku update openrouter`\n",
+						age, s.StaleWarningDays)
+				}
+				_ = cat2.Close()
+			}
+
+			opts := output.Options{
+				Preset:            output.Preset(s.Preset),
+				Format:            s.Format,
+				Pretty:            s.Pretty,
+				Fields:            s.Fields,
+				JQ:                s.JQ,
+				IncludeRaw:        s.IncludeRaw,
+				IncludeAggregated: s.IncludeAggregated,
+				NoColor:           s.NoColor,
+			}
+
+			w := cmd.OutOrStdout()
+			for _, r := range rows {
+				b, err := output.Pipeline(r, opts)
+				if errors.Is(err, output.ErrDropped) {
+					continue
+				}
+				if err != nil {
+					return skuerrors.WriteWrap(cmd.ErrOrStderr(), skuerrors.CodeGeneric, "render: %w", err)
+				}
+				if _, wErr := w.Write(b); wErr != nil {
+					return wErr
+				}
+			}
+			return nil
+		},
+	}
+	c.Flags().StringVar(&model, "model", "", "Model ID, e.g. anthropic/claude-opus-4.6")
+	c.Flags().StringVar(&servingProvider, "serving-provider", "", "Filter to a single serving provider (e.g. aws-bedrock)")
+	return c
+}

--- a/cmd/sku/llm_compare_test.go
+++ b/cmd/sku/llm_compare_test.go
@@ -1,0 +1,173 @@
+package sku
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sofq/sku/internal/batch"
+	"github.com/sofq/sku/internal/catalog"
+)
+
+// seedCompareDataDir creates an openrouter.db with two providers at different
+// prompt prices for "vendor/cheap-model".
+func seedCompareDataDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	ddl := `
+CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+INSERT INTO metadata VALUES ('schema_version','1'),('catalog_version','2026.04.24'),
+  ('currency','USD'),('generated_at','2026-04-24T00:00:00Z');
+
+CREATE TABLE skus (
+  sku_id TEXT PRIMARY KEY, provider TEXT NOT NULL, service TEXT NOT NULL,
+  kind TEXT NOT NULL, resource_name TEXT NOT NULL, region TEXT NOT NULL DEFAULT '',
+  region_normalized TEXT NOT NULL DEFAULT '', terms_hash TEXT NOT NULL DEFAULT ''
+);
+INSERT INTO skus VALUES
+  ('m/cheap','cheap-provider','llm','llm.text','vendor/cheap-model','','',''),
+  ('m/pricey','pricey-provider','llm','llm.text','vendor/cheap-model','','','');
+
+CREATE TABLE terms (
+  sku_id TEXT PRIMARY KEY, commitment TEXT NOT NULL DEFAULT 'on_demand',
+  tenancy TEXT NOT NULL DEFAULT '', os TEXT NOT NULL DEFAULT '',
+  support_tier TEXT, upfront TEXT, payment_option TEXT
+);
+INSERT INTO terms VALUES ('m/cheap','on_demand','','',NULL,NULL,NULL);
+INSERT INTO terms VALUES ('m/pricey','on_demand','','',NULL,NULL,NULL);
+
+CREATE TABLE resource_attrs (
+  sku_id TEXT PRIMARY KEY, vcpu INTEGER, memory_gb REAL, storage_gb REAL,
+  gpu_count INTEGER, gpu_model TEXT, architecture TEXT,
+  context_length INTEGER, max_output_tokens INTEGER,
+  modality TEXT, capabilities TEXT, quantization TEXT,
+  durability_nines INTEGER, availability_tier TEXT
+);
+INSERT INTO resource_attrs (sku_id, context_length) VALUES ('m/cheap', 200000);
+INSERT INTO resource_attrs (sku_id, context_length) VALUES ('m/pricey', 200000);
+
+CREATE TABLE prices (
+  sku_id TEXT NOT NULL, dimension TEXT NOT NULL, tier TEXT NOT NULL DEFAULT '',
+  amount REAL NOT NULL, unit TEXT NOT NULL DEFAULT 'token',
+  PRIMARY KEY (sku_id, dimension, tier)
+);
+INSERT INTO prices VALUES ('m/cheap','prompt','',5e-7,'token');
+INSERT INTO prices VALUES ('m/cheap','completion','',1.5e-6,'token');
+INSERT INTO prices VALUES ('m/pricey','prompt','',1.5e-6,'token');
+INSERT INTO prices VALUES ('m/pricey','completion','',4.5e-6,'token');
+
+CREATE TABLE health (
+  sku_id TEXT PRIMARY KEY, uptime_30d REAL, latency_p50_ms INTEGER,
+  latency_p95_ms INTEGER, throughput_tokens_per_sec REAL, observed_at INTEGER
+);
+`
+	require.NoError(t, catalog.BuildFromSQL(filepath.Join(dir, "openrouter.db"), ddl))
+	t.Setenv("SKU_DATA_DIR", dir)
+	return dir
+}
+
+func runLLMCompare(t *testing.T, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	cmd := newRootCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&errb)
+	cmd.SetArgs(append([]string{"llm", "compare"}, args...))
+	err := cmd.Execute()
+	code = 0
+	if err != nil {
+		code = 1
+	}
+	return out.String(), errb.String(), code
+}
+
+func TestLLMCompare_HappyPath_SortedCheapestFirst(t *testing.T) {
+	seedCompareDataDir(t)
+
+	out, _, code := runLLMCompare(t, "--model", "vendor/cheap-model")
+	require.Zero(t, code)
+
+	lines := splitLines(out)
+	require.Len(t, lines, 2)
+
+	var providers []string
+	for _, line := range lines {
+		var env map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &env))
+		providers = append(providers, env["provider"].(string))
+	}
+	require.Equal(t, "cheap-provider", providers[0], "cheapest provider must be first")
+	require.Equal(t, "pricey-provider", providers[1])
+}
+
+func TestLLMCompare_MissingModel_ReturnsValidationError(t *testing.T) {
+	seedCompareDataDir(t)
+	_, stderr, code := runLLMCompare(t)
+	require.NotZero(t, code)
+	var env map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stderr), &env))
+	require.Equal(t, "validation", env["error"].(map[string]any)["code"])
+}
+
+func TestLLMCompare_ShardMissing_ReturnsNotFound(t *testing.T) {
+	t.Setenv("SKU_DATA_DIR", t.TempDir())
+	_, stderr, code := runLLMCompare(t, "--model", "vendor/cheap-model")
+	require.NotZero(t, code)
+	var env map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stderr), &env))
+	require.Equal(t, "not_found", env["error"].(map[string]any)["code"])
+}
+
+func TestLLMCompare_DryRun(t *testing.T) {
+	t.Setenv("SKU_DATA_DIR", t.TempDir())
+	out, _, code := runLLMCompare(t, "--model", "vendor/cheap-model", "--dry-run")
+	require.Zero(t, code)
+	require.Contains(t, out, `"dry_run":true`)
+	require.Contains(t, out, `"command":"llm compare"`)
+}
+
+func TestLLMCompare_Registered(t *testing.T) {
+	if _, ok := batch.Lookup("llm compare"); !ok {
+		t.Fatal("llm compare handler not registered")
+	}
+}
+
+func TestLLMCompare_SortStability(t *testing.T) {
+	seedTestDataDir(t)
+	out, _, code := runLLMCompare(t, "--model", "anthropic/claude-opus-4.6")
+	require.Zero(t, code)
+	lines := splitLines(out)
+	require.Len(t, lines, 2)
+	providersSeen := map[string]bool{}
+	for _, line := range lines {
+		var env map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &env))
+		providersSeen[env["provider"].(string)] = true
+	}
+	require.True(t, providersSeen["anthropic"])
+	require.True(t, providersSeen["aws-bedrock"])
+}
+
+func TestLLMCompare_ServingProviderFilter(t *testing.T) {
+	seedCompareDataDir(t)
+	out, _, code := runLLMCompare(t, "--model", "vendor/cheap-model", "--serving-provider", "pricey-provider")
+	require.Zero(t, code)
+	lines := splitLines(out)
+	require.Len(t, lines, 1)
+	var env map[string]any
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &env))
+	require.Equal(t, "pricey-provider", env["provider"])
+}
+
+func TestLLMCompare_ModelNotFound(t *testing.T) {
+	seedCompareDataDir(t)
+	_, stderr, code := runLLMCompare(t, "--model", "vendor/nonexistent-model")
+	require.NotZero(t, code)
+	var env map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stderr), &env))
+	require.Equal(t, "not_found", env["error"].(map[string]any)["code"])
+}

--- a/cmd/sku/llm_price.go
+++ b/cmd/sku/llm_price.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -14,6 +13,8 @@ import (
 	skuerrors "github.com/sofq/sku/internal/errors"
 	"github.com/sofq/sku/internal/output"
 )
+
+const shardOpenRouter = "openrouter"
 
 // handleLLMPrice is the shared body used by both the standalone Cobra command
 // and the batch dispatcher. Returns []catalog.Row on success; any *skuerrors.E
@@ -27,16 +28,11 @@ func handleLLMPrice(ctx context.Context, args map[string]any, env batch.Env) (an
 			"pass --model <author>/<slug>, e.g. --model anthropic/claude-opus-4.6",
 		)
 	}
-	shardPath := catalog.ShardPath("openrouter")
-	if _, err := os.Stat(shardPath); err != nil {
-		return nil, &skuerrors.E{
-			Code:       skuerrors.CodeNotFound,
-			Message:    "openrouter shard not installed",
-			Suggestion: "Run: sku update openrouter",
-			Details:    map[string]any{"shard": "openrouter", "install_hint": "sku update openrouter"},
-		}
+	autoFetch := env.Settings != nil && env.Settings.AutoFetch
+	if err := ensureShard(ctx, shardOpenRouter, autoFetch, env.Stderr); err != nil {
+		return nil, err
 	}
-	cat, err := catalog.Open(shardPath)
+	cat, err := catalog.Open(catalog.ShardPath(shardOpenRouter))
 	if err != nil {
 		return nil, &skuerrors.E{
 			Code:       skuerrors.CodeServer,
@@ -52,8 +48,8 @@ func handleLLMPrice(ctx context.Context, args map[string]any, env batch.Env) (an
 		return nil, &skuerrors.E{
 			Code:       skuerrors.CodeStaleData,
 			Message:    fmt.Sprintf("catalog %d days old exceeds threshold %d", age, s.StaleErrorDays),
-			Suggestion: "Run: sku update openrouter",
-			Details:    map[string]any{"shard": "openrouter", "age_days": age, "threshold_days": s.StaleErrorDays},
+			Suggestion: "Run: sku update " + shardOpenRouter,
+			Details:    map[string]any{"shard": shardOpenRouter, "age_days": age, "threshold_days": s.StaleErrorDays},
 		}
 	}
 
@@ -71,7 +67,7 @@ func handleLLMPrice(ctx context.Context, args map[string]any, env batch.Env) (an
 	}
 	if len(rows) == 0 {
 		return nil, skuerrors.NotFound(
-			"openrouter", "llm",
+			shardOpenRouter, "llm",
 			map[string]any{"model": model, "serving_provider": servingProvider},
 			"Try `sku update openrouter` or drop --serving-provider",
 		)
@@ -106,7 +102,7 @@ func newLLMPriceCmd() *cobra.Command {
 						"model":            model,
 						"serving_provider": servingProvider,
 					},
-					Shards: []string{"openrouter"},
+					Shards: []string{shardOpenRouter},
 					Preset: s.Preset,
 				})
 			}
@@ -126,22 +122,19 @@ func newLLMPriceCmd() *cobra.Command {
 
 			if s.Verbose {
 				output.Log(cmd.ErrOrStderr(), "catalog.open",
-					map[string]any{"shard": "openrouter", "path": catalog.ShardPath("openrouter")})
+					map[string]any{"shard": shardOpenRouter, "path": catalog.ShardPath(shardOpenRouter)})
 			}
 
 			// Stale warning (not fatal) still emitted from the Cobra path; batch
 			// callers don't get stderr warnings in v1.
-			shardPath := catalog.ShardPath("openrouter")
-			if _, statErr := os.Stat(shardPath); statErr == nil {
-				if cat, openErr := catalog.Open(shardPath); openErr == nil {
-					age := cat.Age(time.Now().UTC())
-					if s.StaleWarningDays > 0 && age >= s.StaleWarningDays && !s.StaleOK {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-							"warning: catalog is %d days old (warn threshold %d); run `sku update openrouter`\n",
-							age, s.StaleWarningDays)
-					}
-					_ = cat.Close()
+			if cat, openErr := catalog.Open(catalog.ShardPath(shardOpenRouter)); openErr == nil {
+				age := cat.Age(time.Now().UTC())
+				if s.StaleWarningDays > 0 && age >= s.StaleWarningDays && !s.StaleOK {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+						"warning: catalog is %d days old (warn threshold %d); run `sku update openrouter`\n",
+						age, s.StaleWarningDays)
 				}
+				_ = cat.Close()
 			}
 
 			opts := output.Options{

--- a/cmd/sku/llm_price_handler_test.go
+++ b/cmd/sku/llm_price_handler_test.go
@@ -2,9 +2,11 @@ package sku
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/sofq/sku/internal/batch"
+	skuerrors "github.com/sofq/sku/internal/errors"
 )
 
 func TestHandleLLMPrice_notFoundReturnsEnvelope(t *testing.T) {
@@ -20,5 +22,38 @@ func TestHandleLLMPrice_notFoundReturnsEnvelope(t *testing.T) {
 func TestHandleLLMPrice_registered(t *testing.T) {
 	if _, ok := batch.Lookup("llm price"); !ok {
 		t.Fatal("llm price handler not registered")
+	}
+}
+
+func TestHandleLLMPrice_autoFetch_staticVsAttempted(t *testing.T) {
+	t.Setenv("SKU_DATA_DIR", t.TempDir())
+
+	// AutoFetch=false → static "shard not installed" (not_found, no network call).
+	s := batch.Settings{AutoFetch: false}
+	_, errNoFetch := handleLLMPrice(context.Background(), map[string]any{"model": "x/y"}, batch.Env{Settings: &s})
+	if errNoFetch == nil {
+		t.Fatal("expected error when shard missing and AutoFetch=false")
+	}
+	var e *skuerrors.E
+	if !errors.As(errNoFetch, &e) {
+		t.Fatalf("expected *skuerrors.E, got %T: %v", errNoFetch, errNoFetch)
+	}
+	if e.Code != skuerrors.CodeNotFound || e.Message != "openrouter shard not installed" {
+		t.Fatalf("expected static shard-missing error, got code=%s msg=%q", e.Code, e.Message)
+	}
+
+	// AutoFetch=true with blocked URL → server error (auto-fetch attempted, not static).
+	t.Setenv("SKU_UPDATE_BASE_URL", "http://127.0.0.1:1")
+	sFetch := batch.Settings{AutoFetch: true}
+	_, errFetch := handleLLMPrice(context.Background(), map[string]any{"model": "x/y"}, batch.Env{Settings: &sFetch})
+	if errFetch == nil {
+		t.Fatal("expected error with blocked URL")
+	}
+	var e2 *skuerrors.E
+	if !errors.As(errFetch, &e2) {
+		t.Fatalf("expected *skuerrors.E, got %T: %v", errFetch, errFetch)
+	}
+	if e2.Code == skuerrors.CodeNotFound && e2.Message == "openrouter shard not installed" {
+		t.Fatal("auto-fetch was not attempted: got static shard-missing error")
 	}
 }

--- a/cmd/sku/update.go
+++ b/cmd/sku/update.go
@@ -1,13 +1,18 @@
 package sku
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/sofq/sku/internal/catalog"
+	"github.com/sofq/sku/internal/config"
 	skuerrors "github.com/sofq/sku/internal/errors"
 	"github.com/sofq/sku/internal/output"
 	"github.com/sofq/sku/internal/updater"
@@ -52,107 +57,195 @@ func shardNames() []string { return updater.ShardNames() }
 // through the manifest. The data-bootstrap-* release tags are no longer used.
 func shouldUseManifestUpdate(string, updater.Channel, bool) bool { return true }
 
-func newUpdateCmd() *cobra.Command {
-	var channelFlag string
+type shardStatus struct {
+	Name      string `json:"name"`
+	Installed bool   `json:"installed"`
+	Version   string `json:"version,omitempty"`
+	AgeDays   int    `json:"age_days,omitempty"`
+	Path      string `json:"path,omitempty"`
+}
 
-	cmd := &cobra.Command{
-		Use:   "update <shard>",
-		Short: "Download and install a pricing shard (openrouter | aws-* | azure-* | gcp-*)",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			s := globalSettings(cmd)
-			shard := args[0]
+type statusResult struct {
+	Shards []shardStatus `json:"shards"`
+}
 
-			// Validate shard name.
-			_, ok := resolveUpdateBaseURL(shard)
-			if !ok {
-				err := skuerrors.Validation(
-					"unsupported_shard", "shard", shard,
-					"supported shards: "+strings.Join(shardNames(), ", "),
-				)
-				skuerrors.Write(cmd.ErrOrStderr(), err)
-				return err
-			}
+func runUpdateStatus(cmd *cobra.Command, s config.Settings) error {
+	names := shardNames()
+	statuses := make([]shardStatus, 0, len(names))
+	for _, name := range names {
+		path := catalog.ShardPath(name)
+		if _, err := os.Stat(path); err != nil {
+			statuses = append(statuses, shardStatus{Name: name, Installed: false})
+			continue
+		}
+		cat, openErr := catalog.Open(path)
+		if openErr != nil {
+			statuses = append(statuses, shardStatus{Name: name, Installed: true, Path: path})
+			continue
+		}
+		statuses = append(statuses, shardStatus{
+			Name:      name,
+			Installed: true,
+			Version:   cat.CatalogVersion(),
+			AgeDays:   cat.Age(time.Now().UTC()),
+			Path:      path,
+		})
+		_ = cat.Close()
+	}
 
-			// Resolve channel: flag > SKU_UPDATE_CHANNEL env > profile > stable.
-			channel, err := updater.ResolveChannel(
-				channelFlag,
-				os.Getenv("SKU_UPDATE_CHANNEL"),
-				s.Channel,
-			)
-			if err != nil {
-				skuerrors.Write(cmd.ErrOrStderr(), err)
-				return err
-			}
+	result := statusResult{Shards: statuses}
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
 
-			dataDir := catalog.DataDir()
+	var out []byte
+	if s.Pretty {
+		var buf bytes.Buffer
+		if indentErr := json.Indent(&buf, raw, "", "  "); indentErr == nil {
+			out = buf.Bytes()
+		} else {
+			out = raw
+		}
+	} else {
+		out = raw
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", out)
+	return err
+}
 
-			if s.Verbose {
-				output.Log(cmd.ErrOrStderr(), "update.fetch", map[string]any{
-					"shard": shard, "channel": string(channel),
+func runSingleShardUpdate(cmd *cobra.Command, shard, channelFlag string, s config.Settings) error {
+	if _, ok := resolveUpdateBaseURL(shard); !ok {
+		err := skuerrors.Validation(
+			"unsupported_shard", "shard", shard,
+			"supported shards: "+strings.Join(shardNames(), ", "),
+		)
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
+	}
+
+	channel, err := updater.ResolveChannel(
+		channelFlag,
+		os.Getenv("SKU_UPDATE_CHANNEL"),
+		s.Channel,
+	)
+	if err != nil {
+		skuerrors.Write(cmd.ErrOrStderr(), err)
+		return err
+	}
+
+	dataDir := catalog.DataDir()
+
+	if s.Verbose {
+		output.Log(cmd.ErrOrStderr(), "update.fetch", map[string]any{
+			"shard": shard, "channel": string(channel),
+		})
+	}
+
+	primaryManifestURL := resolveManifestPrimaryURL()
+	fallbackManifestURL := "https://cdn.jsdelivr.net/gh/sofq/sku@data/manifest.json"
+	manifestSrc := updater.NewHTTPSource(primaryManifestURL, fallbackManifestURL, nil)
+
+	opts := updater.UpdateOptions{
+		Options: updater.Options{
+			DestDir: dataDir,
+		},
+		Channel:  channel,
+		Manifest: manifestSrc,
+		MaxChain: 20,
+	}
+
+	result, err := updater.Update(cmd.Context(), shard, opts)
+	if err != nil {
+		code := skuerrors.CodeServer
+		var ve *skuerrors.E
+		if errors.As(err, &ve) {
+			skuerrors.Write(cmd.ErrOrStderr(), ve)
+			return ve
+		}
+		if errors.Is(err, updater.ErrSHAMismatch) {
+			code = skuerrors.CodeConflict
+		} else if errors.Is(err, updater.ErrLocked) {
+			code = skuerrors.CodeConflict
+		}
+		e := &skuerrors.E{Code: code, Message: err.Error()}
+		skuerrors.Write(cmd.ErrOrStderr(), e)
+		return e
+	}
+
+	if s.Verbose {
+		if result.FellBackToBaseline {
+			output.Log(cmd.ErrOrStderr(), "update.fallback-to-baseline", map[string]any{
+				"shard": shard, "from": result.From,
+			})
+		}
+		if result.Baseline {
+			output.Log(cmd.ErrOrStderr(), "update.baseline-installed", map[string]any{
+				"shard": shard, "version": result.To,
+			})
+		} else if len(result.Applied) > 0 {
+			for _, d := range result.Applied {
+				output.Log(cmd.ErrOrStderr(), "update.delta-applied", map[string]any{
+					"shard": shard, "from": d.From, "to": d.To,
 				})
 			}
+		} else {
+			output.Log(cmd.ErrOrStderr(), "update.304", map[string]any{
+				"shard": shard, "version": result.From,
+			})
+		}
+	}
 
-			primaryManifestURL := resolveManifestPrimaryURL()
-			fallbackManifestURL := "https://cdn.jsdelivr.net/gh/sofq/sku@data/manifest.json"
+	_, _ = cmd.ErrOrStderr().Write([]byte("installed " + shard + " -> " + catalog.ShardPath(shard) + "\n"))
+	return nil
+}
 
-			manifestSrc := updater.NewHTTPSource(primaryManifestURL, fallbackManifestURL, nil)
+func newUpdateCmd() *cobra.Command {
+	var (
+		channelFlag string
+		statusFlag  bool
+	)
 
-			opts := updater.UpdateOptions{
-				Options: updater.Options{
-					DestDir: dataDir,
-				},
-				Channel:  channel,
-				Manifest: manifestSrc,
-				MaxChain: 20,
+	cmd := &cobra.Command{
+		Use:   "update [<shard>...]",
+		Short: "Download and install pricing shards (openrouter | aws-* | azure-* | gcp-*)",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			s := globalSettings(cmd)
+
+			if statusFlag {
+				return runUpdateStatus(cmd, s)
 			}
 
-			result, err := updater.Update(cmd.Context(), shard, opts)
-			if err != nil {
-				code := skuerrors.CodeServer
-				var ve *skuerrors.E
-				if errors.As(err, &ve) {
-					skuerrors.Write(cmd.ErrOrStderr(), ve)
-					return ve
+			var shards []string
+			if len(args) > 0 {
+				shards = args
+			} else {
+				installed, err := catalog.InstalledShards()
+				if err != nil {
+					e := &skuerrors.E{Code: skuerrors.CodeServer, Message: err.Error()}
+					skuerrors.Write(cmd.ErrOrStderr(), e)
+					return e
 				}
-				if errors.Is(err, updater.ErrSHAMismatch) {
-					code = skuerrors.CodeConflict
-				} else if errors.Is(err, updater.ErrLocked) {
-					code = skuerrors.CodeConflict
-				}
-				e := &skuerrors.E{Code: code, Message: err.Error()}
-				skuerrors.Write(cmd.ErrOrStderr(), e)
-				return e
+				shards = installed
 			}
 
-			if s.Verbose {
-				if result.FellBackToBaseline {
-					output.Log(cmd.ErrOrStderr(), "update.fallback-to-baseline", map[string]any{
-						"shard": shard, "from": result.From,
-					})
-				}
-				if result.Baseline {
-					output.Log(cmd.ErrOrStderr(), "update.baseline-installed", map[string]any{
-						"shard": shard, "version": result.To,
-					})
-				} else if len(result.Applied) > 0 {
-					for _, d := range result.Applied {
-						output.Log(cmd.ErrOrStderr(), "update.delta-applied", map[string]any{
-							"shard": shard, "from": d.From, "to": d.To,
-						})
-					}
-				} else {
-					output.Log(cmd.ErrOrStderr(), "update.304", map[string]any{
-						"shard": shard, "version": result.From,
-					})
-				}
+			if len(shards) == 0 {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "no shards installed; run `sku update <shard>` to install one")
+				return nil
 			}
 
-			_, _ = cmd.ErrOrStderr().Write([]byte("installed " + shard + " -> " + catalog.ShardPath(shard) + "\n"))
-			return nil
+			var firstErr error
+			for _, shard := range shards {
+				if err := runSingleShardUpdate(cmd, shard, channelFlag, s); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
 		},
 	}
 
 	cmd.Flags().StringVar(&channelFlag, "channel", "", `update channel: "stable" (default, always full baseline) or "daily" (delta chain, falls back to baseline)`)
+	cmd.Flags().BoolVar(&statusFlag, "status", false, "Print per-shard freshness JSON; no fetch.")
 	return cmd
 }

--- a/cmd/sku/update_test.go
+++ b/cmd/sku/update_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -199,6 +200,63 @@ func TestUpdate_AllShards(t *testing.T) {
 			require.Greater(t, fi.Size(), int64(0))
 		})
 	}
+}
+
+func TestUpdate_Status_EmptyDir(t *testing.T) {
+	t.Setenv("SKU_DATA_DIR", t.TempDir())
+	stdout, _, err := runUpdate(t, "--status")
+	require.NoError(t, err)
+
+	var result struct {
+		Shards []struct {
+			Name      string `json:"name"`
+			Installed bool   `json:"installed"`
+		} `json:"shards"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(stdout)), &result))
+	require.Greater(t, len(result.Shards), 0, "should list all known shards")
+	for _, s := range result.Shards {
+		require.False(t, s.Installed, "no shards installed in empty dir")
+	}
+}
+
+func TestUpdate_Status_WithShard(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SKU_DATA_DIR", dir)
+
+	ddl, err := os.ReadFile(filepath.Join("..", "..", "internal", "catalog", "testdata", "seed.sql"))
+	require.NoError(t, err)
+	require.NoError(t, catalog.BuildFromSQL(filepath.Join(dir, "openrouter.db"), string(ddl)))
+
+	stdout, _, err := runUpdate(t, "--status")
+	require.NoError(t, err)
+
+	var result struct {
+		Shards []struct {
+			Name      string `json:"name"`
+			Installed bool   `json:"installed"`
+			Version   string `json:"version,omitempty"`
+			Path      string `json:"path,omitempty"`
+		} `json:"shards"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(stdout)), &result))
+
+	var found bool
+	for _, s := range result.Shards {
+		if s.Name == "openrouter" {
+			found = true
+			require.True(t, s.Installed)
+			require.NotEmpty(t, s.Version)
+			require.NotEmpty(t, s.Path)
+		}
+	}
+	require.True(t, found, "openrouter should appear in status output")
+}
+
+func TestUpdate_NoArgs_NoShards(t *testing.T) {
+	t.Setenv("SKU_DATA_DIR", t.TempDir())
+	_, _, err := runUpdate(t)
+	require.NoError(t, err)
 }
 
 func TestUpdate_UnsupportedShard(t *testing.T) {

--- a/cmd/sku/update_test.go
+++ b/cmd/sku/update_test.go
@@ -210,12 +210,29 @@ func TestUpdate_UnsupportedShard(t *testing.T) {
 	require.Contains(t, stderr, "unsupported_shard")
 }
 
-// TestUpdate_HTTPError returns CodeServer when the server replies 502.
+// TestUpdate_HTTPError returns CodeServer when the shard asset download
+// replies 502. The manifest itself must succeed; otherwise the updater may
+// legitimately fall back to its secondary manifest URL and make this test
+// environment-dependent.
 func TestUpdate_HTTPError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "bad gateway", http.StatusBadGateway)
+	_, hexSum := buildTestZst(t)
+
+	var manifest string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(manifest))
+		case "/openrouter.db.zst":
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+		case "/openrouter.db.zst.sha256":
+			_, _ = w.Write([]byte(hexSum + "  openrouter.db.zst\n"))
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 	defer srv.Close()
+	manifest = singleShardManifest("openrouter", srv.URL, hexSum)
 
 	dataDir := t.TempDir()
 	t.Setenv("SKU_DATA_DIR", dataDir)

--- a/internal/batch/registry.go
+++ b/internal/batch/registry.go
@@ -25,6 +25,7 @@ type Settings struct {
 	Fields            string
 	IncludeRaw        bool
 	IncludeAggregated bool
+	AutoFetch         bool
 	StaleOK           bool
 	StaleWarningDays  int
 	StaleErrorDays    int


### PR DESCRIPTION
## Summary

- **`--auto-fetch`**: The flag was parsed but never consulted. Added `AutoFetch bool` to `batch.Settings`, introduced `ensureShard`/`autoFetchShard` helpers, and replaced the static `os.Stat`+`shardMissingErr` pattern in every handler (LLM price, `ec2Lookup`, and 19 Cobra RunE handlers across AWS/Azure/GCP) with `ensureShard`. When the flag is set and the shard is missing, the handler downloads it via the manifest-based updater instead of failing immediately.
- **`sku update --status`**: The flag was not registered. Rewrote `newUpdateCmd` to accept 0-or-more shard args (was `ExactArgs(1)`) and added `--status`, which emits a JSON array of per-shard freshness records (`name`, `installed`, `version`, `age_days`, `path`) without fetching. Zero-arg `sku update` now updates all installed shards.
- **`sku llm compare`**: The command was not registered. New `llm_compare.go` implements `handleLLMCompare` (shared by Cobra and batch) and `newLLMCompareCmd`. Fetches all serving-provider rows for a model, populates `MinPrice` from the prompt dimension, and sorts cheapest-first. Registered in `llm.go` and as batch handler `"llm compare"`.

## Test Plan
- [ ] `make test` — all green
- [ ] `make lint` — 0 issues
- [ ] `sku llm compare --model anthropic/claude-opus-4.6` returns rows sorted by prompt price
- [ ] `sku update --status` emits JSON with `shards` array
- [ ] `sku update` with no args and installed shards updates all of them
- [ ] `sku <cmd> --auto-fetch` downloads missing shard on first run