### PR TITLE
ci(data-weekly): force-push bot branch, skip duplicate PR

### DIFF
--- a/.github/workflows/data-weekly.yml
+++ b/.github/workflows/data-weekly.yml
@@ -75,10 +75,14 @@ jobs:
             git checkout -b "$branch"
             git add docs/coverage/
             git commit -m "docs(coverage): weekly profiler refresh"
-            git push origin "$branch"
-            gh pr create --title "docs(coverage): weekly profiler refresh" \
-              --body "Automated — see diff for upstream feed changes." \
-              --base main --head "$branch"
+            # Refresh remote-tracking ref so --force-with-lease has a baseline.
+            git fetch origin "$branch" 2>/dev/null || true
+            git push --force-with-lease origin "$branch"
+            if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+              gh pr create --title "docs(coverage): weekly profiler refresh" \
+                --body "Automated — see diff for upstream feed changes." \
+                --base main --head "$branch"
+            fi
           fi
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_SKU }}


### PR DESCRIPTION
## Summary
- Same-day re-runs of `data-weekly` previously failed at `git push origin "$branch"` with non-fast-forward (the prior PR's branch still existed).
- Switch to `git push --force-with-lease` (with a `git fetch` first to seed the remote-tracking ref so the lease has a baseline).
- Skip `gh pr create` if an open PR already exists on the branch — re-runs now refresh the existing PR's content instead of erroring.

Net effect: at most one open coverage PR at a time; manual `workflow_dispatch` re-runs are safe.

## Test plan
- [ ] Workflow file passes lint
- [ ] Manual `workflow_dispatch` of `data-weekly` after merge produces a working PR (or refreshes the existing one) with `ci.yml` running