### PR TITLE
fix(validate): skip azure-mariadb/sql/postgres (validator meterName mismatch)

### DIFF
--- a/pipeline/validate/driver.py
+++ b/pipeline/validate/driver.py
@@ -39,6 +39,26 @@ SKIP_REVALIDATION: dict[str, str] = {
         "false-positive drift. Re-enable once a sidecar or component-aware "
         "comparison lands."
     ),
+    # Azure DB shards: validator filters upstream by `meterName eq '{resource_name}'`
+    # (pipeline/validate/azure.py:_filter_for_sample), but the Retail API exposes
+    # `meterName="vCore"` and disambiguates via `productName` + `skuName`. Our
+    # resource_name (e.g. "Gen5 2 vCore", "GP_Gen5_2") never matches the upstream
+    # meterName, so 14-19 of 20 sampled SKUs are reported `missing_upstream` and the
+    # 1-5 that incidentally match return unrelated line items. Re-enable once the
+    # azure validator gains per-shard product/sku-name matching.
+    "azure-mariadb": (
+        "validator's meterName-based filter doesn't match this shard's "
+        "resource_name format (Retail API uses meterName='vCore' with "
+        "productName disambiguation). See pipeline/validate/azure.py."
+    ),
+    "azure-sql": (
+        "validator's meterName-based filter doesn't match this shard's "
+        "resource_name format. See pipeline/validate/azure.py."
+    ),
+    "azure-postgres": (
+        "validator's meterName-based filter doesn't match this shard's "
+        "resource_name format. See pipeline/validate/azure.py."
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- Adds \`azure-mariadb\`, \`azure-sql\`, \`azure-postgres\` to \`SKIP_REVALIDATION\`.
- Root cause is a **validator bug, not a catalog bug**: \`pipeline/validate/azure.py:_filter_for_sample\` builds a filter \`meterName eq '{resource_name}'\` for general Azure shards, but the Retail API exposes Azure DB pricing with \`meterName="vCore"\` and disambiguates via \`productName\` + \`skuName\`. Our \`resource_name\` (e.g. \`"Gen5 2 vCore"\`, \`"GP_Gen5_2"\`) never matches that meterName.
- Verified against the public Retail API for Azure DB services. Result: 14-19/20 sampled SKUs report \`missing_upstream\` and the 1-5 incidental matches are unrelated line items.
- Closes #56, #58, #60.

## Why skip rather than fix the matcher now
The proper fix is per-shard filter strategies in \`pipeline/validate/azure.py\` (similar to the existing App Service / AKS handlers, matching by \`productName\` + \`skuName\`). That's a follow-up; this PR stops the daily false-positive drift issues.

## Not addressed
- #57, #59, #61 (\`gcp-run\`, \`gcp-functions\`, \`gcp-gcs\`) — root cause unverified. The 350× catalog/upstream ratio in #61 doesn't match any \`parse_usage_unit\` divisor or tier-index theory I could confirm by code inspection. Adding speculative skips would defeat the validator. Needs a probe with GCP credentials.

## Test plan
- [x] \`uv run pytest pipeline/tests/test_validate_driver.py\` — 7/7 green.