### PR TITLE
feat(schema): add `sku schema --kind-term-overrides`

### DIFF
--- a/cmd/sku/schema.go
+++ b/cmd/sku/schema.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sofq/sku/internal/batch"
 	"github.com/sofq/sku/internal/catalog"
 	skuerrors "github.com/sofq/sku/internal/errors"
+	"github.com/sofq/sku/internal/schema"
 )
 
 // newSchemaCmd builds the `sku schema` subcommand tree. The command is a
@@ -20,11 +21,12 @@ import (
 // view lands in a later task.
 func newSchemaCmd() *cobra.Command {
 	var (
-		list         bool
-		errs         bool
-		listServing  bool
-		listCommands bool
-		format       string
+		list              bool
+		errs              bool
+		listServing       bool
+		listCommands      bool
+		kindTermOverrides bool
+		format            string
 	)
 	c := &cobra.Command{
 		Use:   "schema [provider [service [verb]]]",
@@ -38,6 +40,9 @@ func newSchemaCmd() *cobra.Command {
 				return enc.Encode(map[string]any{
 					"commands": batch.RegisteredNames(),
 				})
+
+			case kindTermOverrides:
+				return enc.Encode(schema.KindTermOverridesCatalog())
 
 			case errs:
 				return enc.Encode(skuerrors.ErrorCatalog())
@@ -108,6 +113,8 @@ func newSchemaCmd() *cobra.Command {
 		"list serving providers in the openrouter shard")
 	c.Flags().BoolVar(&listCommands, "list-commands", false,
 		"list batch-registered command names")
+	c.Flags().BoolVar(&kindTermOverrides, "kind-term-overrides", false,
+		"emit which `terms` slots are repurposed for which kinds (e.g. tenancy=engine for db.relational)")
 	c.Flags().StringVar(&format, "format", "json", "json | text")
 	return c
 }

--- a/cmd/sku/schema_test.go
+++ b/cmd/sku/schema_test.go
@@ -60,6 +60,19 @@ func TestSchema_Base_ListsProvidersAndGlobals(t *testing.T) {
 	require.NotEmpty(t, doc["globals"])
 }
 
+func TestSchema_KindTermOverrides_EmitsCatalog(t *testing.T) {
+	out, _, code := runSchema(t, "--kind-term-overrides")
+	require.Zero(t, code)
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &doc))
+	overrides, ok := doc["kind_term_overrides"].(map[string]any)
+	require.True(t, ok)
+	dbRel, ok := overrides["db.relational"].(map[string]any)
+	require.True(t, ok)
+	tenancy := dbRel["tenancy"].(map[string]any)
+	require.Equal(t, "engine", tenancy["semantic_name"])
+}
+
 func TestSchema_listCommands_includesBatchRegistry(t *testing.T) {
 	out, _, code := runSchema(t, "--list-commands")
 	require.Zero(t, code)

--- a/internal/schema/kind_overrides.go
+++ b/internal/schema/kind_overrides.go
@@ -1,0 +1,110 @@
+package schema
+
+// TermSlotOverride describes one repurposed slot in the shared `terms` row
+// for a particular kind. The catalog's terms columns (commitment, tenancy,
+// os, support_tier, upfront, payment_option) are fixed across every kind so
+// that terms_hash remains a stable per-row identity. For db-shaped kinds
+// (db.relational, cache.kv, container.orchestration) some slots carry
+// kind-specific semantics rather than their literal column names; this
+// struct tells agents how to read those slots.
+//
+// SemanticName is what the value actually represents (e.g. "engine"). CLIFlag
+// is the price/list flag that filters on the slot for that kind. Values is
+// the enumeration the validator accepts in pipeline/normalize/enums.yaml.
+type TermSlotOverride struct {
+	SemanticName string   `json:"semantic_name"`
+	CLIFlag      string   `json:"cli_flag,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	Values       []string `json:"values,omitempty"`
+}
+
+// KindTermOverrides lists the slots a single kind repurposes. A nil pointer
+// means the slot carries its literal column meaning (or is empty) for that
+// kind.
+type KindTermOverrides struct {
+	Tenancy *TermSlotOverride `json:"tenancy,omitempty"`
+	OS      *TermSlotOverride `json:"os,omitempty"`
+}
+
+// kindTermOverrides is the canonical mapping. Kinds absent from this map use
+// the literal `terms` column semantics (compute.vm: shared/dedicated tenancy
+// + linux/windows os; storage.* and llm.* leave both empty). Adding a new
+// kind here MUST stay consistent with the ingest pipelines and the
+// pipeline/normalize/enums.yaml allowlists.
+var kindTermOverrides = map[string]KindTermOverrides{
+	"db.relational": {
+		Tenancy: &TermSlotOverride{
+			SemanticName: "engine",
+			CLIFlag:      "--engine",
+			Description:  "Database engine (participates in terms_hash).",
+			Values: []string{
+				"postgres", "mysql", "mariadb", "oracle", "sqlserver",
+				"aurora-postgres", "aurora-mysql",
+				"azure-sql", "azure-postgres", "azure-mysql", "azure-mariadb",
+				"cloud-sql-postgres", "cloud-sql-mysql", "cloud-sql-sqlserver",
+			},
+		},
+		OS: &TermSlotOverride{
+			SemanticName: "deployment_option",
+			CLIFlag:      "--deployment-option",
+			Description:  "Deployment topology (participates in terms_hash).",
+			Values: []string{
+				"single-az", "multi-az", "multi-az-cluster",
+				"managed-instance", "elastic-pool", "flexible-server",
+				"zonal", "regional",
+			},
+		},
+	},
+	"cache.kv": {
+		Tenancy: &TermSlotOverride{
+			SemanticName: "engine",
+			CLIFlag:      "--engine",
+			Description:  "Cache engine (participates in terms_hash).",
+			Values: []string{
+				"redis", "memcached",
+				"sql", "mongo", "cassandra", "table", "gremlin",
+				"spanner-standard", "spanner-enterprise", "spanner-enterprise-plus", "spanner-storage",
+			},
+		},
+		OS: &TermSlotOverride{
+			SemanticName: "tier_or_mode",
+			CLIFlag:      "--tier or --capacity-mode",
+			Description:  "Cache tier or capacity mode (participates in terms_hash).",
+			Values: []string{
+				"basic", "standard", "premium", "enterprise",
+				"provisioned", "serverless",
+				"storage",
+			},
+		},
+	},
+	"container.orchestration": {
+		Tenancy: &TermSlotOverride{
+			SemanticName: "product_family",
+			Description:  "Container orchestration product family.",
+			Values:       []string{"kubernetes"},
+		},
+		OS: &TermSlotOverride{
+			SemanticName: "tier_or_mode",
+			CLIFlag:      "--tier or --mode",
+			Description:  "Cluster tier or run mode (e.g. EKS Fargate, AKS virtual-nodes, GKE Autopilot).",
+			Values: []string{
+				"standard", "extended-support",
+				"fargate", "free", "virtual-nodes", "autopilot",
+			},
+		},
+	},
+}
+
+// KindTermOverridesCatalog returns the full catalog of term-slot overrides,
+// suitable for direct JSON encoding by `sku schema --kind-term-overrides`.
+//
+// Spec-level intent: agents fetch this once and use it to interpret the
+// `terms.tenancy` / `terms.os` fields in subsequent price/list/compare
+// envelopes. For any kind not in the returned map, both slots carry their
+// literal column meaning (or are empty).
+func KindTermOverridesCatalog() map[string]any {
+	return map[string]any{
+		"schema_version":      1,
+		"kind_term_overrides": kindTermOverrides,
+	}
+}

--- a/internal/schema/kind_overrides_test.go
+++ b/internal/schema/kind_overrides_test.go
@@ -1,0 +1,55 @@
+package schema
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKindTermOverridesCatalog_StableShape(t *testing.T) {
+	cat := KindTermOverridesCatalog()
+
+	require.Equal(t, 1, cat["schema_version"])
+
+	overrides, ok := cat["kind_term_overrides"].(map[string]KindTermOverrides)
+	require.True(t, ok, "kind_term_overrides should be a typed map")
+
+	for _, kind := range []string{"db.relational", "cache.kv", "container.orchestration"} {
+		require.Contains(t, overrides, kind)
+	}
+
+	dbRel := overrides["db.relational"]
+	require.NotNil(t, dbRel.Tenancy)
+	require.Equal(t, "engine", dbRel.Tenancy.SemanticName)
+	require.Contains(t, dbRel.Tenancy.Values, "postgres")
+	require.NotNil(t, dbRel.OS)
+	require.Equal(t, "deployment_option", dbRel.OS.SemanticName)
+	require.Contains(t, dbRel.OS.Values, "single-az")
+
+	cache := overrides["cache.kv"]
+	require.NotNil(t, cache.Tenancy)
+	require.Contains(t, cache.Tenancy.Values, "redis")
+
+	containers := overrides["container.orchestration"]
+	require.NotNil(t, containers.Tenancy)
+	require.Equal(t, []string{"kubernetes"}, containers.Tenancy.Values)
+}
+
+func TestKindTermOverridesCatalog_RoundTripsJSON(t *testing.T) {
+	cat := KindTermOverridesCatalog()
+	buf, err := json.Marshal(cat)
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(buf, &doc))
+
+	overrides, ok := doc["kind_term_overrides"].(map[string]any)
+	require.True(t, ok)
+	dbRel, ok := overrides["db.relational"].(map[string]any)
+	require.True(t, ok)
+	tenancy, ok := dbRel["tenancy"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "engine", tenancy["semantic_name"])
+	require.Equal(t, "--engine", tenancy["cli_flag"])
+}


### PR DESCRIPTION
## Summary

Adds a discovery surface so agents can mechanically interpret the `terms.tenancy` and `terms.os` slots when they're repurposed for db-shaped kinds.

The catalog overloads `terms.tenancy` to hold `engine` and `terms.os` to hold `deployment_option` for `db.relational` rows (and similar repurposing for `cache.kv` / `container.orchestration`) so those values participate in `terms_hash`. Until now this mapping was only described in comments inside `pipeline/normalize/enums.yaml`, leaving JSON output like `terms.tenancy: postgres, terms.os: single-az` opaque to agents.

The new flag emits a structured catalog:

```json
{
  "schema_version": 1,
  "kind_term_overrides": {
    "db.relational": {
      "tenancy": {"semantic_name": "engine", "cli_flag": "--engine", "values": [...]},
      "os":      {"semantic_name": "deployment_option", "cli_flag": "--deployment-option", "values": [...]}
    },
    "cache.kv":                {...},
    "container.orchestration": {...}
  }
}
```

Kinds absent from the map use literal `terms` semantics (e.g. `compute.vm` keeps shared/dedicated tenancy + linux/windows os).

### Why annotation, not relabeling

An earlier pass considered renaming the JSON envelope fields (`tenancy` → `engine` etc.) for db-shaped kinds. After tracing the design through `pipeline/normalize/enums.yaml`, the ingest pipelines, and the M-γ planning docs, the slot overload is intentional, multi-kind, and not slated for a schema bump. Renaming at output time would create a permanent fork between the catalog SQL columns and the agent-facing JSON. Annotation keeps catalog and envelope aligned and is purely additive.

## Test plan

- [x] `make build` passes
- [x] `make lint` passes (0 issues)
- [x] `go test ./internal/schema/ ./cmd/sku/ -run 'Schema|KindTerm'` (8 passed)
- [x] `./bin/sku schema --kind-term-overrides` emits the catalog
- [x] Existing `--list`, `--errors`, `--list-serving-providers`, `--list-commands` paths unchanged
- [ ] No golden fixtures touched (verified — pure new code path)