### PR TITLE
ci: guard same-day data publish reruns

### DIFF
--- a/.github/workflows/data-daily.yml
+++ b/.github/workflows/data-daily.yml
@@ -11,6 +11,10 @@ on:
       dry_run:
         description: "Forward to provider workflows and stop before publish"
         required: false
+        default: "true"
+      replace_existing_release:
+        description: "Forward to publish; replace today's data release if it already exists"
+        required: false
         default: "false"
       force_baseline:
         description: "Forward to child workflows"
@@ -34,9 +38,9 @@ jobs:
         id: dispatch
         env:
           GH_TOKEN:          ${{ secrets.GITHUB_TOKEN }}
-          DRY_RUN:           ${{ github.event.inputs.dry_run }}
-          FORCE_BASELINE:    ${{ github.event.inputs.force_baseline }}
-          FORCE_FULL_INGEST: ${{ github.event.inputs.force_full_ingest }}
+          DRY_RUN:           ${{ github.event.inputs.dry_run || 'false' }}
+          FORCE_BASELINE:    ${{ github.event.inputs.force_baseline || 'false' }}
+          FORCE_FULL_INGEST: ${{ github.event.inputs.force_full_ingest || 'false' }}
         run: |
           set -euo pipefail
           # Dispatch each child; capture the new run id by diffing `gh run list`
@@ -99,10 +103,11 @@ jobs:
         if: always() && github.event.inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRY_RUN:  ${{ github.event.inputs.dry_run }}
+          DRY_RUN:  ${{ github.event.inputs.dry_run || 'false' }}
+          REPLACE_EXISTING_RELEASE: ${{ github.event.inputs.replace_existing_release || 'false' }}
         run: |
           set -euo pipefail
-          gh workflow run data-publish.yml -f dry_run="$DRY_RUN"
+          gh workflow run data-publish.yml -f dry_run="$DRY_RUN" -f replace_existing_release="$REPLACE_EXISTING_RELEASE"
           echo "publish dispatched — watch via: gh run list --workflow data-publish.yml --limit 1"
 
       - name: Skip publish for dry run

--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -9,6 +9,10 @@ on:
       dry_run:
         description: "Build manifest but skip release creation"
         required: false
+        default: "true"
+      replace_existing_release:
+        description: "Replace today's data release if it already exists"
+        required: false
         default: "false"
 
 permissions:
@@ -88,9 +92,18 @@ jobs:
         if: github.event.inputs.dry_run != 'true'
         env:
           CATALOG_VERSION: ${{ steps.version.outputs.catalog_version }}
+          REPLACE_EXISTING_RELEASE: ${{ github.event.inputs.replace_existing_release || 'false' }}
           GH_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          if gh release view "data-${CATALOG_VERSION}" >/dev/null 2>&1; then
+            if [ "$REPLACE_EXISTING_RELEASE" != "true" ]; then
+              echo "::error::release already exists: data-${CATALOG_VERSION}. Rerun with replace_existing_release=true to replace it."
+              exit 1
+            fi
+            gh release delete "data-${CATALOG_VERSION}" --yes
+            gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/git/refs/tags/data-${CATALOG_VERSION}" 2>/dev/null || true
+          fi
           gh release create "data-${CATALOG_VERSION}" \
             --title "Data release ${CATALOG_VERSION}" \
             --notes "Automated daily data release. See manifest.json for shard inventory." \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,9 @@ Agent quick-start for the `sku` repo.
 | Run discover (fixture / dry-run) | `make discover` |
 | Run discover against real upstreams | `DISCOVER_LIVE=1 make discover` (GCP uses ADC; run `gcloud auth application-default login` first) |
 | Live-ingest a single shard | `make shard-live SHARD=aws_ec2 SRC=/path/to/offer.json` |
-| Dispatch daily data workflow (dry-run) | `gh workflow run data-daily.yml -F dry_run=true -F force_baseline=true` |
+| Dispatch daily data workflow (dry-run) | `gh workflow run data-daily.yml -F force_baseline=true` |
 | Dispatch daily data workflow (publish) | `gh workflow run data-daily.yml -F dry_run=false -F force_baseline=true` |
+| Replace today's data release | `gh workflow run data-daily.yml -F dry_run=false -F force_baseline=true -F replace_existing_release=true` |
 
 ## Repo map
 

