### PR TITLE
ci(data-weekly): use PAT so coverage PRs trigger ci.yml

### DIFF
--- a/.github/workflows/data-weekly.yml
+++ b/.github/workflows/data-weekly.yml
@@ -14,6 +14,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_PAT_SKU }}
       - uses: astral-sh/setup-uv@v6
       - run: cd pipeline && uv sync
       - name: Authenticate to Google Cloud (WIF)
@@ -79,4 +81,4 @@ jobs:
               --base main --head "$branch"
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT_SKU }}


### PR DESCRIPTION
## Summary
- PRs opened by the default \`GITHUB_TOKEN\` do not trigger workflow runs (GitHub safeguard against recursion), so the weekly coverage PR's required \`lint\` and \`test\` checks were stuck as "Expected — Waiting for status to be reported" forever (e.g. #43).
- Switch \`actions/checkout\` and \`gh pr create\` in \`data-weekly.yml\` to use \`secrets.GH_PAT_SKU\` (fine-grained PAT, already added as a repo secret). The push + PR creation now happen as a real user, so \`ci.yml\` fires on the resulting \`pull_request\` event.

## Test plan
- [ ] Workflow file passes lint
- [ ] Next scheduled \`data-weekly\` run (or manual \`workflow_dispatch\`) opens a PR that has \`ci\` running, not stuck