### PR TITLE
fix(ingest): correct productFamily and tier parsing for aws_opensearch and gcp_bigquery

### DIFF
--- a/pipeline/ingest/aws_opensearch.py
+++ b/pipeline/ingest/aws_opensearch.py
@@ -1,7 +1,7 @@
 """Normalize AWS OpenSearch Service offer JSON into search.engine rows.
 
 Two modes:
-  managed-cluster  — Instance-based rows (productFamily = "Amazon OpenSearch Service").
+  managed-cluster  — Instance-based rows (productFamily = "Amazon OpenSearch Service Instance").
   serverless       — OCU + storage rows (productFamily = "Amazon OpenSearch Service Serverless").
 """
 
@@ -77,16 +77,16 @@ def _classify_serverless(attrs: dict) -> tuple[str, str] | None:
     """Return (dimension, billed_unit) or None to skip.
 
     Three serverless dimensions co-exist on one logical SKU per region:
-      compute-ocu  — OpenSearchComputeOCU operation, billed per hour
-      indexing-ocu — OpenSearchIndexingOCU operation, billed per hour
-      storage      — OpenSearchStorageOCU operation, billed per gb-month
+      compute-ocu  — SearchOCU operation, billed per hour
+      indexing-ocu — IndexingOCU operation, billed per hour
+      storage      — StorageUsedInS3ByteHour operation, billed per gb-month
     """
     operation = attrs.get("operation", "")
-    if "OpenSearchComputeOCU" in operation:
+    if operation == "SearchOCU":
         return "compute-ocu", "hour"
-    if "OpenSearchIndexingOCU" in operation:
+    if operation == "IndexingOCU":
         return "indexing-ocu", "hour"
-    if "OpenSearchStorageOCU" in operation:
+    if operation == "StorageUsedInS3ByteHour":
         return "storage", "gb-month"
     return None
 
@@ -122,7 +122,7 @@ def ingest(*, offer_path: Path) -> Iterable[dict[str, Any]]:
         unit_raw = pd.get("unit", "Hrs").lower()
         unit = "hour" if "hr" in unit_raw else unit_raw
 
-        if family == "Amazon OpenSearch Service":
+        if family == "Amazon OpenSearch Service Instance":
             result = _classify_managed_cluster(attrs)
             if result is None:
                 continue

--- a/pipeline/ingest/gcp_bigquery.py
+++ b/pipeline/ingest/gcp_bigquery.py
@@ -53,13 +53,20 @@ _MULTIREGION: dict[str, str] = {
 
 
 def _hourly_usd(sku: dict) -> tuple[float, str]:
-    """Return (amount, unit) from the first pricing tier of a SKU."""
+    """Return (amount, unit) from the first non-zero pricing tier of a SKU.
+
+    GCP Cloud Billing uses tiered rates where tier 0 is typically a free quota
+    at $0. The real price lives in tier 1+.
+    """
     try:
-        tiers = sku["pricingInfo"][0]["pricingExpression"]["tieredRates"]
-        units = float(tiers[0]["unitPrice"]["units"])
-        nanos = float(tiers[0]["unitPrice"]["nanos"]) / 1e9
-        usage_unit = sku["pricingInfo"][0]["pricingExpression"]["usageUnit"]
-        return units + nanos, usage_unit
+        pricing_expr = sku["pricingInfo"][0]["pricingExpression"]
+        tiers = pricing_expr["tieredRates"]
+        usage_unit = pricing_expr["usageUnit"]
+        for tier in tiers:
+            amount = float(tier["unitPrice"]["units"]) + float(tier["unitPrice"]["nanos"]) / 1e9
+            if amount > 0:
+                return amount, usage_unit
+        return 0.0, usage_unit
     except (KeyError, IndexError):
         return 0.0, ""
 

--- a/pipeline/tests/fixtures/aws_opensearch/offer.json
+++ b/pipeline/tests/fixtures/aws_opensearch/offer.json
@@ -2,7 +2,7 @@
   "products": {
     "OPENSEARCH_R6G_LARGE_USE1": {
       "sku": "OPENSEARCH_R6G_LARGE_USE1",
-      "productFamily": "Amazon OpenSearch Service",
+      "productFamily": "Amazon OpenSearch Service Instance",
       "attributes": {
         "regionCode": "us-east-1",
         "instanceType": "r6g.large.search",
@@ -11,31 +11,31 @@
     },
     "OPENSEARCH_SERVERLESS_OCU_USE1": {
       "sku": "OPENSEARCH_SERVERLESS_OCU_USE1",
-      "productFamily": "Amazon OpenSearch Serverless",
+      "productFamily": "Amazon OpenSearch Service Serverless",
       "attributes": {
         "regionCode": "us-east-1",
-        "operation": "OpenSearchComputeOCU"
+        "operation": "SearchOCU"
       }
     },
     "OPENSEARCH_SERVERLESS_STORAGE_USE1": {
       "sku": "OPENSEARCH_SERVERLESS_STORAGE_USE1",
-      "productFamily": "Amazon OpenSearch Serverless",
+      "productFamily": "Amazon OpenSearch Service Serverless",
       "attributes": {
         "regionCode": "us-east-1",
-        "operation": "OpenSearchStorageOCU"
+        "operation": "StorageUsedInS3ByteHour"
       }
     },
     "OPENSEARCH_SERVERLESS_INDEXING_USE1": {
       "sku": "OPENSEARCH_SERVERLESS_INDEXING_USE1",
-      "productFamily": "Amazon OpenSearch Serverless",
+      "productFamily": "Amazon OpenSearch Service Serverless",
       "attributes": {
         "regionCode": "us-east-1",
-        "operation": "OpenSearchIndexingOCU"
+        "operation": "IndexingOCU"
       }
     },
     "OPENSEARCH_UNKNOWN_REGION": {
       "sku": "OPENSEARCH_UNKNOWN_REGION",
-      "productFamily": "Amazon OpenSearch Service",
+      "productFamily": "Amazon OpenSearch Service Instance",
       "attributes": {
         "regionCode": "xx-fake-1",
         "instanceType": "r6g.large.search"


### PR DESCRIPTION
## Summary

- **aws_opensearch**: real AWS API uses `"Amazon OpenSearch Service Instance"` (not `"Amazon OpenSearch Service"`) for managed-cluster rows, and operations `SearchOCU` / `IndexingOCU` / `StorageUsedInS3ByteHour` for serverless rows (not the `OpenSearch*OCU` names that were in the code). Both mismatches produced 0 ingested rows, triggering the `empty_shard` sanity check.
- **gcp_bigquery**: Cloud Billing `tieredRates` always starts with a `$0` free-quota tier at index 0; the real price is in tier 1+. `_hourly_usd` now iterates tiers to find the first non-zero amount instead of unconditionally reading `tiers[0]`.
- **aws_opensearch fixture**: updated to match real API `productFamily` / `operation` strings so tests catch future regressions.

Fixes CI runs [25269744795](https://github.com/sofq/sku/actions/runs/25269744795) (aws_opensearch) and [25270133381](https://github.com/sofq/sku/actions/runs/25270133381) (gcp_bigquery) — both failed with `empty_shard: skus table is empty on first release`.

## Test plan

- [ ] `make pipeline-test` passes (596 tests)
- [ ] `diff_package (aws_opensearch)` succeeds in CI
- [ ] `diff_package (gcp_bigquery)` succeeds in CI
- [ ] `bundle` job no longer skipped in data-aws and data-gcp workflows