### PR TITLE
fix(test): default SKU_STALE_OK=1 in cmd/sku TestMain

### DIFF
--- a/cmd/sku/main_test.go
+++ b/cmd/sku/main_test.go
@@ -6,6 +6,13 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// Test fixtures embed a fixed `as_of_utc` and drift past the 14-day warn
+	// threshold. The staleness warning prints to stderr and breaks tests that
+	// parse stderr as JSON. Tests that specifically exercise staleness behavior
+	// can override with t.Setenv.
+	if os.Getenv("SKU_STALE_OK") == "" {
+		_ = os.Setenv("SKU_STALE_OK", "1")
+	}
 	// Isolate tests from the developer's local sku config (e.g. stale_error_days).
 	// Individual tests that specifically need a config dir (configure_test.go) use
 	// t.Setenv("SKU_CONFIG_DIR", ...) which overrides this for their duration.


### PR DESCRIPTION
## Summary
- Fix CI on `main`: 8 tests in `cmd/sku` (e.g. `TestAWSEC2Price_NotFound_ReturnsExit3`) fail because the seed fixtures' fixed `as_of_utc` crossed the 14-day stale-warning threshold, causing `warning: catalog is N days old ...` to be written to stderr ahead of the JSON envelope the tests unmarshal.
- Set `SKU_STALE_OK=1` as a default in `cmd/sku/main_test.go` `TestMain`. Tests that specifically need to exercise staleness behavior can override with `t.Setenv`.

## Test plan
- [x] `go test ./cmd/sku/ -count=1`
- [x] `go test ./... -count=1`