--- a/docs/ops/data-daily-runbook.md
+++ b/docs/ops/data-daily-runbook.md
@@ -31,7 +31,6 @@ Before enabling it, prove the end-to-end flow with two manual dispatches:
 ```bash
 # 1. Dry run — discover + ingest + diff-package, but skip publish.
 gh workflow run data-daily.yml \
-  -F dry_run=true \
   -F force_baseline=true
 
 gh run watch   # wait for completion; confirm all jobs green
@@ -90,8 +89,9 @@ whatever has changed since the last green release via the discover state.
 If a scheduled run has already completed but you need to re-publish (e.g. to
 pick up a fixed ingest module):
 
-1. Delete the existing release: `gh release delete data-$(date -u +%Y.%m.%d) --yes --cleanup-tag`
-2. `gh workflow run data-daily.yml -F dry_run=false -F force_baseline=true`
+1. `gh workflow run data-daily.yml -F dry_run=false -F force_baseline=true -F replace_existing_release=true`
+2. Watch the run; the publish step replaces `data-$(date -u +%Y.%m.%d)` before
+   recreating `data-latest`.
 
 `force_baseline=true` rebuilds every shard baseline, bypassing the discover
 "nothing changed" short-circuit and resetting every client's delta chain
@@ -121,9 +121,9 @@ gh issue close <issue-number> --comment "Purge verified; manifest fresh on jsDel
 - `discover` job reports every shard errored → upstream site (pricing feed)
   is probably down. Workflow exits 2; no release published. Re-run once
   upstream recovers.
-- `publish` job succeeds but no new release shows up → check `gh release
-  list`; the `gh release create` step may have race-conflicted on the tag.
-  Re-run with `force_baseline=true` after deleting any partial release.
+- `publish` job fails with `release already exists` → today's release already
+  exists. Dry-run for testing, or re-run with `replace_existing_release=true`
+  when you intend to replace the public release.
 
 ## Related files
 

--- a/docs/ops/data-workflows.md
+++ b/docs/ops/data-workflows.md
@@ -71,11 +71,17 @@ gh workflow run data-gcp.yml
 # Bypass AWS ETag fast path (force full re-ingest regardless of 304s):
 gh workflow run data-aws.yml -f force_full_ingest=true
 
-# Re-publish against last-good provider artifacts (no re-ingest):
+# Dry-run publish against last-good provider artifacts (no release writes):
 gh workflow run data-publish.yml
 
-# Full end-to-end pipeline with wait and publish:
+# Re-publish against last-good provider artifacts (replace today's release):
+gh workflow run data-publish.yml -f dry_run=false -f replace_existing_release=true
+
+# Full end-to-end dry run with wait:
 gh workflow run data-daily.yml
+
+# Full end-to-end pipeline with wait and publish:
+gh workflow run data-daily.yml -f dry_run=false
 ```
 
 ## Verifying codegen outputs

--- a/docs/ops/validation.md
+++ b/docs/ops/validation.md
@@ -210,7 +210,8 @@ Decision tree:
    - Investigate the relevant `pipeline/ingest/<shard>.py`; add a
      regression test fixture in `pipeline/tests/`.
    - Push the fix; force a `workflow_dispatch` of `data-daily.yml` with
-     `force_baseline=true` to republish.
+     `dry_run=false`, `force_baseline=true`, and `replace_existing_release=true`
+     to republish today's catalog.
 4. **Validator false positive** (e.g. unit-of-measure mismatch that
    doesn't matter economically).
    - Patch `pipeline/validate/<provider>.py` or the specific filter in

--- a/pipeline/tests/test_data_workflow_manual_publish.py
+++ b/pipeline/tests/test_data_workflow_manual_publish.py
@@ -1,0 +1,47 @@
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow(name: str) -> str:
+    return (ROOT / ".github" / "workflows" / name).read_text()
+
+
+def _input_block(text: str, input_name: str) -> str:
+    match = re.search(rf"^      {input_name}:\n(?P<body>(?:        .*\n)+)", text, re.MULTILINE)
+    assert match is not None, f"missing workflow_dispatch input {input_name}"
+    return match.group("body")
+
+
+def test_manual_data_runs_are_dry_by_default() -> None:
+    for workflow in ("data-daily.yml", "data-publish.yml"):
+        block = _input_block(_workflow(workflow), "dry_run")
+
+        assert 'default: "true"' in block
+
+
+def test_data_daily_forwards_replace_existing_release_to_publish() -> None:
+    text = _workflow("data-daily.yml")
+
+    block = _input_block(text, "replace_existing_release")
+    assert 'default: "false"' in block
+    assert "REPLACE_EXISTING_RELEASE:" in text
+    assert (
+        'gh workflow run data-publish.yml -f dry_run="$DRY_RUN" '
+        '-f replace_existing_release="$REPLACE_EXISTING_RELEASE"'
+    ) in text
+
+
+def test_data_publish_requires_explicit_replace_for_existing_catalog_release() -> None:
+    text = _workflow("data-publish.yml")
+
+    block = _input_block(text, "replace_existing_release")
+    assert 'default: "false"' in block
+    assert 'if gh release view "data-${CATALOG_VERSION}" >/dev/null 2>&1; then' in text
+    assert "REPLACE_EXISTING_RELEASE" in text
+    assert "release already exists: data-${CATALOG_VERSION}" in text
+    assert 'gh release delete "data-${CATALOG_VERSION}" --yes' in text
+    assert (
+        'gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/git/refs/tags/data-${CATALOG_VERSION}"'
+    ) in text


### PR DESCRIPTION
## Summary
- default manual data workflow runs to dry-run mode
- add explicit replace_existing_release handling for intentional same-day republish
- update runbooks and add workflow contract tests

## Test Plan
- rtk make -C pipeline test PYTEST='.venv/bin/pytest -q tests/test_data_workflow_manual_publish.py'
- rtk pipeline/.venv/bin/ruff check pipeline/tests/test_data_workflow_manual_publish.py
- rtk pipeline/.venv/bin/ruff format --check pipeline/tests/test_data_workflow_manual_publish.py
- rtk pipeline/.venv/bin/python -c "import yaml; [yaml.safe_load(open(p)) for p in ['.github/workflows/data-daily.yml', '.github/workflows/data-publish.yml']]"