### PR TITLE
chore: add issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,57 @@
+name: Bug report
+description: Report incorrect behavior in the CLI, updater, catalog reader, or data pipeline.
+title: "bug: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for reproducible product bugs. For automated catalog drift, use the catalog-drift template instead.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened, and what did you expect instead?
+      placeholder: "`sku compare ...` returned ... but I expected ..."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction
+      description: Commands, catalog version, input files, and environment needed to reproduce.
+      placeholder: |
+        1. Run `sku ...`
+        2. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Output
+      description: Paste the relevant terminal output, JSON error, or workflow log excerpt.
+      render: shell
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: sku version
+      description: Output of `sku version`, commit SHA, or release tag.
+      placeholder: "v0.0.0 / commit SHA"
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI
+        - catalog data
+        - updater
+        - compare/search
+        - estimate
+        - pipeline
+        - docs
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Catalog validation runbook
+    url: https://github.com/sofq/sku/blob/main/docs/ops/validation.md
+    about: Triage catalog drift and weekly validation workflow failures.
+  - name: Data workflow runbook
+    url: https://github.com/sofq/sku/blob/main/docs/ops/data-workflows.md
+    about: Operate provider ingest, publish, and daily dispatcher workflows.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Propose a new command, catalog coverage area, workflow, or documentation improvement.
+title: "feat: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user workflow or catalog gap should this solve?
+      placeholder: "I need to compare ... but today ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the smallest useful version of the feature.
+      placeholder: "Add ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI
+        - catalog coverage
+        - compare/search
+        - estimate
+        - updater
+        - pipeline
+        - docs
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Existing commands, scripts, or manual workarounds you tried.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add an issue-template chooser config that disables blank issues while linking operational runbooks.
- Add structured bug report and feature request forms so human reports still have a path.

## Test Plan
- rtk env PYTHONPATH=pipeline pipeline/.venv/bin/python -c 'import pathlib, yaml; [yaml.safe_load(p.read_text()) for p in pathlib.Path(".github/ISSUE_TEMPLATE").glob("*.yml")]; print("issue template yaml ok")'
- rtk git diff --check